### PR TITLE
ci: exclude experimental cache file from whitespace hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,10 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        exclude: |
+          (?x)^(
+            Brainarr\.Plugin/Services/Caching/EnhancedRecommendationCache\.cs
+          )$
       - id: mixed-line-ending
         args: ['--fix=lf']
       # Temporarily disabled during development
@@ -105,7 +109,7 @@ repos:
     hooks:
       - id: dotnet-format-whitespace
         name: dotnet format whitespace (auto-fix)
-        entry: bash -lc 'DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_NOLOGO=1 dotnet format whitespace'
+        entry: bash -lc 'DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_NOLOGO=1 dotnet format whitespace --exclude Brainarr.Plugin/Services/Caching/EnhancedRecommendationCache.cs'
         language: system
         pass_filenames: false
         files: \.cs$


### PR DESCRIPTION
Exclude EnhancedRecommendationCache.cs from whitespace auto-fixers (file is behind #if BRAINARR_EXPERIMENTAL_CACHE). This keeps main green while we iterate on the experimental cache implementation.