### PR TITLE
Add embedded model registry fallback and tests

### DIFF
--- a/Brainarr.Plugin/Brainarr.Plugin.csproj
+++ b/Brainarr.Plugin/Brainarr.Plugin.csproj
@@ -51,6 +51,21 @@
   <ItemGroup>
     <EmbeddedResource Include="Configuration\Defaults\RecommendationJsonSchema.json" />
     <EmbeddedResource Include="Resources\music_styles.json" />
+    <EmbeddedResource Include="docs\models.example.json">
+      <LogicalName>Brainarr.docs.models.example.json</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="docs\models.schema.json">
+      <LogicalName>Brainarr.docs.models.schema.json</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="docs\models.example.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="docs\models.schema.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <!-- Analyzers (NetAnalyzers enabled via SDK); optional extra analyzers can be added later -->

--- a/Brainarr.Plugin/Models/ModelRegistryDocument.cs
+++ b/Brainarr.Plugin/Models/ModelRegistryDocument.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Models
+{
+    /// <summary>
+    /// Represents the structured model registry document bundled with the plugin.
+    /// </summary>
+    public sealed class ModelRegistryDocument
+    {
+        [JsonPropertyName("$schema")]
+        public string? Schema { get; set; }
+
+        [JsonPropertyName("version")]
+        public string? Version { get; set; }
+
+        [JsonPropertyName("generatedAt")]
+        public DateTimeOffset? GeneratedAt { get; set; }
+
+        [JsonPropertyName("providers")]
+        public Dictionary<string, ModelRegistryProvider> Providers { get; set; }
+            = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Describes the models made available by a single provider.
+    /// </summary>
+    public sealed class ModelRegistryProvider
+    {
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+
+        [JsonPropertyName("models")]
+        public List<ModelRegistryEntry> Models { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Defines metadata for an individual model entry in the registry.
+    /// </summary>
+    public sealed class ModelRegistryEntry
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("aliases")]
+        public List<string>? Aliases { get; set; }
+
+        [JsonPropertyName("capabilities")]
+        public Dictionary<string, JsonElement>? Capabilities { get; set; }
+
+        [JsonPropertyName("metadata")]
+        public Dictionary<string, string>? Metadata { get; set; }
+    }
+}

--- a/Brainarr.Plugin/Services/ModelRegistryLoader.cs
+++ b/Brainarr.Plugin/Services/ModelRegistryLoader.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using NLog;
+using NzbDrone.Core.ImportLists.Brainarr.Models;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Services
+{
+    /// <summary>
+    /// Loads the bundled model registry document, supporting both on-disk copies and embedded fallbacks.
+    /// </summary>
+    public class ModelRegistryLoader
+    {
+        private const string RegistryFileName = "models.example.json";
+        private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        };
+
+        private readonly string _baseDirectory;
+        private readonly Assembly _resourceAssembly;
+        private readonly Logger _logger;
+
+        public ModelRegistryLoader(string? baseDirectory = null, Assembly? resourceAssembly = null, Logger? logger = null)
+        {
+            _baseDirectory = baseDirectory ?? AppContext.BaseDirectory;
+            _resourceAssembly = resourceAssembly ?? typeof(ModelRegistryLoader).Assembly;
+            _logger = logger ?? LogManager.GetCurrentClassLogger();
+        }
+
+        /// <summary>
+        /// Loads the model registry document from disk or the embedded fallback resource.
+        /// </summary>
+        public ModelRegistryDocument Load()
+        {
+            var json = LoadRawJson();
+            try
+            {
+                var document = JsonSerializer.Deserialize<ModelRegistryDocument>(json, SerializerOptions);
+                if (document == null)
+                {
+                    throw new InvalidOperationException("Model registry deserialization returned null.");
+                }
+
+                return document;
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException("Failed to parse model registry document.", ex);
+            }
+        }
+
+        /// <summary>
+        /// Returns the raw JSON contents of the model registry.
+        /// </summary>
+        public string LoadRawJson()
+        {
+            var diskPath = ResolveDiskPath();
+            if (diskPath != null && File.Exists(diskPath))
+            {
+                _logger.Debug($"Loading model registry from disk: {diskPath}");
+                return File.ReadAllText(diskPath, Encoding.UTF8);
+            }
+
+            _logger.Debug("Model registry file not found on disk, using embedded fallback.");
+            using var stream = OpenEmbeddedResource() ?? throw new InvalidOperationException("Embedded model registry not found.");
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
+        }
+
+        private string? ResolveDiskPath()
+        {
+            foreach (var candidate in EnumerateCandidatePaths())
+            {
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        private IEnumerable<string> EnumerateCandidatePaths()
+        {
+            var unique = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            void Add(string path)
+            {
+                if (!string.IsNullOrWhiteSpace(path))
+                {
+                    unique.Add(Path.GetFullPath(path));
+                }
+            }
+
+            foreach (var root in GetSearchRoots())
+            {
+                Add(Path.Combine(root, RegistryFileName));
+                Add(Path.Combine(root, "docs", RegistryFileName));
+            }
+
+            foreach (var path in unique)
+            {
+                yield return path;
+            }
+        }
+
+        private IEnumerable<string> GetSearchRoots()
+        {
+            var roots = new List<string>();
+            if (!string.IsNullOrWhiteSpace(_baseDirectory))
+            {
+                roots.Add(_baseDirectory);
+            }
+
+            var assemblyDirectory = Path.GetDirectoryName(_resourceAssembly.Location);
+            if (!string.IsNullOrWhiteSpace(assemblyDirectory))
+            {
+                roots.Add(assemblyDirectory);
+            }
+
+            // Walk up the directory tree to cover publish outputs and development roots.
+            foreach (var root in roots.ToList())
+            {
+                var dir = new DirectoryInfo(root);
+                while (dir != null)
+                {
+                    if (!roots.Contains(dir.FullName))
+                    {
+                        roots.Add(dir.FullName);
+                    }
+
+                    dir = dir.Parent;
+                }
+            }
+
+            return roots.Distinct(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private Stream? OpenEmbeddedResource()
+        {
+            var resourceName = _resourceAssembly
+                .GetManifestResourceNames()
+                .FirstOrDefault(name => name.EndsWith("docs.models.example.json", StringComparison.OrdinalIgnoreCase));
+
+            return resourceName != null
+                ? _resourceAssembly.GetManifestResourceStream(resourceName)
+                : null;
+        }
+    }
+}

--- a/Brainarr.Tests/Services/ModelRegistryLoaderTests.cs
+++ b/Brainarr.Tests/Services/ModelRegistryLoaderTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using NzbDrone.Core.ImportLists.Brainarr.Services;
+using Xunit;
+
+namespace Brainarr.Tests.Services
+{
+    [Trait("Category", "Unit")]
+    public class ModelRegistryLoaderTests : IDisposable
+    {
+        private readonly string _publishRoot;
+
+        public ModelRegistryLoaderTests()
+        {
+            _publishRoot = Path.Combine(Path.GetTempPath(), "brainarr-publish-test", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_publishRoot);
+        }
+
+        [Fact]
+        public void Load_Should_Fall_Back_To_Embedded_Resource_When_Publish_Folder_Lacks_Registry()
+        {
+            // Arrange - mimic publish output without the docs folder
+            CopyPluginAssembly(_publishRoot);
+            var loader = new ModelRegistryLoader(_publishRoot);
+
+            // Act
+            var registry = loader.Load();
+
+            // Assert
+            registry.Should().NotBeNull();
+            registry.Providers.Should().ContainKey("ollama");
+            registry.Providers["ollama"].Models.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void Load_Should_Use_On_Disk_File_When_Available()
+        {
+            // Arrange
+            var docsDir = Path.Combine(_publishRoot, "docs");
+            Directory.CreateDirectory(docsDir);
+            var registryPath = Path.Combine(docsDir, "models.example.json");
+            File.WriteAllText(registryPath, "{ \"providers\": { \"test\": { \"displayName\": \"Test\", \"models\": [{ \"id\": \"m1\", \"label\": \"Model 1\" }] } } }");
+            var loader = new ModelRegistryLoader(_publishRoot);
+
+            // Act
+            var registry = loader.Load();
+
+            // Assert
+            registry.Providers.Should().ContainKey("test");
+            registry.Providers["test"].Models.Should().ContainSingle(m => m.Id == "m1");
+        }
+
+        private static void CopyPluginAssembly(string destination)
+        {
+            var assemblyPath = typeof(ModelRegistryLoader).Assembly.Location;
+            var targetPath = Path.Combine(destination, Path.GetFileName(assemblyPath));
+            File.Copy(assemblyPath, targetPath, overwrite: true);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_publishRoot))
+            {
+                try
+                {
+                    Directory.Delete(_publishRoot, recursive: true);
+                }
+                catch
+                {
+                    // Ignore cleanup failures in tests
+                }
+            }
+        }
+    }
+}

--- a/docs/models.example.json
+++ b/docs/models.example.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "./models.schema.json",
+  "version": "2025.01",
+  "generatedAt": "2025-01-01T00:00:00Z",
+  "providers": {
+    "ollama": {
+      "displayName": "Ollama",
+      "models": [
+        {
+          "id": "qwen2.5:latest",
+          "label": "Qwen 2.5 Latest",
+          "aliases": [
+            "qwen2.5",
+            "qwen"
+          ],
+          "capabilities": {
+            "contextTokens": 32000,
+            "modality": "text"
+          },
+          "metadata": {
+            "tier": "default",
+            "quality": "balanced"
+          }
+        },
+        {
+          "id": "llama3.2:latest",
+          "label": "Llama 3.2 Latest",
+          "aliases": [
+            "llama3",
+            "llama"
+          ],
+          "capabilities": {
+            "contextTokens": 24000,
+            "modality": "text"
+          },
+          "metadata": {
+            "tier": "default",
+            "quality": "premium"
+          }
+        }
+      ]
+    },
+    "lmstudio": {
+      "displayName": "LM Studio",
+      "models": [
+        {
+          "id": "local-model",
+          "label": "Auto-detected",
+          "aliases": [
+            "default"
+          ],
+          "capabilities": {
+            "contextTokens": 8000,
+            "modality": "text"
+          },
+          "metadata": {
+            "tier": "default",
+            "quality": "balanced"
+          }
+        },
+        {
+          "id": "TheBloke/Mistral-7B-Instruct-v0.2-GGUF",
+          "label": "Mistral 7B Instruct",
+          "aliases": [
+            "mistral-7b"
+          ],
+          "capabilities": {
+            "contextTokens": 8000,
+            "modality": "text"
+          },
+          "metadata": {
+            "tier": "balanced",
+            "quality": "premium"
+          }
+        }
+      ]
+    },
+    "openai": {
+      "displayName": "OpenAI",
+      "models": [
+        {
+          "id": "gpt-4o-mini",
+          "label": "GPT-4o Mini",
+          "aliases": [
+            "gpt4o-mini",
+            "gpt-4o"
+          ],
+          "capabilities": {
+            "contextTokens": 128000,
+            "modality": "multimodal"
+          },
+          "metadata": {
+            "tier": "default",
+            "quality": "balanced"
+          }
+        },
+        {
+          "id": "gpt-4.1",
+          "label": "GPT-4.1",
+          "aliases": [
+            "gpt4.1",
+            "gpt-4.1"
+          ],
+          "capabilities": {
+            "contextTokens": 128000,
+            "modality": "multimodal"
+          },
+          "metadata": {
+            "tier": "premium",
+            "quality": "premium"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/models.schema.json
+++ b/docs/models.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Brainarr Model Registry",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "providers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "aliases": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "capabilities": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "number",
+                      "integer",
+                      "boolean"
+                    ]
+                  }
+                },
+                "metadata": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "label"
+              ],
+              "additionalProperties": true
+            }
+          }
+        },
+        "required": [
+          "displayName",
+          "models"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "providers"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- embed the example model registry and schema in the plugin build and copy them to publish outputs
- add strongly typed model registry representations and a loader that falls back to the embedded resource when the file is absent
- cover the loader with tests that mimic a publish layout and verify both disk and fallback loading paths

## Testing
- `dotnet test` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb244356b08331839aeca176198fce