### PR TITLE
tests: raise coverage with cache + settings cases

### DIFF
--- a/Brainarr.Tests/Configuration/BrainarrSettingsValidatorTests.cs
+++ b/Brainarr.Tests/Configuration/BrainarrSettingsValidatorTests.cs
@@ -101,5 +101,30 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Tests.Configuration
             var r3 = validator.Validate(s3);
             r3.IsValid.Should().BeFalse();
         }
+
+        [Fact]
+        public void Local_Provider_Url_Scheme_Inference_And_IPv6_Accepted()
+        {
+            var validator = new BrainarrSettingsValidator();
+
+            // Missing scheme should be inferred for local providers
+            var s1 = new BrainarrSettings { Provider = AIProvider.Ollama, OllamaUrl = "localhost:11434" };
+            validator.Validate(s1).IsValid.Should().BeTrue();
+
+            // IPv6 with brackets should be accepted
+            var s2 = new BrainarrSettings { Provider = AIProvider.Ollama, OllamaUrl = "http://[::1]:11434" };
+            validator.Validate(s2).IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Local_Provider_Port_OutOfRange_Is_Rejected()
+        {
+            var validator = new BrainarrSettingsValidator();
+
+            var s = new BrainarrSettings { Provider = AIProvider.LMStudio, LMStudioUrl = "http://localhost:70000" };
+            var result = validator.Validate(s);
+            result.IsValid.Should().BeFalse();
+            result.Errors.Any(e => e.ErrorMessage.Contains("valid URL", StringComparison.OrdinalIgnoreCase)).Should().BeTrue();
+        }
     }
 }

--- a/Brainarr.Tests/Services/Core/ConcurrentCacheTests.cs
+++ b/Brainarr.Tests/Services/Core/ConcurrentCacheTests.cs
@@ -89,5 +89,66 @@ namespace Brainarr.Tests.Services.Core
             cache.TryGet("b", out var b).Should().BeTrue(); b.Should().Be("2");
             cache.TryGet("c", out var c).Should().BeTrue(); c.Should().Be("3");
         }
+
+        [Fact]
+        public async Task Concurrent_SameKey_Invokes_Factory_Once()
+        {
+            using var cache = new ConcurrentCache<string, int>(maxSize: 10, defaultExpiration: TimeSpan.FromMinutes(5));
+
+            var calls = 0;
+            var tasks = new Task<int>[20];
+
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = cache.GetOrAddAsync("same", async _ =>
+                {
+                    Interlocked.Increment(ref calls);
+                    await Task.Delay(10);
+                    return 123;
+                });
+            }
+
+            var results = await Task.WhenAll(tasks);
+            results.Should().OnlyContain(v => v == 123);
+            calls.Should().Be(1, "cache should prevent stampede for the same key");
+
+            var stats = cache.GetStatistics();
+            stats.Size.Should().Be(1);
+            stats.Misses.Should().BeGreaterThanOrEqualTo(1);
+            (stats.Hits + stats.Misses).Should().BeGreaterThanOrEqualTo(tasks.Length);
+        }
+
+        [Fact]
+        public void Evictions_Counter_Increments_When_OverCapacity()
+        {
+            using var cache = new ConcurrentCache<string, string>(maxSize: 2, defaultExpiration: TimeSpan.FromMinutes(5));
+
+            cache.Set("a", "1");
+            cache.Set("b", "2");
+            cache.Set("c", "3"); // evict 1
+            cache.Set("d", "4"); // evict 1
+
+            var stats = cache.GetStatistics();
+            stats.Evictions.Should().BeGreaterThanOrEqualTo(2);
+            stats.Size.Should().BeLessThanOrEqualTo(2);
+        }
+
+        [Fact]
+        public async Task CleanupExpired_Removes_Entries_When_Invoked()
+        {
+            using var cache = new ConcurrentCache<string, string>(maxSize: 10, defaultExpiration: TimeSpan.FromMilliseconds(50));
+
+            cache.Set("e1", "v1");
+            cache.Set("e2", "v2");
+
+            await Task.Delay(120); // allow to expire
+
+            // invoke private CleanupExpired via reflection to avoid waiting for timer
+            var mi = cache.GetType().GetMethod("CleanupExpired", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            mi!.Invoke(cache, null);
+
+            var stats = cache.GetStatistics();
+            stats.Size.Should().Be(0);
+        }
     }
 }


### PR DESCRIPTION
Add targeted unit tests to raise coverage:

- ConcurrentCache: stampede prevention on same key; evictions counter on over-capacity; cleanup of expired entries via reflection.
- BrainarrSettingsValidator: local provider URL scheme inference; IPv6 acceptance; out-of-range port rejection.

All tests tagged Category=Unit. No production code changes.