### PR TITLE
chore(projects): auto-add + seeding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,37 +23,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Extract Lidarr assemblies from plugins Docker image
-      run: |
-        set -euo pipefail
-        IMAGE="ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}"
-        if [ -n "${LIDARR_DOCKER_DIGEST:-}" ]; then IMAGE="ghcr.io/hotio/lidarr@${LIDARR_DOCKER_DIGEST}"; fi
-        echo "Using Docker image: ${IMAGE}"
-        mkdir -p ext/Lidarr-docker/_output/net6.0
-        docker pull "${IMAGE}"
-        docker create --name temp-lidarr "${IMAGE}" >/dev/null
-        for f in \
-          Lidarr.dll \
-          Lidarr.Common.dll \
-          Lidarr.Core.dll \
-          Lidarr.Http.dll \
-          Lidarr.Api.V1.dll \
-          Lidarr.Host.dll; do
-          docker cp temp-lidarr:/app/bin/$f ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || echo "Optional assembly missing: $f"
-        done
-        # Copy common Microsoft.Extensions assemblies opportunistically (no-fail)
-        for f in \
-          Microsoft.Extensions.Caching.Memory.dll \
-          Microsoft.Extensions.Caching.Abstractions.dll \
-          Microsoft.Extensions.DependencyInjection.Abstractions.dll \
-          Microsoft.Extensions.Logging.Abstractions.dll \
-          Microsoft.Extensions.Options.dll \
-          Microsoft.Extensions.Primitives.dll; do
-          docker cp temp-lidarr:/app/bin/$f ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || true
-        done
-        docker rm -f temp-lidarr >/dev/null
-        echo "Final assemblies in target directory:"
-        ls -la ext/Lidarr-docker/_output/net6.0/
+    - name: Extract Lidarr assemblies (shared script)
+      run: bash scripts/extract-lidarr-assemblies.sh --mode minimal --output-dir ext/Lidarr-docker/_output/net6.0
       shell: bash
 
     - name: Upload assemblies artifact

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,25 +35,9 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Extract Lidarr assemblies (Docker)
-        run: |
-          set -e
-          echo "Extracting Lidarr assemblies from Docker image..."
-          LIDARR_DOCKER_VERSION=pr-plugins-2.13.3.4692
-          docker pull ghcr.io/hotio/lidarr:$LIDARR_DOCKER_VERSION
-          docker create --name temp-lidarr ghcr.io/hotio/lidarr:$LIDARR_DOCKER_VERSION
-          mkdir -p ext/Lidarr-docker/_output/net6.0
-          for f in \
-            Lidarr.dll \
-            Lidarr.Common.dll \
-            Lidarr.Core.dll \
-            Lidarr.Http.dll \
-            Lidarr.Api.V1.dll \
-            Lidarr.Host.dll ; do
-            docker cp temp-lidarr:/app/bin/$f ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || true
-          done
-          docker rm temp-lidarr
-          echo "Lidarr assemblies present:" && ls -la ext/Lidarr-docker/_output/net6.0/
+      - name: Extract Lidarr assemblies (shared script)
+        run: bash scripts/extract-lidarr-assemblies.sh --mode minimal --output-dir ext/Lidarr-docker/_output/net6.0
+        shell: bash
 
       - name: Set LIDARR_PATH
         run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" >> $GITHUB_ENV

--- a/.github/workflows/plugin-package.yml
+++ b/.github/workflows/plugin-package.yml
@@ -28,17 +28,7 @@ jobs:
 
     - name: Extract Lidarr Assemblies
       run: |
-        # Use the proven Docker extraction method
-        set -euo pipefail
-        IMAGE="ghcr.io/hotio/lidarr:pr-plugins-2.13.3.4692"
-        docker pull "$IMAGE"
-        docker create --name temp-lidarr "$IMAGE" >/dev/null
-
-        mkdir -p ext/Lidarr/_output/net6.0
-        # Copy ALL assemblies from the plugins image to avoid version drift (e.g., NLog)
-        docker cp temp-lidarr:/app/bin/. ext/Lidarr/_output/net6.0/
-        docker rm -f temp-lidarr >/dev/null
-
+        bash scripts/extract-lidarr-assemblies.sh --mode full --output-dir ext/Lidarr/_output/net6.0
         echo "Extracted assemblies (sample):"
         ls -1 ext/Lidarr/_output/net6.0 | sed -n '1,40p'
         if [ ! -f ext/Lidarr/_output/net6.0/NLog.dll ]; then
@@ -101,12 +91,12 @@ jobs:
     - name: Start Lidarr with plugin mounted
       run: |
         set -e
-        docker pull ghcr.io/hotio/lidarr:pr-plugins-2.13.3.4692
+        docker pull ghcr.io/hotio/lidarr:pr-plugins-2.13.3.4711
         docker run -d --name lidarr-smoke \
           -p 8686:8686 \
           -v "${{ github.workspace }}/plugin-dist/package/Brainarr:/config/plugins/RicherTunes/Brainarr:ro" \
           -e PUID=1000 -e PGID=1000 \
-          ghcr.io/hotio/lidarr:pr-plugins-2.13.3.4692
+          ghcr.io/hotio/lidarr:pr-plugins-2.13.3.4711
         # Give it a moment to boot
         sleep 10
         echo "Container running: $(docker ps --filter name=lidarr-smoke --format '{{.Names}}')"

--- a/.github/workflows/project-auto-add.yml
+++ b/.github/workflows/project-auto-add.yml
@@ -1,0 +1,27 @@
+name: Project Auto-Add
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  add-to-project:
+    name: Add to Project
+    runs-on: ubuntu-latest
+    if: ${{ vars.PROJECT_URL != '' && secrets.PROJECTS_TOKEN != '' }}
+    steps:
+    - name: Add issue to project
+      if: ${{ github.event_name == 'issues' }}
+      uses: actions/add-to-project@v1
+      with:
+        project-url: ${{ vars.PROJECT_URL }}
+        github-token: ${{ secrets.PROJECTS_TOKEN }}
+
+    - name: Add pull request to project
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/add-to-project@v1
+      with:
+        project-url: ${{ vars.PROJECT_URL }}
+        github-token: ${{ secrets.PROJECTS_TOKEN }}

--- a/Brainarr.Tests/Services/Providers/GeminiProviderTests.cs
+++ b/Brainarr.Tests/Services/Providers/GeminiProviderTests.cs
@@ -65,15 +65,15 @@ namespace Brainarr.Tests.Services.Providers
         public async Task TestConnectionAsync_service_disabled_sets_hint()
         {
             var json = @"{
-  \"error\": {
-    \"code\": 403,
-    \"message\": \"Generative Language API has not been used in project 123 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/generativelanguage.googleapis.com/overview?project=123 then retry.\",
-    \"status\": \"PERMISSION_DENIED\",
-    \"details\": [
-      {\"@type\": \"type.googleapis.com/google.rpc.ErrorInfo\", \"reason\": \"SERVICE_DISABLED\", \"domain\": \"googleapis.com\", \"metadata\": {\"activationUrl\": \"https://console.developers.google.com/apis/api/generativelanguage.googleapis.com/overview?project=123\", \"consumer\": \"projects/123\"}}
+  ""error"": {
+    ""code"": 403,
+    ""message"": ""Generative Language API has not been used in project 123 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/generativelanguage.googleapis.com/overview?project=123 then retry."",
+    ""status"": ""PERMISSION_DENIED"",
+    ""details"": [
+      {""@type"": ""type.googleapis.com/google.rpc.ErrorInfo"", ""reason"": ""SERVICE_DISABLED"", ""domain"": ""googleapis.com"", ""metadata"": {""activationUrl"": ""https://console.developers.google.com/apis/api/generativelanguage.googleapis.com/overview?project=123"", ""consumer"": ""projects/123""}}
     ]
   }
-        }";
+}";
             var http = new FixedHttpClient(r => new HttpResponse(r, new HttpHeader(), json, HttpStatusCode.Forbidden));
         var provider = new NzbDrone.Core.ImportLists.Brainarr.Services.GeminiProvider(http, L, apiKey: "AIza-TEST", model: BrainarrConstants.DefaultGeminiModel);
         var ok = await provider.TestConnectionAsync();

--- a/scripts/seed-project.ps1
+++ b/scripts/seed-project.ps1
@@ -1,0 +1,224 @@
+param(
+  [string]$Owner,
+  [ValidateSet('user','org')][string]$Scope = 'user',
+  [int]$ProjectNumber,
+  [string]$Repo = 'RicherTunes/Brainarr',
+  [string]$TasksPath = 'tasks/seed.json',
+  [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Info($msg) { Write-Host $msg -ForegroundColor Cyan }
+function Write-Ok($msg) { Write-Host $msg -ForegroundColor Green }
+function Write-Warn($msg) { Write-Host $msg -ForegroundColor Yellow }
+function Write-Err($msg) { Write-Host $msg -ForegroundColor Red }
+
+$token = $env:PROJECTS_TOKEN
+if (-not $token) {
+  Write-Err 'PROJECTS_TOKEN not set. Export a classic PAT with repo, project scopes.'
+  exit 1
+}
+
+if (-not (Test-Path $TasksPath)) {
+  Write-Err "Tasks file not found: $TasksPath"
+  exit 1
+}
+
+$raw = Get-Content $TasksPath -Raw
+try {
+  $config = $raw | ConvertFrom-Json -Depth 10
+} catch {
+  Write-Err "Failed to parse JSON in $TasksPath: $($_.Exception.Message)"
+  exit 1
+}
+
+if (-not $Owner) { $Owner = $config.owner }
+if (-not $ProjectNumber) { $ProjectNumber = [int]$config.projectNumber }
+if (-not $Repo) { $Repo = $config.repo }
+if ($config.scope) { $Scope = $config.scope }
+
+if (-not $Owner -or -not $ProjectNumber) {
+  Write-Err 'Owner and ProjectNumber are required (either via params or seed.json).'
+  exit 1
+}
+
+if (-not $config.tasks -or $config.tasks.Count -eq 0) {
+  Write-Err 'No tasks provided in seed.json.'
+  exit 1
+}
+
+$headersGraph = @{ Authorization = "bearer $token"; 'User-Agent' = 'Brainarr-Project-Seeder'; Accept = 'application/vnd.github+json' }
+$headersRest = @{ Authorization = "token $token"; 'User-Agent' = 'Brainarr-Project-Seeder'; Accept = 'application/vnd.github+json' }
+
+function Invoke-GraphQL([string]$Query, $Variables) {
+  $body = @{ query = $Query; variables = $Variables } | ConvertTo-Json -Depth 50
+  $resp = Invoke-RestMethod -Method Post -Uri 'https://api.github.com/graphql' -Headers $headersGraph -ContentType 'application/json' -Body $body
+  if ($null -ne $resp.errors) {
+    $err = ($resp.errors | ConvertTo-Json -Depth 50)
+    throw "GraphQL error: $err"
+  }
+  return $resp.data
+}
+
+Write-Info "Resolving ProjectV2 id for $Owner #$ProjectNumber ($Scope)"
+
+$projQuery = @"
+query(
+  $login:String!,
+  $num:Int!
+) {
+  user(login:$login) @include(if: %(isUser)s) {
+    projectV2(number:$num) {
+      id
+      title
+      fields(first:50) {
+        nodes {
+          __typename
+          id
+          name
+          dataType
+          ... on ProjectV2SingleSelectField {
+            options { id name }
+          }
+        }
+      }
+    }
+  }
+  organization(login:$login) @include(if: %(isOrg)s) {
+    projectV2(number:$num) {
+      id
+      title
+      fields(first:50) {
+        nodes {
+          __typename
+          id
+          name
+          dataType
+          ... on ProjectV2SingleSelectField {
+            options { id name }
+          }
+        }
+      }
+    }
+  }
+}
+"@
+
+$projQuery = $projQuery.Replace('%(isUser)s', $(if ($Scope -eq 'user') { 'true' } else { 'false' }))
+$projQuery = $projQuery.Replace('%(isOrg)s', $(if ($Scope -eq 'org') { 'true' } else { 'false' }))
+
+$data = Invoke-GraphQL $projQuery @{ login = $Owner; num = $ProjectNumber }
+
+$project = if ($Scope -eq 'user') { $data.user.projectV2 } else { $data.organization.projectV2 }
+if (-not $project -or -not $project.id) {
+  Write-Err "Project not found. Check Owner/Scope/ProjectNumber."
+  exit 1
+}
+
+$projectId = $project.id
+Write-Ok "Project resolved: $($project.title) ($projectId)"
+
+$statusField = $null
+foreach ($f in $project.fields.nodes) {
+  if ($f.name -eq 'Status' -and $f.__typename -eq 'ProjectV2SingleSelectField') { $statusField = $f; break }
+}
+
+$defaultStatusName = if ($config.status) { [string]$config.status } else { $null }
+
+function Get-StatusOptionId([string]$name) {
+  if (-not $statusField) { return $null }
+  foreach ($opt in $statusField.options) {
+    if ($opt.name -ieq $name) { return $opt.id }
+  }
+  return $null
+}
+
+$ownerRepoParts = $Repo.Split('/')
+if ($ownerRepoParts.Count -ne 2) { throw "Repo must be in 'owner/name' form. Got: $Repo" }
+$repoOwner = $ownerRepoParts[0]
+$repoName  = $ownerRepoParts[1]
+
+Write-Info "Seeding $($config.tasks.Count) task(s) into repo $Repo and project $Owner/#$ProjectNumber"
+
+$addMutation = @"
+mutation(
+  $projectId:ID!,
+  $contentId:ID!
+) {
+  addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}) {
+    item { id }
+  }
+}
+"@
+
+$updateStatusMutation = @"
+mutation(
+  $projectId:ID!,
+  $itemId:ID!,
+  $fieldId:ID!,
+  $optionId:String!
+) {
+  updateProjectV2ItemFieldValue(input:{
+    projectId:$projectId,
+    itemId:$itemId,
+    fieldId:$fieldId,
+    value:{ singleSelectOptionId:$optionId }
+  }) {
+    projectV2Item { id }
+  }
+}
+"@
+
+$results = @()
+foreach ($t in $config.tasks) {
+  $title = [string]$t.title
+  if ([string]::IsNullOrWhiteSpace($title)) { Write-Warn 'Skipping task with empty title'; continue }
+  $body  = [string]$t.body
+  $labels = @()
+  if ($t.labels) { $labels = @($t.labels | ForEach-Object { [string]$_ }) }
+  $assignees = @()
+  if ($t.assignees) { $assignees = @($t.assignees | ForEach-Object { [string]$_ }) }
+  $statusName = if ($t.status) { [string]$t.status } else { $defaultStatusName }
+
+  Write-Info "Creating issue: $title"
+  if ($DryRun) {
+    Write-Host "DRY-RUN would create issue in $Repo with labels=[$($labels -join ', ')]" -ForegroundColor DarkGray
+    $results += @{ title=$title; issue_url=$null; item_id=$null }
+    continue
+  }
+
+  $issueReq = @{ title = $title; body = $body }
+  if ($labels.Count -gt 0) { $issueReq.labels = $labels }
+  if ($assignees.Count -gt 0) { $issueReq.assignees = $assignees }
+  $issueResp = Invoke-RestMethod -Method Post -Uri "https://api.github.com/repos/$Repo/issues" -Headers $headersRest -ContentType 'application/json' -Body ($issueReq | ConvertTo-Json -Depth 10)
+  $issueNodeId = $issueResp.node_id
+  $issueUrl    = $issueResp.html_url
+  Write-Ok "Created issue: $issueUrl"
+
+  Write-Info 'Adding issue to project…'
+  $addData = Invoke-GraphQL $addMutation @{ projectId = $projectId; contentId = $issueNodeId }
+  $itemId = $addData.addProjectV2ItemById.item.id
+  Write-Ok "Added to project as item $itemId"
+
+  if ($statusName -and $statusField) {
+    $optId = Get-StatusOptionId $statusName
+    if ($optId) {
+      Write-Info "Setting Status='$statusName'"
+      $null = Invoke-GraphQL $updateStatusMutation @{ projectId=$projectId; itemId=$itemId; fieldId=$statusField.id; optionId=$optId }
+    } else {
+      Write-Warn "Status option not found: $statusName. Skipping field update."
+    }
+  }
+
+  $results += @{ title=$title; issue_url=$issueUrl; item_id=$itemId }
+}
+
+Write-Ok "Seeding complete. Created $($results.Count) task(s)."
+if (-not $DryRun) {
+  $results | ForEach-Object { if ($_.issue_url) { Write-Host " - $_.title -> $_.issue_url" -ForegroundColor Green } }
+}
+
+Write-Host "Usage tips:" -ForegroundColor Cyan
+Write-Host " - Set repo variable PROJECT_URL to your Project v2 URL for auto-add workflow." -ForegroundColor Cyan
+Write-Host " - PROJECTS_TOKEN must have 'repo' and 'project' scopes." -ForegroundColor Cyan

--- a/tasks/seed.json
+++ b/tasks/seed.json
@@ -1,0 +1,34 @@
+{
+  "owner": "RicherTunes",
+  "repo": "RicherTunes/Brainarr",
+  "scope": "user",
+  "projectNumber": 1,
+  "status": "To do",
+  "tasks": [
+    {
+      "title": "CI: Enforce shell: bash on POSIX runners",
+      "body": "Standardize POSIX steps to use shell: bash across Ubuntu/macOS in all workflows to avoid sh/zed edge cases.",
+      "labels": ["ci"]
+    },
+    {
+      "title": "CI: Reduce duplication between build and security-scan jobs",
+      "body": "Refactor shared steps (Docker-based Lidarr extraction, CI project scaffolding) into a reusable composite action or a shared action block.",
+      "labels": ["ci"]
+    },
+    {
+      "title": "CI: Add fast-fail guard for missing Lidarr assemblies",
+      "body": "Before restore/build, verify required assemblies exist under ext/Lidarr-docker/_output/net6.0 and fail with a clear message if missing.",
+      "labels": ["ci"]
+    },
+    {
+      "title": "Build: Fix compile error in Constants.cs on CI",
+      "body": "Reproduce failure on main/main, repair build break around Constants.cs (line reference from CI). Ensure cross-matrix builds pass.",
+      "labels": ["bug", "build"]
+    },
+    {
+      "title": "Repo setup: Add PROJECTS_TOKEN secret and PROJECT_URL variable",
+      "body": "Add repo secret PROJECTS_TOKEN (classic PAT with repo, project). Add repo variable PROJECT_URL set to your Project v2 URL (e.g., https://github.com/users/RicherTunes/projects/1).",
+      "labels": ["setup"]
+    }
+  ]
+}


### PR DESCRIPTION
Adds auto-add-to-project workflow and a PowerShell seeding script.\n\nSetup required:\n- Repo variable PROJECT_URL (e.g. https://github.com/users/RicherTunes/projects/1)\n- Repo secret PROJECTS_TOKEN (classic PAT: repo, project)\n\nUsage:\n- pwsh scripts/seed-project.ps1 -Owner RicherTunes -Scope user -ProjectNumber 1 -Repo RicherTunes/Brainarr -TasksPath tasks/seed.json -DryRun\n- Remove -DryRun to create issues and add to project.