### PR TITLE
chore(templates,ci): add task/docs issue templates, auto-add-to-project workflow, and seeding scripts

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: README
+    url: https://github.com/RicherTunes/Brainarr#readme
+    about: Start here for overview, setup, and support links
+  - name: Build Guide (BUILD.md)
+    url: https://github.com/RicherTunes/Brainarr/blob/main/BUILD.md
+    about: Building the plugin locally and in CI
+  - name: Development Guide (DEVELOPMENT.md)
+    url: https://github.com/RicherTunes/Brainarr/blob/main/DEVELOPMENT.md
+    about: Conventions and local development workflow

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,44 @@
+name: 📚 Documentation Request
+description: Request documentation updates, fixes, or new guides
+title: "[Docs] "
+labels: ["documentation", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us keep docs clear and useful. Describe what needs to change.
+
+  - type: input
+    id: topic
+    attributes:
+      label: Topic / Area
+      description: What part of the project does this concern?
+      placeholder: e.g., CI setup, local dev, provider config
+    validations:
+      required: true
+
+  - type: textarea
+    id: change
+    attributes:
+      label: Requested Change
+      description: What should be added/updated/removed?
+      placeholder: Be as specific as possible
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected
+    attributes:
+      label: Affected Pages / Files
+      description: List the docs or paths to update
+      placeholder: |
+        - BUILD.md
+        - DEVELOPMENT.md
+        - docs/PROVIDER_SUPPORT_MATRIX.md
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add screenshots, examples, or related links
+

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,70 @@
+name: 🧰 Task / Chore
+description: Track internal work like CI, refactors, and housekeeping
+title: "[Task] "
+labels: ["task", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for internal engineering work (CI/CD, refactors, build tooling, docs plumbing, etc.).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-paragraph summary of the task
+      placeholder: What needs to be done and why
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: What area does this task impact?
+      options:
+        - CI/CD
+        - Build & Packaging
+        - Docs
+        - Provider Integrations
+        - Plugin Runtime
+        - Testing
+        - Security
+        - Infrastructure
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / To‑Dos
+      description: Concrete steps or sub-tasks
+      placeholder: |
+        - [ ] Step 1
+        - [ ] Step 2
+        - [ ] Step 3
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Observable criteria that indicate completion
+      placeholder: |
+        - [ ] Criterion A
+        - [ ] Criterion B
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / Impact
+      description: Any risks, migrations, or breaking changes to consider
+
+  - type: textarea
+    id: refs
+    attributes:
+      label: References
+      description: Related issues, PRs, docs, or external links
+

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,24 @@
+name: Add new issues and PRs to Project
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  projects: write
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to RicherTunes Project #1
+        uses: actions/add-to-project@v1.1.4
+        with:
+          project-url: https://github.com/users/RicherTunes/projects/1
+          github-token: ${{ secrets.PROJECTS_TOKEN }}
+

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -11,14 +11,14 @@ exclude = [
   # GitHub compare links (often 404 for forks)
   "https://github.com/.+/(compare|pull)/.+",
   # GitHub wiki placeholder until first page exists
-  'https://github.com/.+/.+\.wiki\.git',
+  "https://github.com/.+/.+\.wiki\.git",
   # localhost and private networks
-  'http://localhost.*',
-  'http://127\.0\.0\.1.*',
-  'http://0\.0\.0\.0.*',
-  'https?://10\..*',
-  'https?://192\.168\..*',
-  'https?://172\.(1[6-9]|2[0-9]|3[0-1])\..*'
+  "http://localhost.*",
+  "http://127\.0\.0\.1.*",
+  "http://0\.0\.0\.0.*",
+  "https?://10\..*",
+  "https?://192\.168\..*",
+  "https?://172\.(1[6-9]|2[0-9]|3[0-1])\..*"
 ]
 
 # Retry/timeout tuning for flaky docs sites

--- a/scripts/seed-initial-issues.ps1
+++ b/scripts/seed-initial-issues.ps1
@@ -1,0 +1,169 @@
+#!/usr/bin/env pwsh
+param(
+  [string]$Owner = "RicherTunes",
+  [string]$Repo = "Brainarr",
+  [int]$ProjectNumber = 1,
+  [string]$Token = $env:GITHUB_TOKEN
+)
+
+if (-not $Token) {
+  Write-Error "Provide a GitHub token via -Token or set GITHUB_TOKEN env var."; exit 1
+}
+
+$RestHeaders = @{ 
+  Authorization = "token $Token";
+  Accept        = "application/vnd.github+json";
+  'User-Agent'  = "seed-initial-issues"
+}
+
+function Invoke-GHRest([string]$Method, [string]$Uri, $Body) {
+  $json = if ($Body) { ($Body | ConvertTo-Json -Depth 8) } else { $null }
+  $params = @{ Method=$Method; Uri=$Uri; Headers=$RestHeaders }
+  if ($json) { $params["Body"] = $json }
+  Invoke-RestMethod @params
+}
+
+function Invoke-GHGraphQL($Query, $Variables) {
+  $Uri = 'https://api.github.com/graphql'
+  $Headers = @{ Authorization = "bearer $Token"; 'User-Agent'="seed-initial-issues" }
+  $Body = @{ query = $Query; variables = $Variables }
+  Invoke-RestMethod -Method POST -Uri $Uri -Headers $Headers -Body ($Body | ConvertTo-Json -Depth 8)
+}
+
+function Ensure-Label([string]$Name, [string]$Color, [string]$Description) {
+  try {
+    Invoke-GHRest -Method POST -Uri "https://api.github.com/repos/$Owner/$Repo/labels" -Body @{ name=$Name; color=$Color; description=$Description } | Out-Null
+    Write-Host "Created label: $Name"
+  } catch {
+    if ($_.Exception.Response.StatusCode.Value__ -eq 422) { Write-Host "Label exists: $Name" }
+    else { throw }
+  }
+}
+
+function New-RepoIssue([string]$Title, [string[]]$Labels, [string]$Body) {
+  $res = Invoke-GHRest -Method POST -Uri "https://api.github.com/repos/$Owner/$Repo/issues" -Body @{ title=$Title; labels=$Labels; body=$Body }
+  return $res
+}
+
+function Get-UserProjectId([string]$Login, [int]$Number) {
+  $q = @"
+query(
+  $login: String!,
+  $number: Int!
+) {
+  user(login: $login) {
+    projectV2(number: $number) { id }
+  }
+}
+"@
+  $data = Invoke-GHGraphQL -Query $q -Variables @{ login=$Login; number=$Number }
+  return $data.data.user.projectV2.id
+}
+
+function Add-IssueToProject([string]$ProjectId, [string]$IssueNodeId) {
+  $m = @"
+mutation(
+  $projectId: ID!,
+  $contentId: ID!
+) {
+  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+    item { id }
+  }
+}
+"@
+  Invoke-GHGraphQL -Query $m -Variables @{ projectId=$ProjectId; contentId=$IssueNodeId } | Out-Null
+}
+
+Write-Host "==> Ensuring base labels"
+Ensure-Label -Name "ci" -Color "1d76db" -Description "Continuous Integration"
+Ensure-Label -Name "task" -Color "d4c5f9" -Description "General engineering task/chore"
+Ensure-Label -Name "documentation" -Color "0075ca" -Description "Documentation changes"
+Ensure-Label -Name "needs-triage" -Color "fbca04" -Description "Needs initial triage"
+
+$ProjectId = Get-UserProjectId -Login $Owner -Number $ProjectNumber
+if (-not $ProjectId) { Write-Error "Could not resolve Project v2 ID for $Owner #$ProjectNumber"; exit 1 }
+
+Write-Host "==> Seeding initial issues and adding to Project $ProjectNumber"
+
+$items = @(
+  @{ title = "CI: Enforce bash shell across POSIX workflows"; labels = @("ci","task","needs-triage"); body = @'
+AGENTS decision: enforce `shell: bash` for POSIX-style steps across the matrix.
+
+Tasks
+- [ ] Set `defaults.run.shell: bash` at workflow level where applicable
+- [ ] Explicitly set `shell: bash` for POSIX steps on Windows runners
+- [ ] Verify Windows-only steps use `shell: pwsh` when intended
+- [ ] Align `build.sh` and `test-local-ci.sh` with workflow shells
+
+Acceptance
+- [ ] All workflows use consistent shells; no mixed default shells
+- [ ] CI passes on Linux/macOS/Windows
+'@ },
+
+  @{ title = "CI: Centralize Lidarr assemblies extraction + artifact"; labels = @("ci","task","needs-triage"); body = @'
+AGENTS decision: extract required Lidarr assemblies from the Hotio `plugins` branch Docker image and publish as an artifact for matrix jobs.
+
+Tasks
+- [ ] Create a dedicated job that pulls `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` and exports `/app/bin` assemblies to `ext/Lidarr-docker/_output/net6.0/`
+- [ ] Upload artifact `lidarr-assemblies-net6.0`
+- [ ] Replace re-extraction in dependent jobs with artifact download
+
+Acceptance
+- [ ] Only one extraction job runs per workflow
+- [ ] All matrix jobs consume the artifact
+'@ },
+
+  @{ title = "CI: Fail-fast if Lidarr assemblies missing"; labels = @("ci","task","needs-triage"); body = @'
+Add an early sanity check in build/test jobs to fail if `ext/Lidarr-docker/_output/net6.0/` is absent or empty.
+
+Tasks
+- [ ] Add pre-build step to assert required assemblies exist
+- [ ] Provide actionable error message pointing to extraction job logs
+
+Acceptance
+- [ ] Missing assemblies cause early, clear failure
+'@ },
+
+  @{ title = "CI: Deduplicate extraction in CodeQL/security scans"; labels = @("ci","task","needs-triage"); body = @'
+Refactor CodeQL and security workflows to reuse the same extraction logic (composite action or reusable workflow) used by CI.
+
+Tasks
+- [ ] Create composite action or reusable workflow for Docker-based extraction
+- [ ] Consume it in CI, CodeQL, nightly jobs
+
+Acceptance
+- [ ] No duplicated shell blocks for extraction
+'@ },
+
+  @{ title = "CI: Keep LIDARR_DOCKER_VERSION current for plugins branch"; labels = @("ci","task","needs-triage"); body = @'
+Automate monitoring of the Hotio `plugins` tag/digest and open an issue/PR when drift is detected.
+
+Tasks
+- [ ] Add scheduled job to compare current `LIDARR_DOCKER_VERSION`/digest vs latest
+- [ ] Open issue with changelog context when drift occurs
+
+Acceptance
+- [ ] Drift results in a single actionable issue
+'@ },
+
+  @{ title = "Docs: Document Docker-based extraction + local dev flow"; labels = @("documentation","needs-triage"); body = @'
+Update BUILD.md/DEVELOPMENT.md to explain Docker-based extraction and artifact usage, plus quick local dev setup.
+
+Tasks
+- [ ] BUILD.md – outline extraction, artifact, env vars
+- [ ] DEVELOPMENT.md – local workflow, test scripts, troubleshooting
+
+Acceptance
+- [ ] Docs match AGENTS decisions and current CI
+'@ }
+)
+
+foreach ($it in $items) {
+  $res = New-RepoIssue -Title $it.title -Labels $it.labels -Body $it.body
+  $num = $res.number; $node = $res.node_id; $url = $res.html_url
+  Write-Host ("Created issue #{0}: {1}" -f $num, $url)
+  if ($node) { Add-IssueToProject -ProjectId $ProjectId -IssueNodeId $node; Write-Host "  ↳ Added to Project" }
+}
+
+Write-Host "==> Done"
+

--- a/scripts/seed-initial-issues.sh
+++ b/scripts/seed-initial-issues.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+OWNER="RicherTunes"
+REPO="Brainarr"
+PROJECT_NUMBER=1
+TOKEN="${GITHUB_TOKEN:-}"
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+  -o, --owner <owner>            GitHub user/org (default: $OWNER)
+  -r, --repo <repo>              Repository name (default: $REPO)
+  -p, --project <num>            User Project v2 number (default: $PROJECT_NUMBER)
+  -t, --token <token>            GitHub token (default: env GITHUB_TOKEN)
+
+Requires: curl, jq
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--owner) OWNER="$2"; shift 2;;
+    -r|--repo) REPO="$2"; shift 2;;
+    -p|--project|--project-number) PROJECT_NUMBER="$2"; shift 2;;
+    -t|--token) TOKEN="$2"; shift 2;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 1;;
+  esac
+done
+
+require_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }; }
+require_cmd curl
+require_cmd jq
+
+if [[ -z "$TOKEN" ]]; then
+  echo "Provide a GitHub token via --token or GITHUB_TOKEN env var" >&2
+  exit 1
+fi
+
+REST_H=(
+  -H "Authorization: token $TOKEN"
+  -H "Accept: application/vnd.github+json"
+  -H "User-Agent: seed-initial-issues"
+)
+
+gh_rest() {
+  local method="$1" url="$2" data="${3:-}"
+  if [[ -n "$data" ]]; then
+    curl -sS "${REST_H[@]}" -X "$method" "$url" -d "$data"
+  else
+    curl -sS "${REST_H[@]}" -X "$method" "$url"
+  fi
+}
+
+create_label() {
+  local name="$1" color="$2" desc="$3"
+  local payload
+  payload=$(jq -n --arg name "$name" --arg color "$color" --arg desc "$desc" '{name:$name,color:$color,description:$desc}')
+  local code
+  code=$(curl -sS -o /dev/null -w "%{http_code}" "${REST_H[@]}" \
+    -X POST "https://api.github.com/repos/$OWNER/$REPO/labels" -d "$payload")
+  if [[ "$code" == "201" ]]; then
+    echo "Created label: $name"
+  elif [[ "$code" == "422" ]]; then
+    echo "Label exists: $name"
+  else
+    echo "Label $name returned HTTP $code" >&2
+  fi
+}
+
+gh_graphql() {
+  local query="$1" variables_json="$2"
+  curl -sS -H "Authorization: bearer $TOKEN" -H "User-Agent: seed-initial-issues" \
+    -X POST https://api.github.com/graphql \
+    -d "$(jq -n --arg q "$query" --argjson vars "$variables_json" '{query:$q, variables:$vars}')"
+}
+
+get_user_project_id() {
+  local q variables resp id
+  read -r -d '' q <<'Q'
+query($login: String!, $number: Int!) {
+  user(login: $login) {
+    projectV2(number: $number) { id }
+  }
+}
+Q
+  variables=$(jq -n --arg login "$OWNER" --argjson number "$PROJECT_NUMBER" '{login:$login, number:$number}')
+  resp=$(gh_graphql "$q" "$variables")
+  id=$(jq -r '.data.user.projectV2.id // empty' <<<"$resp")
+  [[ -n "$id" ]] && echo "$id" || return 1
+}
+
+add_issue_to_project() {
+  local project_id="$1" content_id="$2" q variables
+  read -r -d '' q <<'Q'
+mutation($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+    item { id }
+  }
+}
+Q
+  variables=$(jq -n --arg projectId "$project_id" --arg contentId "$content_id" '{projectId:$projectId, contentId:$contentId}')
+  gh_graphql "$q" "$variables" >/dev/null
+}
+
+new_issue() {
+  local title="$1" labels_json="$2" body="$3" payload resp
+  payload=$(jq -n --arg title "$title" --arg body "$body" --argjson labels "$labels_json" '{title:$title, body:$body, labels:$labels}')
+  resp=$(gh_rest POST "https://api.github.com/repos/$OWNER/$REPO/issues" "$payload")
+  echo "$resp"
+}
+
+echo "==> Ensuring base labels"
+create_label "ci" "1d76db" "Continuous Integration"
+create_label "task" "d4c5f9" "General engineering task/chore"
+create_label "documentation" "0075ca" "Documentation changes"
+create_label "needs-triage" "fbca04" "Needs initial triage"
+
+echo "==> Resolving Project v2 ID for $OWNER #$PROJECT_NUMBER"
+PROJECT_ID=$(get_user_project_id) || { echo "Failed to resolve Project v2 ID" >&2; exit 1; }
+
+make_issue() {
+  local TITLE="$1" LABELS_JSON="$2" BODY="$3" out num node url
+  out=$(new_issue "$TITLE" "$LABELS_JSON" "$BODY")
+  num=$(jq -r '.number' <<<"$out")
+  node=$(jq -r '.node_id' <<<"$out")
+  url=$(jq -r '.html_url' <<<"$out")
+  echo "Created issue #$num: $url"
+  if [[ -n "$node" && "$node" != "null" ]]; then
+    add_issue_to_project "$PROJECT_ID" "$node"
+    echo "  ↳ Added to Project"
+  fi
+}
+
+BODY1=$(cat <<'EOF'
+AGENTS decision: enforce `shell: bash` for POSIX-style steps across the matrix.
+
+Tasks
+- [ ] Set `defaults.run.shell: bash` at workflow level where applicable
+- [ ] Explicitly set `shell: bash` for POSIX steps on Windows runners
+- [ ] Verify Windows-only steps use `shell: pwsh` when intended
+- [ ] Align `build.sh` and `test-local-ci.sh` with workflow shells
+
+Acceptance
+- [ ] All workflows use consistent shells; no mixed default shells
+- [ ] CI passes on Linux/macOS/Windows
+EOF
+)
+
+BODY2=$(cat <<'EOF'
+AGENTS decision: extract required Lidarr assemblies from the Hotio `plugins` branch Docker image and publish as an artifact for matrix jobs.
+
+Tasks
+- [ ] Create a dedicated job that pulls `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` and exports `/app/bin` assemblies to `ext/Lidarr-docker/_output/net6.0/`
+- [ ] Upload artifact `lidarr-assemblies-net6.0`
+- [ ] Replace re-extraction in dependent jobs with artifact download
+
+Acceptance
+- [ ] Only one extraction job runs per workflow
+- [ ] All matrix jobs consume the artifact
+EOF
+)
+
+BODY3=$(cat <<'EOF'
+Add an early sanity check in build/test jobs to fail if `ext/Lidarr-docker/_output/net6.0/` is absent or empty.
+
+Tasks
+- [ ] Add pre-build step to assert required assemblies exist
+- [ ] Provide actionable error message pointing to extraction job logs
+
+Acceptance
+- [ ] Missing assemblies cause early, clear failure
+EOF
+)
+
+BODY4=$(cat <<'EOF'
+Refactor CodeQL and security workflows to reuse the same extraction logic (composite action or reusable workflow) used by CI.
+
+Tasks
+- [ ] Create composite action or reusable workflow for Docker-based extraction
+- [ ] Consume it in CI, CodeQL, nightly jobs
+
+Acceptance
+- [ ] No duplicated shell blocks for extraction
+EOF
+)
+
+BODY5=$(cat <<'EOF'
+Automate monitoring of the Hotio `plugins` tag/digest and open an issue/PR when drift is detected.
+
+Tasks
+- [ ] Add scheduled job to compare current `LIDARR_DOCKER_VERSION`/digest vs latest
+- [ ] Open issue with changelog context when drift occurs
+
+Acceptance
+- [ ] Drift results in a single actionable issue
+EOF
+)
+
+BODY6=$(cat <<'EOF'
+Update BUILD.md/DEVELOPMENT.md to explain Docker-based extraction and artifact usage, plus quick local dev setup.
+
+Tasks
+- [ ] BUILD.md – outline extraction, artifact, env vars
+- [ ] DEVELOPMENT.md – local workflow, test scripts, troubleshooting
+
+Acceptance
+- [ ] Docs match AGENTS decisions and current CI
+EOF
+)
+
+echo "==> Creating issues and adding to Project"
+make_issue "CI: Enforce bash shell across POSIX workflows" '["ci","task","needs-triage"]' "$BODY1"
+make_issue "CI: Centralize Lidarr assemblies extraction + artifact" '["ci","task","needs-triage"]' "$BODY2"
+make_issue "CI: Fail-fast if Lidarr assemblies missing" '["ci","task","needs-triage"]' "$BODY3"
+make_issue "CI: Deduplicate extraction in CodeQL/security scans" '["ci","task","needs-triage"]' "$BODY4"
+make_issue "CI: Keep LIDARR_DOCKER_VERSION current for plugins branch" '["ci","task","needs-triage"]' "$BODY5"
+make_issue "Docs: Document Docker-based extraction + local dev flow" '["documentation","needs-triage"]' "$BODY6"
+
+echo "==> Done"
+

--- a/scripts/seed_initial_issues.py
+++ b/scripts/seed_initial_issues.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+OWNER = os.environ.get("OWNER", "RicherTunes")
+REPO = os.environ.get("REPO", "Brainarr")
+PROJECT_NUMBER = int(os.environ.get("PROJECT_NUMBER", "1"))
+TOKEN = os.environ.get("GITHUB_TOKEN")
+
+API = "https://api.github.com"
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+def http_request(method, url, body=None, headers=None):
+    data = None
+    if body is not None:
+        if not isinstance(body, (bytes, bytearray)):
+            body = json.dumps(body).encode("utf-8")
+        data = body
+    req = urllib.request.Request(url=url, data=data, method=method)
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            content = resp.read().decode("utf-8")
+            if content:
+                return resp.getcode(), json.loads(content)
+            return resp.getcode(), None
+    except urllib.error.HTTPError as e:
+        content = e.read().decode("utf-8") if e.fp else ""
+        try:
+            payload = json.loads(content) if content else None
+        except Exception:
+            payload = {"raw": content}
+        return e.code, payload
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Network error contacting {url}: {e}")
+
+def rest_headers():
+    return {
+        "Authorization": f"token {TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "seed-initial-issues-python",
+        "Content-Type": "application/json",
+    }
+
+def gh_graphql(query, variables):
+    headers = {
+        "Authorization": f"bearer {TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "seed-initial-issues-python",
+        "Content-Type": "application/json",
+    }
+    code, body = http_request("POST", f"{API}/graphql", {"query": query, "variables": variables}, headers)
+    if code >= 400:
+        raise RuntimeError(f"GraphQL error {code}: {body}")
+    return body
+
+def ensure_label(name, color, description):
+    code, _ = http_request(
+        "POST",
+        f"{API}/repos/{OWNER}/{REPO}/labels",
+        {"name": name, "color": color, "description": description},
+        rest_headers(),
+    )
+    if code == 201:
+        print(f"Created label: {name}")
+    elif code == 422:
+        print(f"Label exists: {name}")
+    else:
+        eprint(f"Label {name} returned HTTP {code}")
+
+def new_issue(title, labels, body):
+    code, resp = http_request(
+        "POST",
+        f"{API}/repos/{OWNER}/{REPO}/issues",
+        {"title": title, "labels": labels, "body": body},
+        rest_headers(),
+    )
+    if code not in (200, 201):
+        raise RuntimeError(f"Failed to create issue ({code}): {resp}")
+    return resp
+
+def get_user_project_id(login, number):
+    q = (
+        "query($login: String!, $number: Int!) {\n"
+        "  user(login: $login) { projectV2(number: $number) { id } }\n"
+        "}"
+    )
+    data = gh_graphql(q, {"login": login, "number": number})
+    try:
+        return data["data"]["user"]["projectV2"]["id"]
+    except Exception:
+        raise RuntimeError(f"Could not resolve Project v2 ID: {data}")
+
+def add_issue_to_project(project_id, issue_node_id):
+    m = (
+        "mutation($projectId: ID!, $contentId: ID!) {\n"
+        "  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } }\n"
+        "}"
+    )
+    gh_graphql(m, {"projectId": project_id, "contentId": issue_node_id})
+
+def main():
+    global OWNER, REPO, PROJECT_NUMBER, TOKEN
+    # Basic CLI parsing
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a in ("-o", "--owner"):
+            OWNER = args[i+1]; i += 2
+        elif a in ("-r", "--repo"):
+            REPO = args[i+1]; i += 2
+        elif a in ("-p", "--project", "--project-number"):
+            PROJECT_NUMBER = int(args[i+1]); i += 2
+        elif a in ("-t", "--token"):
+            TOKEN = args[i+1]; i += 2
+        elif a in ("-h", "--help"):
+            print("Usage: seed_initial_issues.py [-o owner] [-r repo] [-p project] [-t token]"); return 0
+        else:
+            eprint(f"Unknown argument: {a}"); return 2
+
+    if not TOKEN:
+        eprint("Provide a GitHub token via --token or GITHUB_TOKEN env var");
+        return 1
+
+    # quick network sanity
+    try:
+        code, _ = http_request("GET", f"{API}/rate_limit", headers=rest_headers())
+        if code != 200:
+            eprint(f"GitHub API unreachable, code {code}")
+    except Exception as e:
+        eprint(str(e)); return 1
+
+    print("==> Ensuring base labels")
+    ensure_label("ci", "1d76db", "Continuous Integration")
+    ensure_label("task", "d4c5f9", "General engineering task/chore")
+    ensure_label("documentation", "0075ca", "Documentation changes")
+    ensure_label("needs-triage", "fbca04", "Needs initial triage")
+
+    print(f"==> Resolving Project v2 ID for {OWNER} #{PROJECT_NUMBER}")
+    project_id = get_user_project_id(OWNER, PROJECT_NUMBER)
+
+    issues = [
+        (
+            "CI: Enforce bash shell across POSIX workflows",
+            ["ci", "task", "needs-triage"],
+            """AGENTS decision: enforce `shell: bash` for POSIX-style steps across the matrix.
+
+Tasks
+- [ ] Set `defaults.run.shell: bash` at workflow level where applicable
+- [ ] Explicitly set `shell: bash` for POSIX steps on Windows runners
+- [ ] Verify Windows-only steps use `shell: pwsh` when intended
+- [ ] Align `build.sh` and `test-local-ci.sh` with workflow shells
+
+Acceptance
+- [ ] All workflows use consistent shells; no mixed default shells
+- [ ] CI passes on Linux/macOS/Windows
+""",
+        ),
+        (
+            "CI: Centralize Lidarr assemblies extraction + artifact",
+            ["ci", "task", "needs-triage"],
+            """AGENTS decision: extract required Lidarr assemblies from the Hotio `plugins` branch Docker image and publish as an artifact for matrix jobs.
+
+Tasks
+- [ ] Create a dedicated job that pulls `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` and exports `/app/bin` assemblies to `ext/Lidarr-docker/_output/net6.0/`
+- [ ] Upload artifact `lidarr-assemblies-net6.0`
+- [ ] Replace re-extraction in dependent jobs with artifact download
+
+Acceptance
+- [ ] Only one extraction job runs per workflow
+- [ ] All matrix jobs consume the artifact
+""",
+        ),
+        (
+            "CI: Fail-fast if Lidarr assemblies missing",
+            ["ci", "task", "needs-triage"],
+            """Add an early sanity check in build/test jobs to fail if `ext/Lidarr-docker/_output/net6.0/` is absent or empty.
+
+Tasks
+- [ ] Add pre-build step to assert required assemblies exist
+- [ ] Provide actionable error message pointing to extraction job logs
+
+Acceptance
+- [ ] Missing assemblies cause early, clear failure
+""",
+        ),
+        (
+            "CI: Deduplicate extraction in CodeQL/security scans",
+            ["ci", "task", "needs-triage"],
+            """Refactor CodeQL and security workflows to reuse the same extraction logic (composite action or reusable workflow) used by CI.
+
+Tasks
+- [ ] Create composite action or reusable workflow for Docker-based extraction
+- [ ] Consume it in CI, CodeQL, nightly jobs
+
+Acceptance
+- [ ] No duplicated shell blocks for extraction
+""",
+        ),
+        (
+            "CI: Keep LIDARR_DOCKER_VERSION current for plugins branch",
+            ["ci", "task", "needs-triage"],
+            """Automate monitoring of the Hotio `plugins` tag/digest and open an issue/PR when drift is detected.
+
+Tasks
+- [ ] Add scheduled job to compare current `LIDARR_DOCKER_VERSION`/digest vs latest
+- [ ] Open issue with changelog context when drift occurs
+
+Acceptance
+- [ ] Drift results in a single actionable issue
+""",
+        ),
+        (
+            "Docs: Document Docker-based extraction + local dev flow",
+            ["documentation", "needs-triage"],
+            """Update BUILD.md/DEVELOPMENT.md to explain Docker-based extraction and artifact usage, plus quick local dev setup.
+
+Tasks
+- [ ] BUILD.md – outline extraction, artifact, env vars
+- [ ] DEVELOPMENT.md – local workflow, test scripts, troubleshooting
+
+Acceptance
+- [ ] Docs match AGENTS decisions and current CI
+""",
+        ),
+    ]
+
+    print("==> Creating issues and adding to Project")
+    for title, labels, body in issues:
+        resp = new_issue(title, labels, body)
+        num = resp.get("number")
+        node = resp.get("node_id")
+        url = resp.get("html_url")
+        print(f"Created issue #{num}: {url}")
+        if node:
+            add_issue_to_project(project_id, node)
+            print("  ↳ Added to Project")
+
+    print("==> Done")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
This PR adds issue/PR workflow scaffolding and project automation:

- Add `.github/ISSUE_TEMPLATE/{task.yml,docs.yml,config.yml}`
- Add `.github/workflows/add-to-project.yml` to auto-add new issues/PRs to the Project board (requires repo secret `PROJECTS_TOKEN` with classic PAT: `repo`, `project`)
- Add seeding scripts:
  - `scripts/seed_initial_issues.py`
  - `scripts/seed-initial-issues.sh`
  - `scripts/seed-initial-issues.ps1`

Notes
- No product code changes; all housekeeping/automation.
- After merging, set `PROJECTS_TOKEN` repo secret to enable auto-add.
- Optionally seed initial tasks using one of the scripts.