### PR TITLE
Add packaged model registry fallback

### DIFF
--- a/Brainarr.Plugin/Brainarr.Plugin.csproj
+++ b/Brainarr.Plugin/Brainarr.Plugin.csproj
@@ -53,6 +53,20 @@
     <EmbeddedResource Include="Resources\music_styles.json" />
   </ItemGroup>
 
+  <!-- Ship example model registry + schema for offline defaults -->
+  <ItemGroup>
+    <Content Include="..\docs\models.example.json">
+      <Link>docs\models.example.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include="..\docs\models.schema.json">
+      <Link>docs\models.schema.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
   <!-- Analyzers (NetAnalyzers enabled via SDK); optional extra analyzers can be added later -->
 
   <!-- Lidarr assemblies reference -->

--- a/Brainarr.Plugin/Configuration/ModelRegistryLoader.cs
+++ b/Brainarr.Plugin/Configuration/ModelRegistryLoader.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using NLog;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Configuration
+{
+    /// <summary>
+    /// Loads the static model registry definition used to provide sensible defaults
+    /// when Brainarr cannot reach provider discovery endpoints.
+    /// </summary>
+    public sealed class ModelRegistryLoader
+    {
+        private static readonly string[] _relativeCandidates =
+        {
+            Path.Combine("docs", "models.example.json"),
+            "models.example.json"
+        };
+
+        private static readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        };
+
+        private readonly Logger _logger;
+
+        public ModelRegistryLoader(Logger? logger = null)
+        {
+            _logger = logger ?? LogManager.GetCurrentClassLogger();
+        }
+
+        /// <summary>
+        /// Loads the model registry from an explicit path.
+        /// </summary>
+        public Task<ModelRegistryDocument> LoadAsync(string? path, CancellationToken cancellationToken = default)
+        {
+            return LoadAsync(path, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Loads the model registry from an explicit path or from known fallback locations.
+        /// </summary>
+        /// <param name="path">Absolute or relative path to the registry JSON. When null the loader searches known directories.</param>
+        /// <param name="searchRoots">Optional directories that should be searched before defaults (publish layouts, etc.).</param>
+        public async Task<ModelRegistryDocument> LoadAsync(
+            string? path,
+            IEnumerable<string>? searchRoots,
+            CancellationToken cancellationToken = default)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                return await LoadFromFileAsync(path!, cancellationToken).ConfigureAwait(false);
+            }
+
+            foreach (var candidate in ResolveCandidatePaths(searchRoots))
+            {
+                if (File.Exists(candidate))
+                {
+                    _logger.Debug($"ModelRegistryLoader: loading registry from '{candidate}'.");
+                    return await LoadFromFileAsync(candidate, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            var resourceName = FindEmbeddedResourceName();
+            if (resourceName != null)
+            {
+                var assembly = typeof(ModelRegistryLoader).Assembly;
+                await using var stream = assembly.GetManifestResourceStream(resourceName);
+                if (stream != null)
+                {
+                    _logger.Debug($"ModelRegistryLoader: loading embedded registry '{resourceName}'.");
+                    return await DeserializeAsync(stream, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            throw new FileNotFoundException("Model registry not found. Provide a custom path or ensure docs/models.example.json ships with the plugin.");
+        }
+
+        private IEnumerable<string> ResolveCandidatePaths(IEnumerable<string>? searchRoots)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (searchRoots != null)
+            {
+                foreach (var root in searchRoots)
+                {
+                    if (TryNormalizeDirectory(root, out var normalized) && seen.Add(normalized))
+                    {
+                        foreach (var relative in _relativeCandidates)
+                        {
+                            yield return Path.Combine(normalized, relative);
+                        }
+                    }
+                }
+            }
+
+            if (TryNormalizeDirectory(AppContext.BaseDirectory, out var baseDir) && seen.Add(baseDir))
+            {
+                foreach (var relative in _relativeCandidates)
+                {
+                    yield return Path.Combine(baseDir, relative);
+                }
+            }
+
+            var assemblyLocation = typeof(ModelRegistryLoader).Assembly.Location;
+            var assemblyDir = Path.GetDirectoryName(assemblyLocation);
+            if (TryNormalizeDirectory(assemblyDir, out var asmDir) && seen.Add(asmDir))
+            {
+                foreach (var relative in _relativeCandidates)
+                {
+                    yield return Path.Combine(asmDir, relative);
+                }
+            }
+        }
+
+        private static bool TryNormalizeDirectory(string? path, out string normalized)
+        {
+            normalized = string.Empty;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return false;
+            }
+
+            try
+            {
+                normalized = Path.GetFullPath(path);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static async Task<ModelRegistryDocument> LoadFromFileAsync(string fullPath, CancellationToken cancellationToken)
+        {
+            var resolved = Path.GetFullPath(fullPath);
+            await using var stream = File.Open(resolved, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return await DeserializeAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task<ModelRegistryDocument> DeserializeAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            var document = await JsonSerializer.DeserializeAsync<ModelRegistryDocument>(stream, _serializerOptions, cancellationToken).ConfigureAwait(false);
+            if (document == null)
+            {
+                throw new InvalidDataException("Model registry JSON was empty.");
+            }
+
+            document.Normalize();
+            return document;
+        }
+
+        private static string? FindEmbeddedResourceName()
+        {
+            var assembly = typeof(ModelRegistryLoader).Assembly;
+            const string suffix = ".docs.models.example.json";
+            return assembly
+                .GetManifestResourceNames()
+                .FirstOrDefault(n => n.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    public sealed class ModelRegistryDocument
+    {
+        [JsonPropertyName("$schema")]
+        public string? Schema { get; set; }
+
+        [JsonPropertyName("generatedAt")]
+        public DateTimeOffset? GeneratedAt { get; set; }
+
+        [JsonPropertyName("providers")]
+        public Dictionary<string, ProviderModelRegistry>? Providers { get; set; }
+
+        public void Normalize()
+        {
+            Providers = Providers == null
+                ? new Dictionary<string, ProviderModelRegistry>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, ProviderModelRegistry>(Providers, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var provider in Providers.Values)
+            {
+                provider?.Normalize();
+            }
+        }
+
+        public ProviderModelRegistry? TryGetProvider(string providerId)
+        {
+            if (Providers == null) return null;
+            if (string.IsNullOrWhiteSpace(providerId)) return null;
+            Providers.TryGetValue(providerId, out var provider);
+            return provider;
+        }
+    }
+
+    public sealed class ProviderModelRegistry
+    {
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("defaultModel")]
+        public string? DefaultModel { get; set; }
+
+        [JsonPropertyName("models")]
+        public Dictionary<string, ModelRegistryEntry>? Models { get; set; }
+
+        internal void Normalize()
+        {
+            Models = Models == null
+                ? new Dictionary<string, ModelRegistryEntry>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, ModelRegistryEntry>(Models, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var entry in Models.Values)
+            {
+                entry?.Normalize();
+            }
+        }
+    }
+
+    public sealed class ModelRegistryEntry
+    {
+        [JsonPropertyName("rawId")]
+        public string? RawId { get; set; }
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("aliases")]
+        public List<string>? Aliases { get; set; }
+
+        [JsonPropertyName("capabilities")]
+        public ModelCapabilities? Capabilities { get; set; }
+
+        [JsonPropertyName("pricing")]
+        public ModelPricing? Pricing { get; set; }
+
+        internal void Normalize()
+        {
+            Aliases = Aliases == null
+                ? new List<string>()
+                : Aliases
+                    .Where(a => !string.IsNullOrWhiteSpace(a))
+                    .Select(a => a.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+        }
+    }
+
+    public sealed class ModelCapabilities
+    {
+        [JsonPropertyName("contextWindow")]
+        public int? ContextWindow { get; set; }
+
+        [JsonPropertyName("supportsVision")]
+        public bool? SupportsVision { get; set; }
+
+        [JsonPropertyName("supportsThinking")]
+        public bool? SupportsThinking { get; set; }
+
+        [JsonPropertyName("supportsStreaming")]
+        public bool? SupportsStreaming { get; set; }
+    }
+
+    public sealed class ModelPricing
+    {
+        [JsonPropertyName("inputPer1K")]
+        public decimal? InputPer1K { get; set; }
+
+        [JsonPropertyName("outputPer1K")]
+        public decimal? OutputPer1K { get; set; }
+    }
+}

--- a/Brainarr.Tests/Services/Core/ModelRegistryLoaderTests.cs
+++ b/Brainarr.Tests/Services/Core/ModelRegistryLoaderTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Brainarr.Tests.Helpers;
+using FluentAssertions;
+using NLog;
+using NzbDrone.Core.ImportLists.Brainarr.Configuration;
+using Xunit;
+
+namespace Brainarr.Tests.Services.Core
+{
+    [Trait("Category", "Unit")]
+    public class ModelRegistryLoaderTests
+    {
+        private static readonly Logger Logger = TestLogger.CreateNullLogger();
+        private static readonly string RepoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+        [Fact]
+        public async Task LoadAsync_WithExplicitPath_LoadsRegistry()
+        {
+            var loader = new ModelRegistryLoader(Logger);
+            var samplePath = Path.Combine(RepoRoot, "docs", "models.example.json");
+
+            var document = await loader.LoadAsync(samplePath);
+
+            document.Should().NotBeNull();
+            document.Providers.Should().NotBeNull();
+            document.Providers!.Should().ContainKey("openai");
+            document.Providers!["openai"].Models.Should().ContainKey("GPT41_Mini");
+        }
+
+        [Fact]
+        public async Task LoadAsync_WithoutExplicitPath_FallsBackToPublishLayout()
+        {
+            var loader = new ModelRegistryLoader(Logger);
+            var samplePath = Path.Combine(RepoRoot, "docs", "models.example.json");
+            var publishRoot = CreateTemporaryPublishLayout(samplePath);
+
+            try
+            {
+                var document = await loader.LoadAsync(null, new[] { publishRoot });
+
+                document.Providers.Should().NotBeNull();
+                document.Providers!.Should().ContainKey("anthropic");
+                document.Providers!["anthropic"].DefaultModel.Should().Be("ClaudeSonnet4");
+            }
+            finally
+            {
+                TryDeleteDirectory(publishRoot);
+            }
+        }
+
+        private static string CreateTemporaryPublishLayout(string source)
+        {
+            var tempRoot = Path.Combine(Path.GetTempPath(), "brainarr-model-registry-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempRoot);
+
+            var docsDir = Path.Combine(tempRoot, "docs");
+            Directory.CreateDirectory(docsDir);
+
+            File.Copy(source, Path.Combine(docsDir, "models.example.json"), overwrite: true);
+
+            var schemaSource = Path.Combine(Path.GetDirectoryName(source) ?? RepoRoot, "models.schema.json");
+            if (File.Exists(schemaSource))
+            {
+                File.Copy(schemaSource, Path.Combine(docsDir, "models.schema.json"), overwrite: true);
+            }
+
+            return tempRoot;
+        }
+
+        private static void TryDeleteDirectory(string path)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+    }
+}

--- a/docs/models.example.json
+++ b/docs/models.example.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "./models.schema.json",
+  "generatedAt": "2025-01-07T00:00:00Z",
+  "providers": {
+    "openai": {
+      "displayName": "OpenAI",
+      "description": "Production GPT family exposed through the OpenAI provider.",
+      "defaultModel": "GPT41_Mini",
+      "models": {
+        "GPT41_Mini": {
+          "rawId": "gpt-4.1-mini",
+          "label": "GPT-4.1 Mini",
+          "description": "Balanced GPT-4.1 tier optimised for day-to-day recommendation runs.",
+          "aliases": [
+            "gpt-4o-mini",
+            "o4-mini"
+          ],
+          "capabilities": {
+            "contextWindow": 128000,
+            "supportsVision": true,
+            "supportsThinking": false,
+            "supportsStreaming": true
+          },
+          "pricing": {
+            "inputPer1K": 0.005,
+            "outputPer1K": 0.015
+          }
+        },
+        "GPT41": {
+          "rawId": "gpt-4.1",
+          "label": "GPT-4.1",
+          "description": "Flagship GPT-4.1 quality for premium curation sessions.",
+          "aliases": [
+            "gpt-4o"
+          ],
+          "capabilities": {
+            "contextWindow": 128000,
+            "supportsVision": true,
+            "supportsThinking": false,
+            "supportsStreaming": true
+          },
+          "pricing": {
+            "inputPer1K": 0.01,
+            "outputPer1K": 0.03
+          }
+        }
+      }
+    },
+    "anthropic": {
+      "displayName": "Anthropic Claude",
+      "description": "Claude 3.x family exposed via Anthropic and OpenRouter gateways.",
+      "defaultModel": "ClaudeSonnet4",
+      "models": {
+        "ClaudeSonnet4": {
+          "rawId": "claude-sonnet-4-20250514",
+          "label": "Claude Sonnet 4",
+          "description": "Latest balanced Claude Sonnet with thinking mode support.",
+          "aliases": [
+            "claude-3.5-sonnet",
+            "claude-sonnet-4"
+          ],
+          "capabilities": {
+            "contextWindow": 200000,
+            "supportsVision": true,
+            "supportsThinking": true,
+            "supportsStreaming": true
+          },
+          "pricing": {
+            "inputPer1K": 0.003,
+            "outputPer1K": 0.015
+          }
+        },
+        "Claude35_Haiku": {
+          "rawId": "claude-3-5-haiku-20241022",
+          "label": "Claude 3.5 Haiku",
+          "description": "Fast Claude tier well suited for preview/testing flows.",
+          "aliases": [
+            "claude-haiku"
+          ],
+          "capabilities": {
+            "contextWindow": 200000,
+            "supportsVision": true,
+            "supportsThinking": false,
+            "supportsStreaming": true
+          },
+          "pricing": {
+            "inputPer1K": 0.00025,
+            "outputPer1K": 0.00125
+          }
+        }
+      }
+    },
+    "ollama": {
+      "displayName": "Ollama",
+      "description": "Local models served by Ollama with auto-detection support.",
+      "defaultModel": "qwen2.5:latest",
+      "models": {
+        "qwen2.5:latest": {
+          "rawId": "qwen2.5:latest",
+          "label": "Qwen 2.5 (Latest)",
+          "description": "Default local model tuned for Brainarr prompts.",
+          "aliases": [
+            "qwen2.5"
+          ],
+          "capabilities": {
+            "contextWindow": 32000,
+            "supportsVision": false,
+            "supportsThinking": false,
+            "supportsStreaming": true
+          },
+          "pricing": {
+            "inputPer1K": 0.0,
+            "outputPer1K": 0.0
+          }
+        },
+        "llama3.1:8b": {
+          "rawId": "llama3.1:8b",
+          "label": "Llama 3.1 8B",
+          "description": "Efficient local model for rapid prototyping.",
+          "aliases": [
+            "llama3",
+            "llama3:instruct"
+          ],
+          "capabilities": {
+            "contextWindow": 8000,
+            "supportsVision": false,
+            "supportsThinking": false,
+            "supportsStreaming": true
+          },
+          "pricing": {
+            "inputPer1K": 0.0,
+            "outputPer1K": 0.0
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/models.schema.json
+++ b/docs/models.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Brainarr Model Registry",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "providers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "displayName": { "type": "string" },
+          "description": { "type": "string" },
+          "defaultModel": { "type": "string" },
+          "models": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "rawId": { "type": "string" },
+                "label": { "type": "string" },
+                "description": { "type": "string" },
+                "aliases": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "capabilities": {
+                  "type": "object",
+                  "properties": {
+                    "contextWindow": { "type": "integer" },
+                    "supportsVision": { "type": "boolean" },
+                    "supportsThinking": { "type": "boolean" },
+                    "supportsStreaming": { "type": "boolean" }
+                  },
+                  "additionalProperties": false
+                },
+                "pricing": {
+                  "type": "object",
+                  "properties": {
+                    "inputPer1K": { "type": "number" },
+                    "outputPer1K": { "type": "number" }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "required": ["rawId", "label"],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": ["defaultModel", "models"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["providers"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- copy the example model registry and schema into the plugin output so publish artifacts include the fallback data
- add a ModelRegistryLoader that can resolve the registry from explicit paths, packaged content, or embedded resources
- add a unit test that loads from the repo sample and from a simulated publish layout to prove the fallback path works

## Testing
- `dotnet test --filter ModelRegistryLoaderTests` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb27a5b2b08331ac54990fdd434f66