### PR TITLE
providers: explicit HttpResponse typing + HttpException.Response?.StatusCode

### DIFF
--- a/Brainarr.Plugin/Services/Providers/AnthropicProvider.cs
+++ b/Brainarr.Plugin/Services/Providers/AnthropicProvider.cs
@@ -169,7 +169,7 @@ Respond with only the JSON array, no other text.";
                 var seconds = TimeoutContext.GetSecondsOrDefault(BrainarrConstants.DefaultAITimeout);
                 request.RequestTimeout = TimeSpan.FromSeconds(seconds);
 
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "anthropic",
                     logger: _logger,
@@ -274,7 +274,7 @@ Respond with only the JSON array, no other text.";
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
                 using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(TimeoutContext.GetSecondsOrDefault(BrainarrConstants.DefaultAITimeout)));
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "anthropic",
                     logger: _logger,
@@ -295,7 +295,7 @@ Respond with only the JSON array, no other text.";
                 _logger.Error(ex, "Anthropic connection test failed");
                 if (ex is NzbDrone.Common.Http.HttpException httpEx)
                 {
-                    TryCaptureAnthropicHint(httpEx.Response?.Content, (int)httpEx.StatusCode);
+                    TryCaptureAnthropicHint(httpEx.Response?.Content, (int)(httpEx.Response?.StatusCode ?? 0));
                 }
                 return false;
             }
@@ -333,7 +333,7 @@ Respond with only the JSON array, no other text.";
                 request.SetContent(SecureJsonSerializer.Serialize(requestBody));
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "anthropic",
                     logger: _logger,

--- a/Brainarr.Plugin/Services/Providers/BaseCloudProvider.cs
+++ b/Brainarr.Plugin/Services/Providers/BaseCloudProvider.cs
@@ -139,7 +139,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Providers
                 catch { /* never break the request on logging */ }
             }
 
-            return await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+            return await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                 _ => _httpClient.ExecuteAsync(request),
                 origin: ProviderName,
                 logger: _logger,

--- a/Brainarr.Plugin/Services/Providers/DeepSeekProvider.cs
+++ b/Brainarr.Plugin/Services/Providers/DeepSeekProvider.cs
@@ -185,7 +185,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
                 using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(TimeoutContext.GetSecondsOrDefault(BrainarrConstants.DefaultAITimeout)));
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "deepseek",
                     logger: _logger,
@@ -224,7 +224,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 request.SetContent(SecureJsonSerializer.Serialize(requestBody));
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "deepseek",
                     logger: _logger,

--- a/Brainarr.Plugin/Services/Providers/GeminiProvider.cs
+++ b/Brainarr.Plugin/Services/Providers/GeminiProvider.cs
@@ -120,7 +120,7 @@ User request:
                 var seconds = TimeoutContext.GetSecondsOrDefault(BrainarrConstants.DefaultAITimeout);
                 request.RequestTimeout = TimeSpan.FromSeconds(seconds);
 
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "gemini",
                     logger: _logger,
@@ -253,7 +253,7 @@ User request:
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
                 using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(TimeoutContext.GetSecondsOrDefault(BrainarrConstants.DefaultAITimeout)));
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "gemini",
                     logger: _logger,
@@ -307,7 +307,7 @@ User request:
                 request.SetContent(SecureJsonSerializer.Serialize(body));
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "gemini",
                     logger: _logger,

--- a/Brainarr.Plugin/Services/Providers/GroqProvider.cs
+++ b/Brainarr.Plugin/Services/Providers/GroqProvider.cs
@@ -225,7 +225,7 @@ Return ONLY a JSON array, no other text. Example:
 
                 var startTime = DateTime.UtcNow;
                 using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(TimeoutContext.GetSecondsOrDefault(BrainarrConstants.DefaultAITimeout)));
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "groq",
                     logger: _logger,
@@ -266,7 +266,7 @@ Return ONLY a JSON array, no other text. Example:
                 request.SetContent(SecureJsonSerializer.Serialize(testBody));
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "groq",
                     logger: _logger,

--- a/Brainarr.Plugin/Services/Providers/LMStudioProvider.cs
+++ b/Brainarr.Plugin/Services/Providers/LMStudioProvider.cs
@@ -308,7 +308,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Providers
             {
                 var request = new HttpRequestBuilder($"{_baseUrl}/v1/models").Build();
                 using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(TimeoutContext.GetSecondsOrDefault(BrainarrConstants.DefaultAITimeout)));
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "lmstudio",
                     logger: _logger,
@@ -329,7 +329,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Providers
             try
             {
                 var request = new HttpRequestBuilder($"{_baseUrl}/v1/models").Build();
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "lmstudio",
                     logger: _logger,

--- a/Brainarr.Plugin/Services/Providers/OllamaProvider.cs
+++ b/Brainarr.Plugin/Services/Providers/OllamaProvider.cs
@@ -115,7 +115,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Providers
                 if (avoidCount > 0) { try { _logger.Info("[Brainarr Debug] Applied system avoid list (Ollama): " + avoidCount + " names"); } catch { } }
                 request.RequestTimeout = TimeSpan.FromSeconds(TimeoutContext.GetSecondsOrDefault(BrainarrConstants.MaxAITimeout));
 
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "ollama",
                     logger: _logger,
@@ -199,7 +199,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Providers
             {
                 var request = new HttpRequestBuilder($"{_baseUrl}/api/tags").Build();
                 using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(TimeoutContext.GetSecondsOrDefault(BrainarrConstants.DefaultAITimeout)));
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "ollama",
                     logger: _logger,
@@ -220,7 +220,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Providers
             try
             {
                 var request = new HttpRequestBuilder($"{_baseUrl}/api/tags").Build();
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "ollama",
                     logger: _logger,

--- a/Brainarr.Plugin/Services/Providers/OpenAIProvider.cs
+++ b/Brainarr.Plugin/Services/Providers/OpenAIProvider.cs
@@ -401,7 +401,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
 
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
                 using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(TimeoutContext.GetSecondsOrDefault(BrainarrConstants.DefaultAITimeout)));
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "openai",
                     logger: _logger,
@@ -422,7 +422,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 _logger.Error(ex, "OpenAI connection test failed");
                 if (ex is NzbDrone.Common.Http.HttpException httpEx)
                 {
-                    TryCaptureOpenAIHint(httpEx.Response?.Content, (int)httpEx.StatusCode);
+                    TryCaptureOpenAIHint(httpEx.Response?.Content, (int)(httpEx.Response?.StatusCode ?? 0));
                 }
                 return false;
             }
@@ -448,7 +448,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 request.SetContent(SecureJsonSerializer.Serialize(body));
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "openai",
                     logger: _logger,

--- a/Brainarr.Plugin/Services/Providers/OpenRouterProvider.cs
+++ b/Brainarr.Plugin/Services/Providers/OpenRouterProvider.cs
@@ -245,7 +245,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
                 using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(TimeoutContext.GetSecondsOrDefault(BrainarrConstants.DefaultAITimeout)));
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "openrouter",
                     logger: _logger,
@@ -266,7 +266,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 _logger.Error(ex, "OpenRouter connection test failed");
                 if (ex is NzbDrone.Common.Http.HttpException httpEx)
                 {
-                    TryCaptureOpenRouterHint(httpEx.Response?.Content, (int)httpEx.StatusCode);
+                    TryCaptureOpenRouterHint(httpEx.Response?.Content, (int)(httpEx.Response?.StatusCode ?? 0));
                 }
                 return false;
             }
@@ -297,7 +297,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 request.SetContent(SecureJsonSerializer.Serialize(requestBody));
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "openrouter",
                     logger: _logger,

--- a/Brainarr.Plugin/Services/Providers/PerplexityProvider.cs
+++ b/Brainarr.Plugin/Services/Providers/PerplexityProvider.cs
@@ -336,7 +336,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
 
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
                 using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout));
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "perplexity",
                     logger: _logger,
@@ -375,7 +375,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 request.SetContent(JsonConvert.SerializeObject(requestBody));
                 request.RequestTimeout = TimeSpan.FromSeconds(BrainarrConstants.TestConnectionTimeout);
 
-                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync(
+                var response = await NzbDrone.Core.ImportLists.Brainarr.Resilience.ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse>(
                     _ => _httpClient.ExecuteAsync(request),
                     origin: "perplexity",
                     logger: _logger,


### PR DESCRIPTION
Compile/analysis hardening only:
- Explicitly type ResiliencePolicy.WithResilienceAsync<NzbDrone.Common.Http.HttpResponse> in provider calls
- Use httpEx.Response?.StatusCode instead of httpEx.StatusCode to match pinned Lidarr HttpException API

No behavior changes. CI policy unchanged (Docker-based plugins assemblies; shell: bash).