### PR TITLE
Add branch audit script and Lidarr setup script

### DIFF
--- a/scripts/branch-audit.sh
+++ b/scripts/branch-audit.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE=${1:-origin}
+BASE_BRANCH=${2:-main}
+BASE_REF="$REMOTE/$BASE_BRANCH"
+
+echo "# Branch Audit Report (vs $BASE_REF)"; echo "generated: $(date -u +%FT%TZ)"; echo
+
+# List non-main, non-dependabot, non-PR remote branches
+branches=$(git branch -r | sed 's/^\s*//' | grep -v -- '->' | grep "^$REMOTE/" | grep -v "^$BASE_REF$" | grep -v "^$REMOTE/pr/" | grep -v "^$REMOTE/dependabot/")
+
+while read -r ref; do
+  [ -z "$ref" ] && continue
+  br=${ref#"$REMOTE/"}
+  counts=$(git rev-list --left-right --count "$BASE_REF...$ref" 2>/dev/null || echo "0\t0")
+  ahead=$(echo "$counts" | awk '{print $1}')
+  behind=$(echo "$counts" | awk '{print $2}')
+  last=$(git log -1 --pretty=format:%h\ %ci\ %an:\ %s "$ref" 2>/dev/null || echo "-")
+  files=$(git ls-tree -r --name-only "$ref" | wc -l | tr -d ' ')
+  # quick category hints
+  cats="code"
+  if git diff --name-only "$BASE_REF...$ref" | grep -q "^docs/\|\.md$"; then cats="docs,$cats"; fi
+  if git diff --name-only "$BASE_REF...$ref" | grep -qi "security\|secure\|sanit"; then cats="security,$cats"; fi
+  if git diff --name-only "$BASE_REF...$ref" | grep -qi "rate.?limit"; then cats="rate-limit,$cats"; fi
+  if git diff --name-only "$BASE_REF...$ref" | grep -qi "logging\|logger"; then cats="logging,$cats"; fi
+  dirs=$(git diff --name-only "$BASE_REF...$ref" | awk -F/ '{print $1"/"$2}' | sort -u | tr '\n' ' ')
+  echo "$ref | ahead:$ahead behind:$behind files:$files | cats:$cats | last:$last | dirs:${dirs:-/}"
+done <<< "$branches"
+

--- a/setup-lidarr.sh
+++ b/setup-lidarr.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'EOF'
+Usage: ./setup-lidarr.sh [--mode docker|source] [--branch plugins] [--ext-path ext/Lidarr] [--out-path ext/Lidarr/_output/net6.0] [--docker-tag <tag>]
+
+Options:
+  --mode        docker (default) to extract from ghcr.io/hotio/lidarr:<tag>, or source to clone/build Lidarr.
+  --branch      Lidarr branch for MODE=source (default: plugins)
+  --ext-path    Path to ext/Lidarr working directory (default: ext/Lidarr)
+  --out-path    Destination for assemblies (default: ext/Lidarr/_output/net6.0)
+  --docker-tag  Docker tag for plugins image (default: env LIDARR_DOCKER_VERSION or pr-plugins-2.13.3.4692)
+
+Environment:
+  LIDARR_DOCKER_VERSION  Overrides --docker-tag when set.
+
+The script sets and prints LIDARR_PATH on success.
+EOF
+}
+
+MODE=docker
+BRANCH=plugins
+EXT_PATH="ext/Lidarr"
+OUT_PATH="ext/Lidarr/_output/net6.0"
+DOCKER_TAG="${LIDARR_DOCKER_VERSION:-pr-plugins-2.13.3.4692}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mode) MODE="$2"; shift 2;;
+    --branch) BRANCH="$2"; shift 2;;
+    --ext-path) EXT_PATH="$2"; shift 2;;
+    --out-path) OUT_PATH="$2"; shift 2;;
+    --docker-tag) DOCKER_TAG="$2"; shift 2;;
+    -h|--help) show_help; exit 0;;
+    *) echo "Unknown argument: $1" >&2; show_help; exit 1;;
+  esac
+done
+
+mkdir -p "$OUT_PATH"
+
+if [ "$MODE" = "docker" ]; then
+  IMAGE="ghcr.io/hotio/lidarr:${DOCKER_TAG}"
+  echo "Using Docker image: $IMAGE"
+  docker pull "$IMAGE" >/dev/null
+  cid=$(docker create "$IMAGE")
+  docker cp "$cid:/app/bin/." "$OUT_PATH/"
+  docker rm -f "$cid" >/dev/null
+elif [ "$MODE" = "source" ]; then
+  if [ ! -d "$EXT_PATH/.git" ]; then
+    echo "Cloning Lidarr:$BRANCH into $EXT_PATH"
+    git clone --branch "$BRANCH" --depth 1 https://github.com/Lidarr/Lidarr.git "$EXT_PATH" >/dev/null
+  else
+    echo "Updating Lidarr at $EXT_PATH"
+    git -C "$EXT_PATH" fetch origin "$BRANCH"
+    git -C "$EXT_PATH" reset --hard "origin/$BRANCH"
+  fi
+  # Try to use prebuilt output if available
+  if [ ! -d "$OUT_PATH" ] || [ -z "$(ls -A "$OUT_PATH" 2>/dev/null || true)" ]; then
+    echo "Warning: _output path not found. You may need to build Lidarr locally and copy assemblies." >&2
+  fi
+else
+  echo "Invalid mode: $MODE" >&2; exit 1
+fi
+
+export LIDARR_PATH="$(cd "$OUT_PATH" && pwd)"
+echo "LIDARR_PATH=$LIDARR_PATH"
+ls -1 "$LIDARR_PATH" | head -20 || true
+


### PR DESCRIPTION
## Summary
- Introduces a new branch audit script to report on remote branches relative to the main branch
- Adds a setup script for Lidarr to support both Docker image extraction and source cloning/building

## Changes

### Branch Audit Script
- New `scripts/branch-audit.sh` script
- Lists remote branches excluding main, dependabot, and PR branches
- Reports ahead/behind commit counts, file counts, categories (code, docs, security, rate-limit, logging), last commit info, and directories changed

### Lidarr Setup Script
- New `setup-lidarr.sh` script
- Supports two modes: `docker` (default) and `source`
- Docker mode pulls Lidarr image and extracts assemblies
- Source mode clones or updates Lidarr repository and expects local build output
- Configurable options for branch, paths, and Docker tag
- Prints and exports `LIDARR_PATH` environment variable on success

## Test plan
- [ ] Run `branch-audit.sh` to verify branch reporting accuracy
- [ ] Run `setup-lidarr.sh` in docker mode to confirm image extraction
- [ ] Run `setup-lidarr.sh` in source mode to verify cloning and path setup
- [ ] Validate help output and error handling for invalid arguments

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8e2d8f6e-5609-4f14-bd1a-c5c5b055e46f