### PR TITLE
Final CI Fix Instructions - Update Workflow to Fetch Submodules

### DIFF
--- a/CI_WORKFLOW_FIX.md
+++ b/CI_WORKFLOW_FIX.md
@@ -1,0 +1,88 @@
+# CI Workflow Fix - Final Step
+
+## Current Status
+✅ **PR #47 merged** - Lidarr submodule is now in the repository  
+❌ **CI still failing** - Workflow doesn't fetch the submodule
+
+## The Problem
+The CI workflow has `submodules: false` (default), causing:
+```
+git fetch --no-recurse-submodules
+```
+
+## The Solution - Manual Update Required
+
+### Edit `.github/workflows/ci.yml` on GitHub:
+
+1. **Go to:** https://github.com/RicherTunes/Brainarr/edit/main/.github/workflows/ci.yml
+
+2. **Find these 3 sections and add `with: submodules: true`:**
+
+#### First occurrence (line ~22):
+```yaml
+# Change from:
+- name: Checkout
+  uses: actions/checkout@v4
+
+# To:
+- name: Checkout
+  uses: actions/checkout@v4
+  with:
+    submodules: true
+```
+
+#### Second occurrence (line ~84):
+```yaml
+# Change from:
+- name: Checkout
+  uses: actions/checkout@v4
+
+# To:
+- name: Checkout
+  uses: actions/checkout@v4
+  with:
+    submodules: true
+```
+
+#### Third occurrence (line ~133):
+```yaml
+# Change from:
+- name: Checkout
+  uses: actions/checkout@v4
+
+# To:
+- name: Checkout
+  uses: actions/checkout@v4
+  with:
+    submodules: true
+```
+
+3. **Remove mock DLL creation steps:**
+   - Delete lines 37-49 (first "Setup Lidarr Dependencies (Mock)" block)
+   - Delete lines 91-99 (second mock block)
+   - Delete lines 145-154 (third mock block)
+
+4. **Commit with message:** 
+   ```
+   fix: Enable submodule fetching in CI workflow
+   ```
+
+## Why This Will Work
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Lidarr submodule | ✅ Exists | Added by PR #47 |
+| .gitmodules | ✅ Tracked | Defines submodule location |
+| .gitignore | ✅ Fixed | No longer blocks ext/ |
+| CI workflow | ❌ Needs update | Must add `submodules: true` |
+
+## Expected Result After Fix
+1. CI fetches the repository
+2. CI fetches the Lidarr submodule
+3. Build finds all Lidarr projects
+4. Compilation succeeds
+5. Tests pass
+6. ✅ Green build!
+
+## Alternative: Use Fixed Workflow
+Copy the entire content from `.github-workflows-fixed/ci.yml` in this repository.


### PR DESCRIPTION
## 🎯 This PR Contains Instructions to Fix CI

### Current Situation
- ✅ **PR #47 added the Lidarr submodule** to the repository
- ❌ **CI workflow doesn't fetch submodules** (uses default `submodules: false`)

### The Final Fix Required
The CI workflow at `.github/workflows/ci.yml` needs **manual update** to add `submodules: true` to all checkout steps.

### Evidence from CI Logs
```
submodules: false
git fetch --no-recurse-submodules
```

## 📝 Instructions in This PR
This PR adds `CI_WORKFLOW_FIX.md` with:
- Exact line numbers to change
- Before/after examples
- Clear step-by-step instructions

## 🚀 Quick Fix Steps
1. Go to: https://github.com/RicherTunes/Brainarr/edit/main/.github/workflows/ci.yml
2. Add `with: submodules: true` to ALL 3 checkout steps
3. Remove mock DLL creation blocks
4. Commit directly to main branch

## 📊 Why CI Will Pass After This
| Step | Status | Result |
|------|--------|--------|
| 1. Repository checkout | ✅ | Gets main code |
| 2. Submodule fetch | ✅ (after fix) | Gets Lidarr source |
| 3. Project references | ✅ | Finds all .csproj files |
| 4. Build | ✅ | Compiles successfully |
| 5. Tests | ✅ | All pass |

## Note
Due to GitHub App permissions, workflow files must be updated manually. This PR provides the exact instructions needed.