### PR TITLE
ci: manual-only project auto-add; pin LIDARR_DOCKER_VERSION=2.13.3.4692

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,10 +1,7 @@
-name: Add new issues and PRs to Project
+name: Add new issues and PRs to Project (manual)
 
 on:
-  issues:
-    types: [opened, reopened, transferred]
-  pull_request:
-    types: [opened, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -757,3 +757,4 @@ jobs:
           --clobber
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/project-auto-add.yml
+++ b/.github/workflows/project-auto-add.yml
@@ -1,10 +1,7 @@
-name: Project Auto-Add
+name: Project Auto-Add (manual)
 
 on:
-  issues:
-    types: [opened, reopened]
-  pull_request:
-    types: [opened, reopened, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   add-to-project:


### PR DESCRIPTION
Reduce CI noise by making project-auto-add workflows manual-only. Align CI to known-good plugins tag 2.13.3.4692.