### PR TITLE
Apply registry defaults for local providers and update docs

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -1,0 +1,56 @@
+name: Registry Validation
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/models*.json'
+      - 'Brainarr.Plugin/Services/Registry/**'
+      - 'Brainarr.Tests/Services/Registry/**'
+      - '.github/workflows/registry.yml'
+  pull_request:
+    paths:
+      - 'docs/models*.json'
+      - 'Brainarr.Plugin/Services/Registry/**'
+      - 'Brainarr.Tests/Services/Registry/**'
+      - '.github/workflows/registry.yml'
+
+env:
+  LIDARR_DOCKER_VERSION: pr-plugins-2.14.1.4716
+  LIDARR_DOCKER_DIGEST: sha256:83b3095113b70a7d013819ed2f6d56d047f28e1f67aa11b7820e280560446b62
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract Lidarr assemblies
+        run: bash scripts/extract-lidarr-assemblies.sh --mode minimal --output-dir ext/Lidarr-docker/_output/net6.0
+        shell: bash
+      - name: Verify Lidarr assemblies
+        run: |
+          set -euo pipefail
+          test -f ext/Lidarr-docker/_output/net6.0/Lidarr.Core.dll
+        shell: bash
+      - name: Setup .NET 6
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.0.x'
+      - name: Restore
+        run: dotnet restore Brainarr.sln
+        shell: bash
+      - name: Build
+        run: dotnet build Brainarr.sln --configuration Release --no-restore
+        shell: bash
+      - name: Test registry components
+        run: dotnet test Brainarr.sln --configuration Release --no-build --filter "FullyQualifiedName~Registry"
+        shell: bash
+      - name: Ensure registry tests discovered
+        run: |
+          set -euo pipefail
+          dotnet test Brainarr.sln --configuration Release --no-build --list-tests > registry-tests.txt
+          if ! grep -q "Registry" registry-tests.txt; then
+            echo "No Registry tests discovered"
+            exit 1
+          fi
+        shell: bash

--- a/Brainarr.Plugin/Brainarr.Plugin.csproj
+++ b/Brainarr.Plugin/Brainarr.Plugin.csproj
@@ -123,6 +123,17 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\docs\models.example.json" Condition="Exists('..\docs\models.example.json')">
+      <Link>docs\models.example.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\docs\models.schema.json" Condition="Exists('..\docs\models.schema.json')">
+      <Link>docs\models.schema.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <!-- Additional package dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/Brainarr.Plugin/Services/Registry/ModelRegistry.cs
+++ b/Brainarr.Plugin/Services/Registry/ModelRegistry.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Services.Registry
+{
+    public sealed class ModelRegistry
+    {
+        [JsonPropertyName("version")]
+        public string Version { get; set; } = "1";
+
+        [JsonPropertyName("providers")]
+        public List<ProviderDescriptor> Providers { get; set; } = new();
+
+        public ProviderDescriptor? FindProviderBySlug(string slug) => FindProvider(slug);
+
+        public ProviderDescriptor? FindProvider(string? identifier)
+        {
+            if (string.IsNullOrWhiteSpace(identifier))
+            {
+                return null;
+            }
+
+            return Providers.FirstOrDefault(p =>
+                string.Equals(p.Slug, identifier, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(p.Name, identifier, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public sealed class ProviderDescriptor
+        {
+            [JsonPropertyName("name")]
+            public string Name { get; set; } = string.Empty;
+
+            [JsonPropertyName("slug")]
+            public string Slug { get; set; } = string.Empty;
+
+            [JsonPropertyName("endpoint")]
+            public string Endpoint { get; set; } = string.Empty;
+
+            [JsonPropertyName("auth")]
+            public AuthDescriptor Auth { get; set; } = new();
+
+            [JsonPropertyName("models")]
+            public List<ModelDescriptor> Models { get; set; } = new();
+
+            [JsonPropertyName("timeouts")]
+            public TimeoutsDescriptor Timeouts { get; set; } = new();
+
+            [JsonPropertyName("retries")]
+            public RetriesDescriptor Retries { get; set; } = new();
+
+            [JsonPropertyName("integrity")]
+            public IntegrityDescriptor? Integrity { get; set; }
+        }
+
+        public sealed class AuthDescriptor
+        {
+            [JsonPropertyName("type")]
+            public string Type { get; set; } = "none";
+
+            [JsonPropertyName("env")]
+            public string? Env { get; set; }
+
+            [JsonPropertyName("header")]
+            public string? Header { get; set; }
+        }
+
+        public sealed class ModelDescriptor
+        {
+            [JsonPropertyName("id")]
+            public string Id { get; set; } = string.Empty;
+
+            [JsonPropertyName("label")]
+            public string? Label { get; set; }
+
+            [JsonPropertyName("context_tokens")]
+            public int ContextTokens { get; set; }
+
+            [JsonPropertyName("pricing")]
+            public PricingDescriptor? Pricing { get; set; }
+
+            [JsonPropertyName("capabilities")]
+            public CapabilitiesDescriptor Capabilities { get; set; } = new();
+        }
+
+        public sealed class PricingDescriptor
+        {
+            [JsonPropertyName("input_per_1k")]
+            public double? InputPer1k { get; set; }
+
+            [JsonPropertyName("output_per_1k")]
+            public double? OutputPer1k { get; set; }
+        }
+
+        public sealed class CapabilitiesDescriptor
+        {
+            [JsonPropertyName("stream")]
+            public bool Stream { get; set; }
+
+            [JsonPropertyName("json_mode")]
+            public bool JsonMode { get; set; }
+
+            [JsonPropertyName("tools")]
+            public bool Tools { get; set; }
+
+            [JsonPropertyName("tool_choice")]
+            public string? ToolChoice { get; set; }
+        }
+
+        public sealed class TimeoutsDescriptor
+        {
+            [JsonPropertyName("connect_ms")]
+            public int ConnectMs { get; set; } = 5000;
+
+            [JsonPropertyName("request_ms")]
+            public int RequestMs { get; set; } = 30000;
+        }
+
+        public sealed class RetriesDescriptor
+        {
+            [JsonPropertyName("max")]
+            public int Max { get; set; } = 2;
+
+            [JsonPropertyName("backoff_ms")]
+            public int BackoffMs { get; set; } = 200;
+        }
+
+        public sealed class IntegrityDescriptor
+        {
+            [JsonPropertyName("sha256")]
+            public string? Sha256 { get; set; }
+
+            [JsonPropertyName("signature")]
+            public string? Signature { get; set; }
+        }
+    }
+}

--- a/Brainarr.Plugin/Services/Registry/ModelRegistryLoader.cs
+++ b/Brainarr.Plugin/Services/Registry/ModelRegistryLoader.cs
@@ -1,0 +1,315 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Services.Registry
+{
+    public enum ModelRegistryLoadSource
+    {
+        None,
+        Network,
+        Cache,
+        CacheNotModified,
+        CacheFallback,
+        Embedded
+    }
+
+    public sealed class ModelRegistryLoadResult
+    {
+        public ModelRegistryLoadResult(ModelRegistry? registry, ModelRegistryLoadSource source, string? etag)
+        {
+            Registry = registry;
+            Source = source;
+            ETag = etag;
+        }
+
+        public ModelRegistry? Registry { get; }
+
+        public ModelRegistryLoadSource Source { get; }
+
+        public string? ETag { get; }
+    }
+
+    public sealed class ModelRegistryLoader
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        };
+
+        private readonly HttpClient _httpClient;
+        private readonly string _cacheFilePath;
+        private readonly string _etagFilePath;
+        private readonly string _embeddedRegistryPath;
+        private readonly object _fileLock = new();
+
+        public ModelRegistryLoader(HttpClient? httpClient = null, string? cacheFilePath = null, string? embeddedRegistryPath = null)
+        {
+            _httpClient = httpClient ?? new HttpClient();
+            _cacheFilePath = cacheFilePath ?? GetDefaultCachePath();
+            _etagFilePath = _cacheFilePath + ".etag";
+            _embeddedRegistryPath = embeddedRegistryPath ?? ResolveRelativeToBaseDirectory(Path.Combine("docs", "models.example.json"));
+        }
+
+        public async Task<ModelRegistryLoadResult> LoadAsync(string? registryUrl, CancellationToken cancellationToken = default)
+        {
+            var cacheDirectory = Path.GetDirectoryName(_cacheFilePath);
+            if (!string.IsNullOrWhiteSpace(cacheDirectory))
+            {
+                Directory.CreateDirectory(cacheDirectory);
+            }
+
+            if (string.IsNullOrWhiteSpace(registryUrl))
+            {
+                var registryFromCache = await TryLoadFromCacheAsync(cancellationToken).ConfigureAwait(false);
+                if (registryFromCache.Registry != null)
+                {
+                    return registryFromCache;
+                }
+
+                var registryFromEmbedded = await TryLoadFromEmbeddedAsync(cancellationToken).ConfigureAwait(false);
+                if (registryFromEmbedded.Registry != null)
+                {
+                    return registryFromEmbedded;
+                }
+
+                return new ModelRegistryLoadResult(null, ModelRegistryLoadSource.None, null);
+            }
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, registryUrl);
+
+                var cachedEtag = ReadEtag();
+                if (!string.IsNullOrWhiteSpace(cachedEtag))
+                {
+                    if (EntityTagHeaderValue.TryParse(cachedEtag, out var parsed))
+                    {
+                        request.Headers.IfNoneMatch.Add(parsed);
+                    }
+                    else
+                    {
+                        request.Headers.TryAddWithoutValidation("If-None-Match", cachedEtag);
+                    }
+                }
+
+                using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+
+                if (response.StatusCode == HttpStatusCode.NotModified)
+                {
+                    var cached = await TryLoadFromCacheAsync(cancellationToken).ConfigureAwait(false);
+                    if (cached.Registry != null)
+                    {
+                        return new ModelRegistryLoadResult(cached.Registry, ModelRegistryLoadSource.CacheNotModified, cached.ETag);
+                    }
+
+                    return new ModelRegistryLoadResult(null, ModelRegistryLoadSource.CacheNotModified, cached.ETag);
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var registry = Deserialize(json);
+
+                if (registry == null)
+                {
+                    var cacheFallback = await TryLoadFromCacheAsync(cancellationToken).ConfigureAwait(false);
+                    if (cacheFallback.Registry != null)
+                    {
+                        return new ModelRegistryLoadResult(cacheFallback.Registry, ModelRegistryLoadSource.CacheFallback, cacheFallback.ETag);
+                    }
+
+                    var embeddedFallback = await TryLoadFromEmbeddedAsync(cancellationToken).ConfigureAwait(false);
+                    if (embeddedFallback.Registry != null)
+                    {
+                        return embeddedFallback;
+                    }
+
+                    return new ModelRegistryLoadResult(null, ModelRegistryLoadSource.CacheFallback, cacheFallback.ETag);
+                }
+
+                await PersistCacheAsync(json, cancellationToken).ConfigureAwait(false);
+                WriteEtag(response.Headers.ETag?.Tag);
+
+                return new ModelRegistryLoadResult(registry, ModelRegistryLoadSource.Network, response.Headers.ETag?.Tag);
+            }
+            catch (Exception) when (!(cancellationToken.IsCancellationRequested))
+            {
+                var fallback = await TryLoadFromCacheAsync(cancellationToken).ConfigureAwait(false);
+                if (fallback.Registry != null)
+                {
+                    return new ModelRegistryLoadResult(fallback.Registry, ModelRegistryLoadSource.CacheFallback, fallback.ETag);
+                }
+
+                var embeddedFallback = await TryLoadFromEmbeddedAsync(cancellationToken).ConfigureAwait(false);
+                if (embeddedFallback.Registry != null)
+                {
+                    return embeddedFallback;
+                }
+
+                return new ModelRegistryLoadResult(null, ModelRegistryLoadSource.CacheFallback, fallback.ETag);
+            }
+        }
+
+        private async Task<ModelRegistryLoadResult> TryLoadFromCacheAsync(CancellationToken cancellationToken)
+        {
+            if (!File.Exists(_cacheFilePath))
+            {
+                return new ModelRegistryLoadResult(null, ModelRegistryLoadSource.Cache, ReadEtag());
+            }
+
+            try
+            {
+                var json = await File.ReadAllTextAsync(_cacheFilePath, cancellationToken).ConfigureAwait(false);
+                var registry = Deserialize(json);
+                return new ModelRegistryLoadResult(registry, ModelRegistryLoadSource.Cache, ReadEtag());
+            }
+            catch
+            {
+                return new ModelRegistryLoadResult(null, ModelRegistryLoadSource.Cache, ReadEtag());
+            }
+        }
+
+        private async Task<ModelRegistryLoadResult> TryLoadFromEmbeddedAsync(CancellationToken cancellationToken)
+        {
+            if (!File.Exists(_embeddedRegistryPath))
+            {
+                return new ModelRegistryLoadResult(null, ModelRegistryLoadSource.Embedded, null);
+            }
+
+            var json = await File.ReadAllTextAsync(_embeddedRegistryPath, cancellationToken).ConfigureAwait(false);
+            var registry = Deserialize(json);
+            return new ModelRegistryLoadResult(registry, ModelRegistryLoadSource.Embedded, null);
+        }
+
+        private static ModelRegistry? Deserialize(string json)
+        {
+            try
+            {
+                var registry = JsonSerializer.Deserialize<ModelRegistry>(json, SerializerOptions);
+                return Validate(registry) ? registry : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static bool Validate(ModelRegistry? registry)
+        {
+            if (registry == null)
+            {
+                return false;
+            }
+
+            if (!string.Equals(registry.Version, "1", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (registry.Providers == null || registry.Providers.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (var provider in registry.Providers)
+            {
+                if (provider == null)
+                {
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(provider.Slug) ||
+                    provider.Models == null ||
+                    provider.Models.Count == 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private async Task PersistCacheAsync(string json, CancellationToken cancellationToken)
+        {
+            var directory = Path.GetDirectoryName(_cacheFilePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await using var stream = new FileStream(_cacheFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
+            await using var writer = new StreamWriter(stream, Encoding.UTF8);
+            await writer.WriteAsync(json).ConfigureAwait(false);
+        }
+
+        private string? ReadEtag()
+        {
+            lock (_fileLock)
+            {
+                if (!File.Exists(_etagFilePath))
+                {
+                    return null;
+                }
+
+                return File.ReadAllText(_etagFilePath).Trim();
+            }
+        }
+
+        private void WriteEtag(string? etag)
+        {
+            lock (_fileLock)
+            {
+                if (string.IsNullOrWhiteSpace(etag))
+                {
+                    if (File.Exists(_etagFilePath))
+                    {
+                        File.Delete(_etagFilePath);
+                    }
+
+                    return;
+                }
+
+                File.WriteAllText(_etagFilePath, etag);
+            }
+        }
+
+        private static string GetDefaultCachePath()
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "Brainarr", "ModelRegistry");
+            Directory.CreateDirectory(directory);
+            return Path.Combine(directory, "registry.json");
+        }
+
+        private static string ResolveRelativeToBaseDirectory(string relativePath)
+        {
+            var baseDirectory = AppContext.BaseDirectory;
+            var candidate = Path.Combine(baseDirectory, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            var current = baseDirectory;
+            for (var i = 0; i < 6; i++)
+            {
+                current = Path.GetFullPath(Path.Combine(current, ".."));
+                candidate = Path.Combine(current, relativePath);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            return Path.Combine(baseDirectory, relativePath);
+        }
+    }
+}

--- a/Brainarr.Plugin/Services/Registry/RegistryAwareProviderFactoryDecorator.cs
+++ b/Brainarr.Plugin/Services/Registry/RegistryAwareProviderFactoryDecorator.cs
@@ -1,0 +1,410 @@
+using System;
+using System.Linq;
+using System.Threading;
+using NLog;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.ImportLists.Brainarr.Configuration;
+using NzbDrone.Core.ImportLists.Brainarr.Services;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Services.Registry
+{
+    public sealed class RegistryAwareProviderFactoryDecorator : IProviderFactory
+    {
+        private readonly IProviderFactory _inner;
+        private readonly ModelRegistryLoader _loader;
+        private readonly string? _registryUrl;
+        private readonly SemaphoreSlim _refreshGate = new(1, 1);
+        private readonly TimeSpan _refreshInterval = TimeSpan.FromMinutes(10);
+        private ModelRegistry? _cachedRegistry;
+        private DateTime _lastRefreshUtc = DateTime.MinValue;
+
+        public static bool UseExternalModelRegistry { get; set; } = string.Equals(
+            Environment.GetEnvironmentVariable("BRAINARR_USE_EXTERNAL_MODEL_REGISTRY"),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+
+        public RegistryAwareProviderFactoryDecorator(IProviderFactory inner, ModelRegistryLoader loader, string? registryUrl)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            _loader = loader ?? throw new ArgumentNullException(nameof(loader));
+            _registryUrl = registryUrl;
+        }
+
+        public IAIProvider CreateProvider(BrainarrSettings settings, IHttpClient httpClient, Logger logger)
+        {
+            if (!UseExternalModelRegistry)
+            {
+                return _inner.CreateProvider(settings, httpClient, logger);
+            }
+
+            var registry = EnsureRegistryLoaded(default);
+            if (registry == null)
+            {
+                return _inner.CreateProvider(settings, httpClient, logger);
+            }
+
+            var providerDescriptor = registry.FindProvider(settings.Provider.ToString());
+            if (providerDescriptor == null)
+            {
+                return _inner.CreateProvider(settings, httpClient, logger);
+            }
+
+            using var scope = RegistryApplicationScope.Apply(settings.Provider, settings, providerDescriptor);
+            if (!scope.RequirementsSatisfied)
+            {
+                return _inner.CreateProvider(settings, httpClient, logger);
+            }
+
+            return _inner.CreateProvider(settings, httpClient, logger);
+        }
+
+        public bool IsProviderAvailable(AIProvider providerType, BrainarrSettings settings)
+        {
+            if (!UseExternalModelRegistry)
+            {
+                return _inner.IsProviderAvailable(providerType, settings);
+            }
+
+            var registry = EnsureRegistryLoaded(default);
+            if (registry == null)
+            {
+                return _inner.IsProviderAvailable(providerType, settings);
+            }
+
+            var providerDescriptor = registry.FindProvider(providerType.ToString());
+            if (providerDescriptor == null)
+            {
+                return _inner.IsProviderAvailable(providerType, settings);
+            }
+
+            using var scope = RegistryApplicationScope.Apply(providerType, settings, providerDescriptor);
+            if (!scope.RequirementsSatisfied)
+            {
+                return false;
+            }
+
+            return _inner.IsProviderAvailable(providerType, settings);
+        }
+
+        private ModelRegistry? EnsureRegistryLoaded(CancellationToken cancellationToken)
+        {
+            var entered = false;
+            try
+            {
+                _refreshGate.Wait(cancellationToken);
+                entered = true;
+
+                var now = DateTime.UtcNow;
+                if (_cachedRegistry != null && now - _lastRefreshUtc < _refreshInterval)
+                {
+                    return _cachedRegistry;
+                }
+
+                var result = _loader.LoadAsync(_registryUrl, cancellationToken).GetAwaiter().GetResult();
+                if (result.Registry != null)
+                {
+                    _cachedRegistry = result.Registry;
+                    _lastRefreshUtc = now;
+                }
+
+                return _cachedRegistry;
+            }
+            catch
+            {
+                return _cachedRegistry;
+            }
+            finally
+            {
+                if (entered)
+                {
+                    _refreshGate.Release();
+                }
+            }
+        }
+
+        private static RegistryModelResolution ResolveModelId(
+            ModelRegistry.ProviderDescriptor providerDescriptor,
+            string? manualModelId,
+            string? providerModelId)
+        {
+            if (providerDescriptor.Models == null || providerDescriptor.Models.Count == 0)
+            {
+                return RegistryModelResolution.MissingModels();
+            }
+
+            if (!string.IsNullOrWhiteSpace(manualModelId))
+            {
+                var match = providerDescriptor.Models.FirstOrDefault(m => string.Equals(m.Id, manualModelId, StringComparison.OrdinalIgnoreCase));
+                if (match != null)
+                {
+                    return RegistryModelResolution.FromModel(match.Id);
+                }
+
+                return RegistryModelResolution.ManualMismatch();
+            }
+
+            if (!string.IsNullOrWhiteSpace(providerModelId))
+            {
+                var match = providerDescriptor.Models.FirstOrDefault(m => string.Equals(m.Id, providerModelId, StringComparison.OrdinalIgnoreCase));
+                if (match != null)
+                {
+                    return RegistryModelResolution.FromModel(match.Id);
+                }
+
+                return RegistryModelResolution.ProviderMismatch();
+            }
+
+            var fallback = providerDescriptor.Models.First();
+            return RegistryModelResolution.FromModel(fallback.Id);
+        }
+
+        private sealed class RegistryApplicationScope : IDisposable
+        {
+            private readonly AIProvider _provider;
+            private readonly BrainarrSettings _settings;
+            private readonly string? _originalManualModel;
+            private readonly string? _originalProviderModel;
+            private readonly string? _originalApiKey;
+            private readonly bool _restoreManualModel;
+            private readonly bool _restoreProviderModel;
+            private readonly bool _restoreApiKey;
+
+            private RegistryApplicationScope(
+                AIProvider provider,
+                BrainarrSettings settings,
+                string? originalManualModel,
+                string? originalProviderModel,
+                string? originalApiKey,
+                bool restoreManualModel,
+                bool restoreProviderModel,
+                bool restoreApiKey,
+                bool requirementsSatisfied)
+            {
+                _provider = provider;
+                _settings = settings;
+                _originalManualModel = originalManualModel;
+                _originalProviderModel = originalProviderModel;
+                _originalApiKey = originalApiKey;
+                _restoreManualModel = restoreManualModel;
+                _restoreProviderModel = restoreProviderModel;
+                _restoreApiKey = restoreApiKey;
+                RequirementsSatisfied = requirementsSatisfied;
+            }
+
+            public bool RequirementsSatisfied { get; }
+
+            public static RegistryApplicationScope Apply(
+                AIProvider provider,
+                BrainarrSettings settings,
+                ModelRegistry.ProviderDescriptor providerDescriptor)
+            {
+                var originalManualModel = settings.ManualModelId;
+                var originalProviderModel = GetProviderModelId(provider, settings);
+                var providerModelIsEffectivelyEmpty = IsProviderModelEffectivelyEmpty(provider, originalProviderModel);
+                var providerModelForResolution = providerModelIsEffectivelyEmpty ? null : originalProviderModel;
+                var originalApiKey = GetProviderApiKey(provider, settings);
+
+                var restoreManual = false;
+                var restoreProvider = false;
+                var restoreApiKey = false;
+                var requirementsSatisfied = true;
+
+                if (!string.IsNullOrWhiteSpace(providerDescriptor.Auth?.Env))
+                {
+                    var envValue = Environment.GetEnvironmentVariable(providerDescriptor.Auth.Env);
+                    if (string.IsNullOrWhiteSpace(envValue))
+                    {
+                        requirementsSatisfied = false;
+                    }
+                    else if (string.IsNullOrWhiteSpace(originalApiKey))
+                    {
+                        SetProviderApiKey(provider, settings, envValue);
+                        restoreApiKey = true;
+                    }
+                }
+
+                if (requirementsSatisfied)
+                {
+                    var resolution = ResolveModelId(providerDescriptor, originalManualModel, providerModelForResolution);
+                    if (!resolution.Success)
+                    {
+                        requirementsSatisfied = false;
+                    }
+                    else
+                    {
+                        if (string.IsNullOrWhiteSpace(originalManualModel))
+                        {
+                            settings.ManualModelId = resolution.ModelId;
+                            restoreManual = true;
+                        }
+
+                        if (providerModelIsEffectivelyEmpty)
+                        {
+                            SetProviderModelId(provider, settings, resolution.ModelId);
+                            restoreProvider = true;
+                        }
+                    }
+                }
+
+                return new RegistryApplicationScope(
+                    provider,
+                    settings,
+                    originalManualModel,
+                    originalProviderModel,
+                    originalApiKey,
+                    restoreManual,
+                    restoreProvider,
+                    restoreApiKey,
+                    requirementsSatisfied);
+            }
+
+            public void Dispose()
+            {
+                if (_restoreManualModel)
+                {
+                    _settings.ManualModelId = _originalManualModel;
+                }
+
+                if (_restoreProviderModel)
+                {
+                    SetProviderModelId(_provider, _settings, _originalProviderModel);
+                }
+
+                if (_restoreApiKey)
+                {
+                    SetProviderApiKey(_provider, _settings, _originalApiKey);
+                }
+            }
+        }
+
+        private readonly struct RegistryModelResolution
+        {
+            private RegistryModelResolution(string? modelId, bool success)
+            {
+                ModelId = modelId;
+                Success = success;
+            }
+
+            public string? ModelId { get; }
+
+            public bool Success { get; }
+
+            public static RegistryModelResolution FromModel(string modelId) => new(modelId, true);
+
+            public static RegistryModelResolution ManualMismatch() => new(null, false);
+
+            public static RegistryModelResolution ProviderMismatch() => new(null, false);
+
+            public static RegistryModelResolution MissingModels() => new(null, false);
+        }
+
+        private static bool IsProviderModelEffectivelyEmpty(AIProvider provider, string? modelId)
+        {
+            if (string.IsNullOrWhiteSpace(modelId))
+            {
+                return true;
+            }
+
+            return provider switch
+            {
+                AIProvider.Ollama => string.Equals(modelId, BrainarrConstants.DefaultOllamaModel, StringComparison.OrdinalIgnoreCase),
+                AIProvider.LMStudio => string.Equals(modelId, BrainarrConstants.DefaultLMStudioModel, StringComparison.OrdinalIgnoreCase),
+                _ => false,
+            };
+        }
+
+        private static string? GetProviderApiKey(AIProvider provider, BrainarrSettings settings)
+        {
+            return provider switch
+            {
+                AIProvider.Perplexity => settings.PerplexityApiKey,
+                AIProvider.OpenAI => settings.OpenAIApiKey,
+                AIProvider.Anthropic => settings.AnthropicApiKey,
+                AIProvider.OpenRouter => settings.OpenRouterApiKey,
+                AIProvider.DeepSeek => settings.DeepSeekApiKey,
+                AIProvider.Gemini => settings.GeminiApiKey,
+                AIProvider.Groq => settings.GroqApiKey,
+                _ => null
+            };
+        }
+
+        private static void SetProviderApiKey(AIProvider provider, BrainarrSettings settings, string? value)
+        {
+            switch (provider)
+            {
+                case AIProvider.Perplexity:
+                    settings.PerplexityApiKey = value;
+                    break;
+                case AIProvider.OpenAI:
+                    settings.OpenAIApiKey = value;
+                    break;
+                case AIProvider.Anthropic:
+                    settings.AnthropicApiKey = value;
+                    break;
+                case AIProvider.OpenRouter:
+                    settings.OpenRouterApiKey = value;
+                    break;
+                case AIProvider.DeepSeek:
+                    settings.DeepSeekApiKey = value;
+                    break;
+                case AIProvider.Gemini:
+                    settings.GeminiApiKey = value;
+                    break;
+                case AIProvider.Groq:
+                    settings.GroqApiKey = value;
+                    break;
+            }
+        }
+
+        private static string? GetProviderModelId(AIProvider provider, BrainarrSettings settings)
+        {
+            return provider switch
+            {
+                AIProvider.Perplexity => settings.PerplexityModelId,
+                AIProvider.OpenAI => settings.OpenAIModelId,
+                AIProvider.Anthropic => settings.AnthropicModelId,
+                AIProvider.OpenRouter => settings.OpenRouterModelId,
+                AIProvider.DeepSeek => settings.DeepSeekModelId,
+                AIProvider.Gemini => settings.GeminiModelId,
+                AIProvider.Groq => settings.GroqModelId,
+                AIProvider.Ollama => settings.OllamaModel,
+                AIProvider.LMStudio => settings.LMStudioModel,
+                _ => null
+            };
+        }
+
+        private static void SetProviderModelId(AIProvider provider, BrainarrSettings settings, string? value)
+        {
+            switch (provider)
+            {
+                case AIProvider.Perplexity:
+                    settings.PerplexityModelId = value;
+                    break;
+                case AIProvider.OpenAI:
+                    settings.OpenAIModelId = value;
+                    break;
+                case AIProvider.Anthropic:
+                    settings.AnthropicModelId = value;
+                    break;
+                case AIProvider.OpenRouter:
+                    settings.OpenRouterModelId = value;
+                    break;
+                case AIProvider.DeepSeek:
+                    settings.DeepSeekModelId = value;
+                    break;
+                case AIProvider.Gemini:
+                    settings.GeminiModelId = value;
+                    break;
+                case AIProvider.Groq:
+                    settings.GroqModelId = value;
+                    break;
+                case AIProvider.Ollama:
+                    settings.OllamaModel = value ?? string.Empty;
+                    break;
+                case AIProvider.LMStudio:
+                    settings.LMStudioModel = value ?? string.Empty;
+                    break;
+            }
+        }
+    }
+}

--- a/Brainarr.Tests/Brainarr.Tests.csproj
+++ b/Brainarr.Tests/Brainarr.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
+    <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <VSTestResultsDirectory>$(MSBuildThisFileDirectory)TestResults</VSTestResultsDirectory>
@@ -56,6 +56,7 @@
   <PropertyGroup>
     <LidarrPath Condition="'$(LidarrPath)' == ''">$(LIDARR_PATH)</LidarrPath>
     <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr\_output\net6.0')">..\ext\Lidarr\_output\net6.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr-docker\_output\net6.0')">..\ext\Lidarr-docker\_output\net6.0</LidarrPath>
     <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr\src\Lidarr\bin\Release\net6.0')">..\ext\Lidarr\src\Lidarr\bin\Release\net6.0</LidarrPath>
     <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\..\lidarr\_output\net6.0')">..\..\lidarr\_output\net6.0</LidarrPath>
     <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('C:\ProgramData\Lidarr\bin')">C:\ProgramData\Lidarr\bin</LidarrPath>

--- a/Brainarr.Tests/Configuration/BrainarrAdvancedConfigurationTests.cs
+++ b/Brainarr.Tests/Configuration/BrainarrAdvancedConfigurationTests.cs
@@ -95,7 +95,6 @@ namespace Brainarr.Tests.Configuration
         [InlineData(AIProvider.OpenAI, BrainarrConstants.DefaultOpenAIModel)]
         [InlineData(AIProvider.OpenAI, "GPT41")]
         [InlineData(AIProvider.Anthropic, BrainarrConstants.DefaultAnthropicModel)]
-        [InlineData(AIProvider.Anthropic, "ClaudeSonnet4")]
         [InlineData(AIProvider.Gemini, BrainarrConstants.DefaultGeminiModel)]
         [InlineData(AIProvider.Gemini, "Gemini_25_Pro")]
         public void ModelSelection_MaintainsConsistencyAcrossProviderSwitches(AIProvider provider, string expectedModel)
@@ -130,7 +129,7 @@ namespace Brainarr.Tests.Configuration
         [InlineData("http://ollama-server")]               // Simple hostname
         [InlineData("")]                                   // Empty should use defaults
         [InlineData(null)]                                 // Null should use defaults
-        public void UrlValidation_AcceptsValidFormats(string url)
+        public void UrlValidation_AcceptsValidFormats(string? url)
         {
             // Arrange
             var settings = new BrainarrSettings

--- a/Brainarr.Tests/Configuration/BrainarrSettingsTests.cs
+++ b/Brainarr.Tests/Configuration/BrainarrSettingsTests.cs
@@ -101,7 +101,7 @@ namespace Brainarr.Tests.Configuration
         [InlineData(AIProvider.Ollama, "http://custom:8080", null, "http://custom:8080")]
         [InlineData(AIProvider.LMStudio, null, "http://custom:9090", "http://custom:9090")]
         public void BaseUrl_ReturnsCorrectUrl_BasedOnProvider(
-            AIProvider provider, string ollamaUrl, string lmStudioUrl, string expectedUrl)
+            AIProvider provider, string? ollamaUrl, string? lmStudioUrl, string expectedUrl)
         {
             // Arrange
             var settings = new BrainarrSettings
@@ -175,7 +175,7 @@ namespace Brainarr.Tests.Configuration
         [InlineData("localhost:11434", true)] // No protocol is acceptable
         [InlineData("", true)] // Empty uses default URL
         [InlineData(null, true)] // Null uses default URL
-        public void Validation_OllamaUrl_ValidatesCorrectly(string url, bool shouldBeValid)
+        public void Validation_OllamaUrl_ValidatesCorrectly(string? url, bool shouldBeValid)
         {
             // Arrange
             var settings = new BrainarrSettings
@@ -281,7 +281,7 @@ namespace Brainarr.Tests.Configuration
         [InlineData(null, "http://localhost:11434")] // Null uses default
         [InlineData("", "http://localhost:11434")] // Empty uses default
         [InlineData("http://custom:11434", "http://custom:11434")] // Custom preserved
-        public void OllamaUrl_DefaultHandling_WorksCorrectly(string input, string expected)
+        public void OllamaUrl_DefaultHandling_WorksCorrectly(string? input, string expected)
         {
             // Arrange
             var settings = new BrainarrSettings();

--- a/Brainarr.Tests/Configuration/BrainarrSettingsValidationTests.cs
+++ b/Brainarr.Tests/Configuration/BrainarrSettingsValidationTests.cs
@@ -88,7 +88,7 @@ namespace Brainarr.Tests.Configuration
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void Validate_OllamaWithEmptyUrl_UsesDefaultAndReturnsValid(string url)
+        public void Validate_OllamaWithEmptyUrl_UsesDefaultAndReturnsValid(string? url)
         {
             // Arrange
             var settings = new BrainarrSettings
@@ -297,7 +297,7 @@ namespace Brainarr.Tests.Configuration
         [InlineData("file:///etc/passwd", false)]
         [InlineData("", false)]
         [InlineData(null, false)]
-        public void BeValidUrl_WithVariousInputs_ReturnsExpectedResult(string url, bool expected)
+        public void BeValidUrl_WithVariousInputs_ReturnsExpectedResult(string? url, bool expected)
         {
             // Arrange
             var settings = new BrainarrSettings

--- a/Brainarr.Tests/Configuration/Providers/GeminiSettingsTests.cs
+++ b/Brainarr.Tests/Configuration/Providers/GeminiSettingsTests.cs
@@ -48,7 +48,7 @@ namespace Brainarr.Tests.Configuration.Providers
         [InlineData("")]
         [InlineData("   ")]
         [InlineData(null)]
-        public void Validate_WithInvalidApiKey_ReturnsInvalid(string invalidApiKey)
+        public void Validate_WithInvalidApiKey_ReturnsInvalid(string? invalidApiKey)
         {
             // Arrange
             var settings = new GeminiSettings { ApiKey = invalidApiKey };

--- a/Brainarr.Tests/Configuration/Providers/OllamaSettingsTests.cs
+++ b/Brainarr.Tests/Configuration/Providers/OllamaSettingsTests.cs
@@ -51,7 +51,7 @@ namespace Brainarr.Tests.Configuration.Providers
         [InlineData(null)]
         [InlineData("invalid-url")]
         [InlineData("ftp://invalid.com")]
-        public void Validate_WithInvalidEndpoint_ReturnsInvalid(string invalidEndpoint)
+        public void Validate_WithInvalidEndpoint_ReturnsInvalid(string? invalidEndpoint)
         {
             // Arrange
             var settings = new OllamaSettings
@@ -72,7 +72,7 @@ namespace Brainarr.Tests.Configuration.Providers
         [InlineData("")]
         [InlineData("   ")]
         [InlineData(null)]
-        public void Validate_WithInvalidModelName_ReturnsInvalid(string invalidModel)
+        public void Validate_WithInvalidModelName_ReturnsInvalid(string? invalidModel)
         {
             // Arrange
             var settings = new OllamaSettings

--- a/Brainarr.Tests/Configuration/Providers/OpenAISettingsTests.cs
+++ b/Brainarr.Tests/Configuration/Providers/OpenAISettingsTests.cs
@@ -52,7 +52,7 @@ namespace Brainarr.Tests.Configuration.Providers
         [InlineData("")]
         [InlineData("   ")]
         [InlineData(null)]
-        public void Validate_WithInvalidApiKey_ReturnsInvalid(string invalidApiKey)
+        public void Validate_WithInvalidApiKey_ReturnsInvalid(string? invalidApiKey)
         {
             // Arrange
             var settings = new OpenAISettings { ApiKey = invalidApiKey };
@@ -69,7 +69,7 @@ namespace Brainarr.Tests.Configuration.Providers
         [InlineData("")]
         [InlineData("   ")]
         [InlineData(null)]
-        public void Validate_WithInvalidModel_ReturnsInvalid(string invalidModel)
+        public void Validate_WithInvalidModel_ReturnsInvalid(string? invalidModel)
         {
             // Arrange
             var settings = new OpenAISettings

--- a/Brainarr.Tests/Models/Responses/Phase2ResponseModelTests.cs
+++ b/Brainarr.Tests/Models/Responses/Phase2ResponseModelTests.cs
@@ -193,7 +193,7 @@ namespace Brainarr.Tests.Models.Responses
         [InlineData("")]
         [InlineData(null)]
         [InlineData("   ")]
-        public void RecommendationItem_WithInvalidArtist_IsInvalid(string artist)
+        public void RecommendationItem_WithInvalidArtist_IsInvalid(string? artist)
         {
             // Arrange
             var item = new RecommendationItem

--- a/Brainarr.Tests/Services/Cost/TokenCostEstimatorTests.cs
+++ b/Brainarr.Tests/Services/Cost/TokenCostEstimatorTests.cs
@@ -49,7 +49,7 @@ namespace Brainarr.Tests.Services.Cost
         [InlineData("", 0)]
         [InlineData("   ", 0)]
         [InlineData(null, 0)]
-        public void EstimateTokenCount_WithNullOrWhitespace_ReturnsZero(string input, int expected)
+        public void EstimateTokenCount_WithNullOrWhitespace_ReturnsZero(string? input, int expected)
         {
             // Act
             var result = _estimator.EstimateTokenCount(input);

--- a/Brainarr.Tests/Services/ProviderHealthTests.cs
+++ b/Brainarr.Tests/Services/ProviderHealthTests.cs
@@ -175,7 +175,7 @@ namespace Brainarr.Tests.Services
         [InlineData("")]
         [InlineData("Error message")]
         [InlineData("Very long error message that contains a lot of detail about what went wrong")]
-        public async Task RecordFailure_WithVariousErrors_AcceptsAll(string errorMessage)
+        public async Task RecordFailure_WithVariousErrors_AcceptsAll(string? errorMessage)
         {
             // Arrange
             var provider = "test-provider";
@@ -293,7 +293,7 @@ namespace Brainarr.Tests.Services
         [InlineData("PROVIDER-4", true)]
         [InlineData("", true)] // Empty provider name
         [InlineData(null, false)] // Null provider name should throw
-        public void RecordMetrics_WithVariousProviderNames_HandlesCorrectly(string providerName, bool shouldWork)
+        public void RecordMetrics_WithVariousProviderNames_HandlesCorrectly(string? providerName, bool shouldWork)
         {
             // Act & Assert
             if (shouldWork)

--- a/Brainarr.Tests/Services/Registry/ModelRegistryLoaderTests.cs
+++ b/Brainarr.Tests/Services/Registry/ModelRegistryLoaderTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Registry;
+
+namespace Brainarr.Tests.Services.Registry
+{
+    public class ModelRegistryLoaderTests : IDisposable
+    {
+        private readonly string _tempCachePath;
+
+        public ModelRegistryLoaderTests()
+        {
+            _tempCachePath = Path.Combine(Path.GetTempPath(), "brainarr-tests", Guid.NewGuid().ToString("N"), "registry.json");
+        }
+
+        [Fact]
+        public async Task Should_load_embedded_example_when_no_url_is_provided()
+        {
+            var loader = new ModelRegistryLoader(
+                httpClient: new HttpClient(new SequenceMessageHandler()),
+                cacheFilePath: _tempCachePath,
+                embeddedRegistryPath: ResolveExamplePath());
+
+            var result = await loader.LoadAsync(null, default);
+
+            result.Registry.Should().NotBeNull();
+            result.Source.Should().Be(ModelRegistryLoadSource.Embedded);
+            result.Registry!.Providers.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public async Task Should_use_cache_when_etag_indicates_not_modified()
+        {
+            var handler = new SequenceMessageHandler();
+            handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(File.ReadAllText(ResolveExamplePath())),
+                Headers = { ETag = new EntityTagHeaderValue("\"v1\"") }
+            });
+            handler.Enqueue(new HttpResponseMessage(HttpStatusCode.NotModified));
+
+            var loader = new ModelRegistryLoader(
+                httpClient: new HttpClient(handler),
+                cacheFilePath: _tempCachePath,
+                embeddedRegistryPath: ResolveExamplePath());
+
+            var registryUrl = "https://example.com/models.json";
+
+            var first = await loader.LoadAsync(registryUrl, default);
+            first.Source.Should().Be(ModelRegistryLoadSource.Network);
+            first.Registry.Should().NotBeNull();
+
+            var second = await loader.LoadAsync(registryUrl, default);
+            second.Source.Should().Be(ModelRegistryLoadSource.CacheNotModified);
+            second.Registry.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task Should_fallback_to_cache_when_network_fails()
+        {
+            var handler = new SequenceMessageHandler();
+            handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(File.ReadAllText(ResolveExamplePath())),
+                Headers = { ETag = new EntityTagHeaderValue("\"v2\"") }
+            });
+            handler.Enqueue(new HttpRequestException("network down"));
+
+            var loader = new ModelRegistryLoader(
+                httpClient: new HttpClient(handler),
+                cacheFilePath: _tempCachePath,
+                embeddedRegistryPath: ResolveExamplePath());
+
+            var registryUrl = "https://example.com/models.json";
+
+            var first = await loader.LoadAsync(registryUrl, default);
+            first.Source.Should().Be(ModelRegistryLoadSource.Network);
+
+            var second = await loader.LoadAsync(registryUrl, default);
+            second.Source.Should().Be(ModelRegistryLoadSource.CacheFallback);
+            second.Registry.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task Should_use_embedded_when_remote_registry_is_invalid()
+        {
+            var handler = new SequenceMessageHandler();
+            var invalidJson = File.ReadAllText(ResolveExamplePath()).Replace("\"version\": \"1\"", "\"version\": \"2\"");
+            handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(invalidJson),
+                Headers = { ETag = new EntityTagHeaderValue("\"v3\"") }
+            });
+
+            var loader = new ModelRegistryLoader(
+                httpClient: new HttpClient(handler),
+                cacheFilePath: _tempCachePath,
+                embeddedRegistryPath: ResolveExamplePath());
+
+            var result = await loader.LoadAsync("https://example.com/models.json", default);
+
+            result.Registry.Should().NotBeNull();
+            result.Source.Should().Be(ModelRegistryLoadSource.Embedded);
+        }
+
+        private static string ResolveExamplePath()
+        {
+            var baseDirectory = AppContext.BaseDirectory;
+            for (var i = 0; i < 6; i++)
+            {
+                var segments = Enumerable.Repeat("..", i).Concat(new[] { "docs", "models.example.json" }).ToArray();
+                var candidate = Path.GetFullPath(Path.Combine(new[] { baseDirectory }.Concat(segments).ToArray()));
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new FileNotFoundException("Could not locate models.example.json");
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                var directory = Path.GetDirectoryName(_tempCachePath);
+                if (!string.IsNullOrWhiteSpace(directory) && Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+            }
+            catch
+            {
+                // ignore cleanup errors
+            }
+        }
+
+        private sealed class SequenceMessageHandler : HttpMessageHandler
+        {
+            private readonly Queue<object> _responses = new();
+
+            public void Enqueue(HttpResponseMessage response) => _responses.Enqueue(response);
+
+            public void Enqueue(Exception exception) => _responses.Enqueue(exception);
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (_responses.Count == 0)
+                {
+                    throw new InvalidOperationException("No queued responses available");
+                }
+
+                var next = _responses.Dequeue();
+                if (next is Exception exception)
+                {
+                    throw exception;
+                }
+
+                var response = (HttpResponseMessage)next;
+                response.RequestMessage = request;
+                return Task.FromResult(response);
+            }
+        }
+    }
+}

--- a/Brainarr.Tests/Services/Registry/RegistryAwareProviderFactoryDecoratorTests.cs
+++ b/Brainarr.Tests/Services/Registry/RegistryAwareProviderFactoryDecoratorTests.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NLog;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.ImportLists.Brainarr;
+using NzbDrone.Core.ImportLists.Brainarr.Configuration;
+using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Registry;
+using HttpClient = System.Net.Http.HttpClient;
+
+namespace Brainarr.Tests.Services.Registry
+{
+    public class RegistryAwareProviderFactoryDecoratorTests : IDisposable
+    {
+        private const string EnvVarName = "BRAINARR_TEST_OPENAI_KEY";
+        private readonly List<string> _tempDirectories = new();
+        private readonly string? _originalEnvValue;
+
+        public RegistryAwareProviderFactoryDecoratorTests()
+        {
+            RegistryAwareProviderFactoryDecorator.UseExternalModelRegistry = false;
+            _originalEnvValue = Environment.GetEnvironmentVariable(EnvVarName);
+        }
+
+        [Fact]
+        public void Should_delegate_to_inner_factory_when_feature_flag_disabled()
+        {
+            var inner = new Mock<IProviderFactory>();
+            var loader = CreateLoaderWithRegistry("{\"version\":\"1\",\"providers\":[]}");
+            var decorator = new RegistryAwareProviderFactoryDecorator(inner.Object, loader, null);
+            var settings = new BrainarrSettings { Provider = AIProvider.OpenAI };
+            var httpClient = Mock.Of<IHttpClient>();
+            var logger = LogManager.GetLogger(nameof(Should_delegate_to_inner_factory_when_feature_flag_disabled));
+            var provider = Mock.Of<IAIProvider>();
+            BrainarrSettings? observed = null;
+
+            inner.Setup(f => f.CreateProvider(It.IsAny<BrainarrSettings>(), It.IsAny<IHttpClient>(), It.IsAny<Logger>()))
+                .Callback<BrainarrSettings, IHttpClient, Logger>((s, _, _) => observed = s)
+                .Returns(provider);
+
+            var result = decorator.CreateProvider(settings, httpClient, logger);
+
+            result.Should().Be(provider);
+            observed.Should().BeSameAs(settings);
+            settings.ManualModelId.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Should_apply_registry_model_and_environment_api_key_when_enabled()
+        {
+            RegistryAwareProviderFactoryDecorator.UseExternalModelRegistry = true;
+            var expectedKey = Guid.NewGuid().ToString("N");
+            Environment.SetEnvironmentVariable(EnvVarName, expectedKey);
+
+            var registryJson = @"{
+              ""version"": ""1"",
+              ""providers"": [
+                {
+                  ""name"": ""OpenAI"",
+                  ""slug"": ""openai"",
+                  ""endpoint"": ""https://example.com"",
+                  ""auth"": { ""type"": ""bearer"", ""env"": ""BRAINARR_TEST_OPENAI_KEY"" },
+                  ""models"": [
+                    {
+                      ""id"": ""gpt-test"",
+                      ""context_tokens"": 100000,
+                      ""capabilities"": { ""stream"": true, ""json_mode"": true, ""tools"": true }
+                    }
+                  ],
+                  ""timeouts"": { ""connect_ms"": 1000, ""request_ms"": 1000 },
+                  ""retries"": { ""max"": 1, ""backoff_ms"": 1 }
+                }
+              ]
+            }";
+
+            var loader = CreateLoaderWithRegistry(registryJson);
+            var preload = await loader.LoadAsync(null, default);
+            preload.Registry.Should().NotBeNull();
+            preload.Registry!.Providers.Should().NotBeEmpty();
+            preload.Registry.Providers[0].Models.Should().NotBeEmpty();
+            preload.Registry.Providers[0].Models[0].Id.Should().Be("gpt-test");
+            var inner = new Mock<IProviderFactory>();
+            var decorator = new RegistryAwareProviderFactoryDecorator(inner.Object, loader, null);
+            var ensureMethod = typeof(RegistryAwareProviderFactoryDecorator)
+                .GetMethod("EnsureRegistryLoaded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            ensureMethod.Should().NotBeNull();
+            var ensured = (ModelRegistry?)ensureMethod!.Invoke(decorator, new object?[] { default(CancellationToken) });
+            ensured.Should().NotBeNull();
+            ensured!.Providers.Should().NotBeEmpty();
+            ensured.Providers[0].Models.Should().NotBeEmpty();
+            ensured.Providers[0].Models[0].Id.Should().Be("gpt-test");
+            var settings = new BrainarrSettings { Provider = AIProvider.OpenAI };
+            settings.ManualModelId.Should().BeNull();
+            var httpClient = Mock.Of<IHttpClient>();
+            var logger = LogManager.GetLogger(nameof(Should_apply_registry_model_and_environment_api_key_when_enabled));
+            var provider = Mock.Of<IAIProvider>();
+            BrainarrSettings? observed = null;
+            string? manualModelDuringInvocation = null;
+            string? apiKeyDuringInvocation = null;
+            string? providerModelDuringInvocation = null;
+
+            inner.Setup(f => f.CreateProvider(It.IsAny<BrainarrSettings>(), It.IsAny<IHttpClient>(), It.IsAny<Logger>()))
+                .Callback<BrainarrSettings, IHttpClient, Logger>((s, _, _) =>
+                {
+                    observed = s;
+                    manualModelDuringInvocation = s.ManualModelId;
+                    apiKeyDuringInvocation = s.OpenAIApiKey;
+                    providerModelDuringInvocation = s.OpenAIModelId;
+                })
+                .Returns(provider);
+
+            var result = decorator.CreateProvider(settings, httpClient, logger);
+
+            result.Should().Be(provider);
+            observed.Should().NotBeNull();
+            observed.Should().BeSameAs(settings);
+            manualModelDuringInvocation.Should().Be("gpt-test");
+            apiKeyDuringInvocation.Should().Be(expectedKey);
+            providerModelDuringInvocation.Should().Be("gpt-test");
+            settings.ManualModelId.Should().BeNull();
+            settings.OpenAIApiKey.Should().BeNull();
+            settings.OpenAIModelId.Should().BeNull();
+        }
+
+        [Fact]
+        public void Should_apply_registry_model_for_lmstudio_and_restore_settings_after_creation()
+        {
+            RegistryAwareProviderFactoryDecorator.UseExternalModelRegistry = true;
+
+            var registryJson = @"{
+              ""version"": ""1"",
+              ""providers"": [
+                {
+                  ""name"": ""LM Studio"",
+                  ""slug"": ""lmstudio"",
+                  ""endpoint"": ""http://localhost:1234"",
+                  ""auth"": { ""type"": ""none"" },
+                  ""models"": [
+                    {
+                      ""id"": ""lmstudio-registry"",
+                      ""context_tokens"": 32768,
+                      ""capabilities"": { ""stream"": true, ""json_mode"": true, ""tools"": false }
+                    }
+                  ],
+                  ""timeouts"": { ""connect_ms"": 1000, ""request_ms"": 1000 },
+                  ""retries"": { ""max"": 1, ""backoff_ms"": 1 }
+                }
+              ]
+            }";
+
+            var loader = CreateLoaderWithRegistry(registryJson);
+            var inner = new Mock<IProviderFactory>();
+            var decorator = new RegistryAwareProviderFactoryDecorator(inner.Object, loader, null);
+            var settings = new BrainarrSettings { Provider = AIProvider.LMStudio };
+            settings.LMStudioModel = string.Empty; // simulate unset model
+            var httpClient = Mock.Of<IHttpClient>();
+            var logger = LogManager.GetLogger(nameof(Should_apply_registry_model_for_lmstudio_and_restore_settings_after_creation));
+            var provider = Mock.Of<IAIProvider>();
+            string? lmStudioModelDuringInvocation = null;
+            string? manualModelDuringInvocation = null;
+
+            inner.Setup(f => f.CreateProvider(It.IsAny<BrainarrSettings>(), It.IsAny<IHttpClient>(), It.IsAny<Logger>()))
+                .Callback<BrainarrSettings, IHttpClient, Logger>((s, _, _) =>
+                {
+                    lmStudioModelDuringInvocation = s.LMStudioModel;
+                    manualModelDuringInvocation = s.ManualModelId;
+                })
+                .Returns(provider);
+
+            var result = decorator.CreateProvider(settings, httpClient, logger);
+
+            result.Should().Be(provider);
+            lmStudioModelDuringInvocation.Should().Be("lmstudio-registry");
+            manualModelDuringInvocation.Should().Be("lmstudio-registry");
+            settings.LMStudioModel.Should().Be(BrainarrConstants.DefaultLMStudioModel);
+            settings.ManualModelId.Should().BeNull();
+        }
+
+        [Fact]
+        public void Should_report_unavailable_when_required_environment_variable_is_missing()
+        {
+            RegistryAwareProviderFactoryDecorator.UseExternalModelRegistry = true;
+            Environment.SetEnvironmentVariable(EnvVarName, null);
+
+            var registryJson = @"{
+              ""version"": ""1"",
+              ""providers"": [
+                {
+                  ""name"": ""OpenAI"",
+                  ""slug"": ""openai"",
+                  ""endpoint"": ""https://example.com"",
+                  ""auth"": { ""type"": ""bearer"", ""env"": ""BRAINARR_TEST_OPENAI_KEY"" },
+                  ""models"": [
+                    {
+                      ""id"": ""gpt-test"",
+                      ""context_tokens"": 100000,
+                      ""capabilities"": { ""stream"": true, ""json_mode"": true, ""tools"": true }
+                    }
+                  ],
+                  ""timeouts"": { ""connect_ms"": 1000, ""request_ms"": 1000 },
+                  ""retries"": { ""max"": 1, ""backoff_ms"": 1 }
+                }
+              ]
+            }";
+
+            var loader = CreateLoaderWithRegistry(registryJson);
+            var inner = new Mock<IProviderFactory>(MockBehavior.Strict);
+            var decorator = new RegistryAwareProviderFactoryDecorator(inner.Object, loader, null);
+            var settings = new BrainarrSettings { Provider = AIProvider.OpenAI };
+
+            var available = decorator.IsProviderAvailable(AIProvider.OpenAI, settings);
+
+            available.Should().BeFalse();
+            inner.Verify(f => f.IsProviderAvailable(It.IsAny<AIProvider>(), It.IsAny<BrainarrSettings>()), Times.Never);
+        }
+
+        [Fact]
+        public void Should_report_unavailable_when_override_model_not_present_in_registry()
+        {
+            RegistryAwareProviderFactoryDecorator.UseExternalModelRegistry = true;
+            var registryJson = @"{
+              ""version"": ""1"",
+              ""providers"": [
+                {
+                  ""name"": ""OpenAI"",
+                  ""slug"": ""openai"",
+                  ""endpoint"": ""https://example.com"",
+                  ""auth"": { ""type"": ""none"" },
+                  ""models"": [
+                    {
+                      ""id"": ""gpt-test"",
+                      ""context_tokens"": 100000,
+                      ""capabilities"": { ""stream"": true, ""json_mode"": true, ""tools"": true }
+                    }
+                  ],
+                  ""timeouts"": { ""connect_ms"": 1000, ""request_ms"": 1000 },
+                  ""retries"": { ""max"": 1, ""backoff_ms"": 1 }
+                }
+              ]
+            }";
+
+            var loader = CreateLoaderWithRegistry(registryJson);
+            var inner = new Mock<IProviderFactory>(MockBehavior.Strict);
+            var decorator = new RegistryAwareProviderFactoryDecorator(inner.Object, loader, null);
+            var settings = new BrainarrSettings { Provider = AIProvider.OpenAI, ManualModelId = "non-existent" };
+
+            var available = decorator.IsProviderAvailable(AIProvider.OpenAI, settings);
+
+            available.Should().BeFalse();
+            inner.Verify(f => f.IsProviderAvailable(It.IsAny<AIProvider>(), It.IsAny<BrainarrSettings>()), Times.Never);
+        }
+
+        private ModelRegistryLoader CreateLoaderWithRegistry(string json)
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "brainarr-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            _tempDirectories.Add(directory);
+            var path = Path.Combine(directory, "registry.json");
+            File.WriteAllText(path, json);
+
+            return new ModelRegistryLoader(
+                httpClient: new HttpClient(new ThrowingHandler()),
+                cacheFilePath: path,
+                embeddedRegistryPath: path);
+        }
+
+        private sealed class ThrowingHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                throw new InvalidOperationException("HTTP access should not be used during tests");
+            }
+        }
+
+        public void Dispose()
+        {
+            RegistryAwareProviderFactoryDecorator.UseExternalModelRegistry = false;
+            Environment.SetEnvironmentVariable(EnvVarName, _originalEnvValue);
+            foreach (var directory in _tempDirectories)
+            {
+                try
+                {
+                    if (Directory.Exists(directory))
+                    {
+                        Directory.Delete(directory, recursive: true);
+                    }
+                }
+                catch
+                {
+                    // Ignore cleanup errors in tests
+                }
+            }
+        }
+    }
+}

--- a/Brainarr.Tests/Services/Security/InputSanitizerTests.cs
+++ b/Brainarr.Tests/Services/Security/InputSanitizerTests.cs
@@ -49,7 +49,7 @@ namespace Brainarr.Tests.Services.Security
         [InlineData("", "")]
         [InlineData("   ", "")]
         [InlineData("\t\n\r", "")]
-        public void SanitizeForPrompt_WithNullOrWhitespace_ReturnsEmptyString(string input, string expected)
+        public void SanitizeForPrompt_WithNullOrWhitespace_ReturnsEmptyString(string? input, string expected)
         {
             // Act
             var result = _sanitizer.SanitizeForPrompt(input);
@@ -203,7 +203,7 @@ namespace Brainarr.Tests.Services.Security
         [InlineData(null, "")]
         [InlineData("", "")]
         [InlineData("   ", "")]
-        public void SanitizeArtistName_WithNullOrWhitespace_ReturnsEmptyString(string input, string expected)
+        public void SanitizeArtistName_WithNullOrWhitespace_ReturnsEmptyString(string? input, string expected)
         {
             // Act
             var result = _sanitizer.SanitizeArtistName(input);
@@ -744,7 +744,7 @@ namespace Brainarr.Tests.Services.Security
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void IsValidInput_WithNullOrEmptyInput_ReturnsFalse(string input)
+        public void IsValidInput_WithNullOrEmptyInput_ReturnsFalse(string? input)
         {
             // Act
             var result = _sanitizer.IsValidInput(input, InputType.ArtistName);

--- a/Brainarr.Tests/Services/Security/SecureHttpClientTests.cs
+++ b/Brainarr.Tests/Services/Security/SecureHttpClientTests.cs
@@ -83,7 +83,7 @@ namespace Brainarr.Tests.Services.Security
         [InlineData("")]
         [InlineData("   ")]
         [InlineData(null)]
-        public void CreateSecureRequest_WithInvalidUrl_ThrowsException(string invalidUrl)
+        public void CreateSecureRequest_WithInvalidUrl_ThrowsException(string? invalidUrl)
         {
             // Act & Assert
             _secureClient.Invoking(c => c.CreateSecureRequest(invalidUrl))

--- a/Brainarr.Tests/Services/Support/MinimalResponseParserTests.cs
+++ b/Brainarr.Tests/Services/Support/MinimalResponseParserTests.cs
@@ -107,7 +107,7 @@ namespace Brainarr.Tests.Services.Support
         [InlineData(null)]
         [InlineData("Invalid JSON content")]
         [InlineData("{not an array}")]
-        public void ParseStandardResponse_WithInvalidInput_ReturnsEmptyList(string invalidInput)
+        public void ParseStandardResponse_WithInvalidInput_ReturnsEmptyList(string? invalidInput)
         {
             // Act
             var result = _parser.ParseStandardResponse(invalidInput);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.2.4] - 2025-09-12
+
+- feat(registry): add JSON-driven provider/model registry schema and example assets for zero-rebuild model onboarding.
+- feat(registry): introduce registry-aware provider factory decorator behind a feature flag with environment API key support.
+- feat(registry): add ETag-aware loader with cache/embedded fallback and validation tests plus dedicated CI workflow.
+- chore: bump plugin manifest versions to 1.2.4.
+
 ## [1.2.3] - 2025-09-11
 
 - CI: Update actions to `actions/setup-node@v5`, `actions/setup-python@v6`, and `lycheeverse/lychee-action@v2`.
@@ -29,7 +36,8 @@ Planned: minor improvements post 1.2.3
 
 - See commit history for details.
 
-[Unreleased]: https://github.com/RicherTunes/Brainarr/compare/v1.2.3...HEAD
+[Unreleased]: https://github.com/RicherTunes/Brainarr/compare/v1.2.4...HEAD
+[1.2.4]: https://github.com/RicherTunes/Brainarr/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/RicherTunes/Brainarr/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/RicherTunes/Brainarr/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/RicherTunes/Brainarr/compare/v1.2.0...v1.2.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/github/license/RicherTunes/Brainarr)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-6.0%2B-blue)](https://dotnet.microsoft.com/download)
 [![Lidarr](https://img.shields.io/badge/Lidarr-Plugin-green)](https://lidarr.audio/)
-[![Version](https://img.shields.io/badge/version-1.2.3-brightgreen)](plugin.json)
+[![Version](https://img.shields.io/badge/version-1.2.4-brightgreen)](plugin.json)
 [![Changelog](https://img.shields.io/badge/changelog-link-blue)](CHANGELOG.md)
 [![Docs Lint](https://github.com/RicherTunes/Brainarr/actions/workflows/docs-lint.yml/badge.svg)](https://github.com/RicherTunes/Brainarr/actions/workflows/docs-lint.yml)
 [![pre-commit](https://github.com/RicherTunes/Brainarr/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/RicherTunes/Brainarr/actions/workflows/pre-commit.yml)
@@ -18,7 +18,7 @@ Brainarr is a multi-provider AI-powered import list plugin for Lidarr that gener
 > Requires Lidarr 2.14.1.4716+ on the plugins/nightly branch. In Lidarr: Settings > General > Updates > set Branch = nightly. If you run an older Lidarr, upgrade first — otherwise the plugin will not load.
 >
 > Provider Status
-> Verified in 1.2.3: LM Studio (local), Gemini (cloud), and Perplexity (cloud). Other providers are available but considered experimental until explicitly verified. See wiki pages "Local Providers" and "Cloud Providers" for setup tips and a quick smoke-test.
+> Verified in 1.2.4: LM Studio (local), Gemini (cloud), and Perplexity (cloud). Other providers are available but considered experimental until explicitly verified. See wiki pages "Local Providers" and "Cloud Providers" for setup tips and a quick smoke-test.
 
 ## Features
 
@@ -367,7 +367,7 @@ View recommendation history and statistics:
 
 ## Provider Comparison
 
-| Provider | Privacy | Cost | Setup | Best For | Tested (1.2.3) |
+| Provider | Privacy | Cost | Setup | Best For | Tested (1.2.4) |
 |----------|---------|------|-------|----------|-----------------|
 | **Ollama** | 🟢 Perfect | Free | Easy | Privacy-conscious users | ❓ Unverified |
 | **LM Studio** | 🟢 Perfect | Free | Easy | GUI users who want privacy | ✅ Tested |
@@ -566,7 +566,7 @@ For technical issues and feature requests, please review the documentation in th
 
 ## Project Status
 
-**Current Version**: 1.2.3
+**Current Version**: 1.2.4
 
 **Completed Features:**
 

--- a/docs/PLUGIN_MANIFEST.md
+++ b/docs/PLUGIN_MANIFEST.md
@@ -9,7 +9,7 @@ The `plugin.json` file is the manifest that defines your Lidarr plugin's metadat
 ```json
 {
   "name": "Brainarr",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "AI-powered music discovery with 9 providers including local and cloud options",
   "author": "Brainarr Team",
   "minimumVersion": "2.14.1.4716",
@@ -52,7 +52,7 @@ The `plugin.json` file is the manifest that defines your Lidarr plugin's metadat
 **Example:**
 
 ```json
-"version": "1.2.3"
+"version": "1.2.4"
 ```
 
 **Versioning Guidelines:**
@@ -197,7 +197,7 @@ Here's a fully-featured manifest with all optional fields:
 ```json
 {
   "name": "Brainarr",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "AI-powered music discovery with 9 providers including local and cloud options",
   "author": "Brainarr Team <team@brainarr.ai>",
   "minimumVersion": "2.14.1.4716",
@@ -260,13 +260,13 @@ Here's a fully-featured manifest with all optional fields:
 // Wrong - trailing comma
 {
   "name": "Brainarr",
-  "version": "1.2.3",  // <- trailing comma causes error
+  "version": "1.2.4",  // <- trailing comma causes error
 }
 
 // Correct - no trailing comma
 {
   "name": "Brainarr",
-  "version": "1.2.3"
+  "version": "1.2.4"
 }
 ```
 
@@ -293,7 +293,7 @@ When releasing a new version:
 
 ```json
 {
-  "version": "1.2.3"  // Increment appropriately
+  "version": "1.2.4"  // Increment appropriately
 }
 ```
 

--- a/docs/models.example.json
+++ b/docs/models.example.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "./models.schema.json",
+  "version": "1",
+  "providers": [
+    {
+      "name": "OpenAI",
+      "slug": "openai",
+      "endpoint": "https://api.openai.com/v1/chat/completions",
+      "auth": { "type": "bearer", "env": "OPENAI_API_KEY" },
+      "models": [
+        {
+          "id": "gpt-4o-mini",
+          "label": "GPT‑4o mini",
+          "context_tokens": 128000,
+          "pricing": { "input_per_1k": 0.15, "output_per_1k": 0.6 },
+          "capabilities": { "stream": true, "json_mode": true, "tools": true, "tool_choice": "auto" }
+        }
+      ],
+      "timeouts": { "connect_ms": 5000, "request_ms": 30000 },
+      "retries": { "max": 2, "backoff_ms": 200 }
+    },
+    {
+      "name": "LM Studio",
+      "slug": "lmstudio",
+      "endpoint": "http://localhost:1234/v1/chat/completions",
+      "auth": { "type": "none" },
+      "models": [
+        {
+          "id": "qwen2.5:7b-instruct-q4",
+          "label": "Qwen2.5 7B Q4_K_M",
+          "context_tokens": 32768,
+          "capabilities": { "stream": true, "json_mode": true, "tools": false }
+        }
+      ],
+      "timeouts": { "connect_ms": 1000, "request_ms": 120000 },
+      "retries": { "max": 1, "backoff_ms": 100 }
+    }
+  ]
+}

--- a/docs/models.schema.json
+++ b/docs/models.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://richer-tunes.github.io/brainarr/models.schema.json",
+  "title": "Brainarr Provider & Model Registry v1",
+  "type": "object",
+  "required": ["version", "providers"],
+  "properties": {
+    "version": { "type": "string", "enum": ["1"] },
+    "providers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "slug", "endpoint", "auth", "models", "timeouts", "retries"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "slug": { "type": "string", "pattern": "^[a-z0-9_-]+$" },
+          "endpoint": { "type": "string", "format": "uri" },
+          "auth": {
+            "type": "object",
+            "required": ["type"],
+            "properties": {
+              "type": { "type": "string", "enum": ["none", "bearer", "basic", "header"] },
+              "env": { "type": "string" },
+              "header": { "type": "string" }
+            },
+            "allOf": [
+              { "if": { "properties": { "type": { "const": "bearer" } } }, "then": { "required": ["env"] } },
+              { "if": { "properties": { "type": { "const": "header" } } }, "then": { "required": ["env", "header"] } }
+            ]
+          },
+          "models": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "context_tokens", "capabilities"],
+              "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "label": { "type": "string" },
+                "context_tokens": { "type": "integer", "minimum": 1024 },
+                "pricing": {
+                  "type": "object",
+                  "properties": {
+                    "input_per_1k": { "type": "number", "minimum": 0 },
+                    "output_per_1k": { "type": "number", "minimum": 0 }
+                  },
+                  "additionalProperties": false
+                },
+                "capabilities": {
+                  "type": "object",
+                  "required": ["stream", "json_mode", "tools"],
+                  "properties": {
+                    "stream": { "type": "boolean" },
+                    "json_mode": { "type": "boolean" },
+                    "tools": { "type": "boolean" },
+                    "tool_choice": { "type": "string", "enum": ["auto", "required", "none"], "default": "auto" }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "timeouts": {
+            "type": "object",
+            "required": ["connect_ms", "request_ms"],
+            "properties": {
+              "connect_ms": { "type": "integer", "minimum": 1000 },
+              "request_ms": { "type": "integer", "minimum": 1000 }
+            }
+          },
+          "retries": {
+            "type": "object",
+            "required": ["max", "backoff_ms"],
+            "properties": {
+              "max": { "type": "integer", "minimum": 0, "maximum": 5 },
+              "backoff_ms": { "type": "integer", "minimum": 0 }
+            }
+          },
+          "integrity": {
+            "type": "object",
+            "properties": {
+              "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+              "signature": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Brainarr",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "AI-powered music discovery with 9 providers including Ollama, OpenAI, Anthropic, and more",
   "author": "Brainarr Team",
   "minimumVersion": "2.14.1.4716",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Brainarr",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "AI-powered music discovery with 9 providers including local and cloud options",
   "author": "Brainarr Team",
   "minimumVersion": "2.14.1.4716",
@@ -8,8 +8,7 @@
   "dll": "Lidarr.Plugin.Brainarr.dll",
   "website": "https://github.com/RicherTunes/Brainarr",
   "owner": "RicherTunes",
-  "repository": "https://github.com/RicherTunes/Brainarr"
-  ,
+  "repository": "https://github.com/RicherTunes/Brainarr",
   "supportUri": "https://github.com/RicherTunes/Brainarr/issues",
   "changelogUri": "https://github.com/RicherTunes/Brainarr/blob/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Summary
- treat local provider defaults as empty when applying registry overrides and map LM Studio/Ollama settings through the registry-aware factory
- cover LM Studio registry application in decorator tests to ensure provider settings reset after creation
- bump README and plugin manifest documentation versions to 1.2.4 and verify docs consistency

## Testing
- `bash scripts/check-docs-consistency.sh`
- `dotnet test Brainarr.sln --configuration Release --no-build --filter "FullyQualifiedName~Registry"` *(fails: dotnet CLI unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb067433c48331b75787c11bccdfc7