### PR TITLE
Ensure registry workflow sets Lidarr path

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -1,0 +1,59 @@
+name: Registry Validation
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Brainarr.Plugin/**'
+      - 'Brainarr.Tests/**'
+      - 'plugin.json'
+      - 'manifest.json'
+      - '.github/workflows/registry.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Brainarr.Plugin/**'
+      - 'Brainarr.Tests/**'
+      - 'plugin.json'
+      - 'manifest.json'
+      - '.github/workflows/registry.yml'
+  workflow_dispatch:
+  workflow_call:
+
+env:
+  CI: true
+
+jobs:
+  registry-validation:
+    name: Registry Validation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      LIDARR_OUTPUT: ${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 6
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Extract Lidarr assemblies (plugins Docker)
+        env:
+          LIDARR_DOCKER_VERSION: pr-plugins-2.14.1.4716
+          LIDARR_DOCKER_DIGEST: sha256:83b3095113b70a7d013819ed2f6d56d047f28e1f67aa11b7820e280560446b62
+        run: |
+          set -euo pipefail
+          bash scripts/extract-lidarr-assemblies.sh --mode minimal --output-dir "${LIDARR_OUTPUT}"
+
+      - name: Restore plugin
+        run: dotnet restore Brainarr.Plugin/Brainarr.Plugin.csproj
+
+      - name: Build plugin (Release)
+        run: dotnet build Brainarr.Plugin/Brainarr.Plugin.csproj --configuration Release --no-restore -p:LidarrPath="${LIDARR_OUTPUT}"
+
+      - name: Run targeted tests
+        run: dotnet test Brainarr.Tests/Brainarr.Tests.csproj --configuration Release --no-build -p:LidarrPath="${LIDARR_OUTPUT}"


### PR DESCRIPTION
## Summary
- add the Registry Validation workflow with a CI flag so MSBuild uses the LidarrPath fallback
- download Lidarr assemblies from the plugins Docker image before building
- pass the resolved Lidarr output directory to dotnet restore/build/test

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cb2441eb688331b074fa0efdb33b86