### PR TITLE
Implement style-aware prompt builder with model-aware budgeting

### DIFF
--- a/Brainarr.Plugin/Models/LibraryStyleContext.cs
+++ b/Brainarr.Plugin/Models/LibraryStyleContext.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Models
+{
+    /// <summary>
+    /// Captures normalized style information for the user's library so sampling and prompts
+    /// can remain grounded in the listener's actual collection.
+    /// </summary>
+    public class LibraryStyleContext
+    {
+        /// <summary>
+        /// Mapping of artist id to the set of normalized style slugs detected for that artist.
+        /// </summary>
+        public Dictionary<int, HashSet<string>> ArtistStyles { get; set; } = new Dictionary<int, HashSet<string>>();
+
+        /// <summary>
+        /// Mapping of album id to the set of normalized style slugs detected for that album.
+        /// </summary>
+        public Dictionary<int, HashSet<string>> AlbumStyles { get; set; } = new Dictionary<int, HashSet<string>>();
+
+        /// <summary>
+        /// Aggregated coverage counts for each normalized style slug across the library.
+        /// Counts include both artist and album level matches to provide a sense of breadth.
+        /// </summary>
+        public Dictionary<string, int> StyleCoverage { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Convenience set of every style slug observed in the library.
+        /// </summary>
+        public HashSet<string> AllStyleSlugs { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Ordered list of dominant styles discovered in the library. Used for inference when
+        /// the user has not explicitly selected styles.
+        /// </summary>
+        public List<string> DominantStyles { get; set; } = new List<string>();
+
+        /// <summary>
+        /// True when at least one normalized style could be extracted from the library.
+        /// </summary>
+        public bool HasStyles => AllStyleSlugs.Count > 0;
+    }
+
+    /// <summary>
+    /// Represents an artist selected for inclusion in the prompt sample.
+    /// Stores matched styles and sampling metadata to support compression and telemetry.
+    /// </summary>
+    public class LibrarySampleArtist
+    {
+        public int ArtistId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public HashSet<string> MatchedStyles { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        public double MatchScore { get; set; }
+        public DateTime? Added { get; set; }
+        public double Weight { get; set; }
+        public List<LibrarySampleAlbum> Albums { get; set; } = new List<LibrarySampleAlbum>();
+    }
+
+    /// <summary>
+    /// Represents an album selected for inclusion in the prompt sample.
+    /// Tracks artist association, matched styles, and recency metadata for compression.
+    /// </summary>
+    public class LibrarySampleAlbum
+    {
+        public int AlbumId { get; set; }
+        public int ArtistId { get; set; }
+        public string ArtistName { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public HashSet<string> MatchedStyles { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        public double MatchScore { get; set; }
+        public DateTime? Added { get; set; }
+        public int? Year { get; set; }
+    }
+
+    /// <summary>
+    /// Container for sampled artists and albums that will seed the prompt.
+    /// </summary>
+    public class LibrarySample
+    {
+        public List<LibrarySampleArtist> Artists { get; set; } = new List<LibrarySampleArtist>();
+        public List<LibrarySampleAlbum> Albums { get; set; } = new List<LibrarySampleAlbum>();
+
+        public int ArtistCount => Artists.Count;
+        public int AlbumCount => Albums.Count;
+    }
+}

--- a/Brainarr.Plugin/Models/Recommendation.cs
+++ b/Brainarr.Plugin/Models/Recommendation.cs
@@ -112,6 +112,12 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Models
         /// Includes genre distribution, temporal patterns, quality metrics, and user preferences.
         /// </summary>
         public Dictionary<string, object> Metadata { get; init; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Pre-computed style context used to keep sampling and prompts aligned with the
+        /// listener's actual collection footprint.
+        /// </summary>
+        public LibraryStyleContext StyleContext { get; init; } = new LibraryStyleContext();
     }
 
     /// <summary>

--- a/Brainarr.Plugin/Services/ILibraryAwarePromptBuilder.cs
+++ b/Brainarr.Plugin/Services/ILibraryAwarePromptBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NzbDrone.Core.Music;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
@@ -53,4 +54,21 @@ public class LibraryPromptResult
     public int SampledArtists { get; set; }
     public int SampledAlbums { get; set; }
     public int EstimatedTokens { get; set; }
+    public int EstimatedTokensPreCompression { get; set; }
+    public int PromptBudgetTokens { get; set; }
+    public int ModelContextTokens { get; set; }
+    public string BudgetModelKey { get; set; } = string.Empty;
+    public bool Compressed { get; set; }
+    public bool Trimmed { get; set; }
+    public string FallbackReason { get; set; } = string.Empty;
+    public string SampleSeed { get; set; } = string.Empty;
+    public string SampleFingerprint { get; set; } = string.Empty;
+    public bool RelaxedStyleMatching { get; set; }
+    public List<string> AppliedStyleSlugs { get; set; } = new List<string>();
+    public List<string> AppliedStyleNames { get; set; } = new List<string>();
+    public List<string> TrimmedStyles { get; set; } = new List<string>();
+    public List<string> InferredStyleSlugs { get; set; } = new List<string>();
+    public Dictionary<string, int> StyleCoverage { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, int> MatchedStyleCounts { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+    public bool StyleCoverageSparse { get; set; }
 }

--- a/Brainarr.Plugin/Services/ILibraryAwarePromptBuilder.cs
+++ b/Brainarr.Plugin/Services/ILibraryAwarePromptBuilder.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
-using NzbDrone.Core.Music;
+using System.Threading;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
+using NzbDrone.Core.Music;
 
 namespace NzbDrone.Core.ImportLists.Brainarr.Services;
 
@@ -25,7 +26,8 @@ public interface ILibraryAwarePromptBuilder
         List<Artist> allArtists,
         List<Album> allAlbums,
         BrainarrSettings settings,
-        bool shouldRecommendArtists = false);
+        bool shouldRecommendArtists = false,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the effective token limit for the given sampling strategy and provider.
@@ -35,7 +37,7 @@ public interface ILibraryAwarePromptBuilder
     /// <summary>
     /// Estimates the token count of the provided text using the builder's heuristic.
     /// </summary>
-    int EstimateTokens(string text);
+    int EstimateTokens(string text, string? modelKey = null);
 
     /// <summary>
     /// Builds a library-aware prompt and returns prompt + sampling metrics.
@@ -45,7 +47,8 @@ public interface ILibraryAwarePromptBuilder
         List<Artist> allArtists,
         List<Album> allAlbums,
         BrainarrSettings settings,
-        bool shouldRecommendArtists = false);
+        bool shouldRecommendArtists = false,
+        CancellationToken cancellationToken = default);
 }
 
 public class LibraryPromptResult
@@ -58,6 +61,7 @@ public class LibraryPromptResult
     public int PromptBudgetTokens { get; set; }
     public int ModelContextTokens { get; set; }
     public string BudgetModelKey { get; set; } = string.Empty;
+    public int TokenHeadroom { get; set; }
     public bool Compressed { get; set; }
     public bool Trimmed { get; set; }
     public string FallbackReason { get; set; } = string.Empty;
@@ -71,4 +75,6 @@ public class LibraryPromptResult
     public Dictionary<string, int> StyleCoverage { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
     public Dictionary<string, int> MatchedStyleCounts { get; set; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
     public bool StyleCoverageSparse { get; set; }
+    public double CompressionRatio { get; set; }
+    public double TokenEstimateDrift { get; set; }
 }

--- a/Brainarr.Plugin/Services/LibraryAwarePromptBuilder.cs
+++ b/Brainarr.Plugin/Services/LibraryAwarePromptBuilder.cs
@@ -1,65 +1,65 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
-using NzbDrone.Core.Music;
+using System.Text.Json;
+using NLog;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
-using NLog;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Styles;
+using NzbDrone.Core.Music;
 
 namespace NzbDrone.Core.ImportLists.Brainarr.Services
 {
     /// <summary>
-    /// Builds context-aware prompts for AI providers by intelligently sampling
-    /// the user's music library to provide personalized recommendations.
+    /// Builds rich, library-grounded prompts for AI providers. Prompts honour user-selected
+    /// styles, stay within model-specific token budgets, and expose telemetry for diagnostics.
     /// </summary>
-    /// <remarks>
-    /// This builder implements several optimization strategies:
-    /// 1. Token budget management - Ensures prompts fit within model limits
-    /// 2. Smart sampling - Selects representative artists/albums within token constraints
-    /// 3. Genre distribution - Maintains proportional genre representation
-    /// 4. Recency bias - Prioritizes recently added music for trend detection
-    /// 5. Popularity weighting - Includes both mainstream and niche artists
-    ///
-    /// The builder adapts to different provider capabilities, using minimal context
-    /// for local models and comprehensive context for premium cloud providers.
-    /// </remarks>
     public class LibraryAwarePromptBuilder : ILibraryAwarePromptBuilder
     {
         private readonly Logger _logger;
+        private readonly IStyleCatalogService _styleCatalog;
+        private readonly ModelRegistryLoader _modelRegistryLoader;
+        private readonly Lazy<Dictionary<string, ModelContextInfo>> _modelContextCache;
 
-        // Token estimation constants based on GPT-style tokenization
-        // Approximation: ~1.3 tokens per word for English text
-        private const double TOKENS_PER_WORD = 1.3;
-        // Base prompt structure overhead (instructions, formatting)
-        private const int BASE_PROMPT_TOKENS = 300;
+        private const int SystemPromptReserve = 1200;
+        private const double CompletionReserveRatio = 0.20;
+        private const double SafetyMarginRatio = 0.10;
+        private const double MinimalRatio = 0.35;
+        private const double BalancedRatio = 0.60;
+        private const double ComprehensiveRatio = 1.00;
+        private const int MinimalPromptFloor = 1500;
+        private const int SparseStyleArtistThreshold = 5;
+        private const double RelaxedMatchThreshold = 0.70;
 
-        // Token limits by sampling strategy and provider type
-        // Local models have smaller context windows
-        private const int MINIMAL_TOKEN_LIMIT = 3000;
-        // Standard cloud providers balance cost and context
-        private const int BALANCED_TOKEN_LIMIT = 6000;
-        // Premium providers can handle much larger contexts
-        private const int COMPREHENSIVE_TOKEN_LIMIT = 20000;
+        private static readonly Dictionary<AIProvider, int> DefaultContextTokens = new()
+        {
+            [AIProvider.Ollama] = 32768,
+            [AIProvider.LMStudio] = 32768,
+            [AIProvider.OpenAI] = 64000,
+            [AIProvider.Anthropic] = 120000,
+            [AIProvider.Perplexity] = 32000,
+            [AIProvider.OpenRouter] = 64000,
+            [AIProvider.DeepSeek] = 48000,
+            [AIProvider.Gemini] = 32000,
+            [AIProvider.Groq] = 32000,
+        };
 
         public LibraryAwarePromptBuilder(Logger logger)
+            : this(logger, new StyleCatalogService(logger, httpClient: null), new ModelRegistryLoader(logger: logger))
         {
-            _logger = logger;
-            _logger.Debug("LibraryAwarePromptBuilder instance created");
         }
 
-        /// <summary>
-        /// Builds a library-aware prompt optimized for the specified AI provider.
-        /// </summary>
-        /// <param name="profile">User's library profile with genre and artist preferences</param>
-        /// <param name="allArtists">Complete list of artists in the library</param>
-        /// <param name="allAlbums">Complete list of albums for context</param>
-        /// <param name="settings">Configuration including provider, discovery mode, and constraints</param>
-        /// <returns>A token-optimized prompt with relevant library context</returns>
-        /// <remarks>
-        /// The method gracefully degrades to simpler prompts if the library is too large
-        /// or if an error occurs during sampling, ensuring recommendations are always possible.
-        /// </remarks>
+        public LibraryAwarePromptBuilder(Logger logger, IStyleCatalogService styleCatalog, ModelRegistryLoader modelRegistryLoader)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _styleCatalog = styleCatalog ?? throw new ArgumentNullException(nameof(styleCatalog));
+            _modelRegistryLoader = modelRegistryLoader ?? throw new ArgumentNullException(nameof(modelRegistryLoader));
+            _modelContextCache = new Lazy<Dictionary<string, ModelContextInfo>>(LoadModelContextCache, isThreadSafe: true);
+            _logger.Debug("LibraryAwarePromptBuilder instance created");
+        }
         public string BuildLibraryAwarePrompt(
             LibraryProfile profile,
             List<Artist> allArtists,
@@ -67,72 +67,8 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
             BrainarrSettings settings,
             bool shouldRecommendArtists = false)
         {
-            try
-            {
-                // Calculate token budget based on provider capabilities
-                // Premium providers get more context for better recommendations
-                var maxTokens = GetTokenLimitForStrategy(settings.SamplingStrategy, settings.Provider);
-                var availableTokens = maxTokens - BASE_PROMPT_TOKENS;
-
-                // Intelligently sample library to fit within token budget
-                // Prioritizes diversity, recency, and genre representation
-                var librarySample = BuildSmartLibrarySample(allArtists, allAlbums, availableTokens, settings.DiscoveryMode);
-
-                var prompt = BuildPromptWithLibraryContext(profile, librarySample, settings, shouldRecommendArtists);
-
-                _logger.Debug($"Built library-aware prompt with {librarySample.Artists.Count} artists, " +
-                             $"{librarySample.Albums.Count} albums (estimated {EstimateTokens(prompt)} tokens)");
-
-                return prompt;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, "Failed to build library-aware prompt, falling back to simple prompt");
-                return BuildFallbackPrompt(profile, settings);
-            }
-        }
-
-        /// <summary>
-        /// Creates an intelligent sample of the library that fits within token constraints.
-        /// </summary>
-        /// <param name="allArtists">All artists to sample from</param>
-        /// <param name="allAlbums">All albums for additional context</param>
-        /// <param name="tokenBudget">Maximum tokens available for library data</param>
-        /// <returns>A representative sample of the library optimized for AI understanding</returns>
-        /// <remarks>
-        /// Sampling algorithm:
-        /// 1. Groups artists by genre for proportional representation
-        /// 2. Selects artists based on: album count, rating, recency
-        /// 3. Includes both popular and niche artists for diversity
-        /// 4. Adds recent albums for trend awareness
-        /// </remarks>
-        private LibrarySample BuildSmartLibrarySample(List<Artist> allArtists, List<Album> allAlbums, int tokenBudget, DiscoveryMode mode)
-        {
-            var sample = new LibrarySample();
-
-            // Prioritize sampling strategy based on library size
-            if (allArtists.Count <= 50)
-            {
-                // Small library: Include most artists and albums
-                sample.Artists = allArtists.Take(Math.Min(40, allArtists.Count)).Select(a => a.Name).ToList();
-                sample.Albums = allAlbums.Take(Math.Min(100, allAlbums.Count))
-                    .Select(a => $"{a.ArtistMetadata?.Value?.Name} - {a.Title}")
-                    .Where(name => !string.IsNullOrEmpty(name))
-                    .ToList();
-            }
-            else if (allArtists.Count <= 200)
-            {
-                // Medium library: Strategic sampling
-                sample.Artists = SampleArtistsStrategically(allArtists, allAlbums, 30, mode);
-                sample.Albums = SampleAlbumsStrategically(allAlbums, 80, mode);
-            }
-            else
-            {
-                // Large library: Smart sampling with token estimation
-                sample = BuildTokenConstrainedSample(allArtists, allAlbums, tokenBudget, mode);
-            }
-
-            return sample;
+            var res = BuildLibraryAwarePromptWithMetrics(profile, allArtists, allAlbums, settings, shouldRecommendArtists);
+            return res.Prompt;
         }
 
         public LibraryPromptResult BuildLibraryAwarePromptWithMetrics(
@@ -143,42 +79,64 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
             bool shouldRecommendArtists = false)
         {
             var result = new LibraryPromptResult();
+
             try
             {
-                var maxTokens = GetTokenLimitForStrategy(settings.SamplingStrategy, settings.Provider);
-                var availableTokens = maxTokens - BASE_PROMPT_TOKENS;
-                // For local providers (LM Studio/Ollama), keep a safety margin to reduce truncation risk
-                if (settings.Provider == AIProvider.LMStudio || settings.Provider == AIProvider.Ollama)
+                var budget = ResolvePromptBudget(settings);
+                result.PromptBudgetTokens = budget.TierBudget;
+                result.ModelContextTokens = budget.ContextTokens;
+                result.BudgetModelKey = budget.ModelKey;
+
+                var styleSelection = BuildStyleSelection(profile, settings, result);
+                var seed = ComputeSamplingSeed(profile, allArtists, allAlbums, styleSelection, settings);
+                result.SampleSeed = seed.ToString(CultureInfo.InvariantCulture);
+
+                var sample = BuildLibrarySample(
+                    allArtists,
+                    allAlbums,
+                    profile.StyleContext ?? new LibraryStyleContext(),
+                    styleSelection,
+                    settings,
+                    Math.Max(1000, budget.TierBudget - SystemPromptReserve),
+                    seed,
+                    result);
+
+                result.MatchedStyleCounts = new Dictionary<string, int>(styleSelection.MatchedCounts, StringComparer.OrdinalIgnoreCase);
+                result.StyleCoverageSparse = styleSelection.Sparse;
+
+                var fingerprint = ComputeSampleFingerprint(sample);
+                result.SampleFingerprint = fingerprint;
+
+                var composer = new PromptComposer(this, profile, sample, settings, styleSelection, shouldRecommendArtists, result);
+                var prompt = composer.Render();
+                var estimated = EstimateTokens(prompt);
+                result.EstimatedTokensPreCompression = estimated;
+
+                while (estimated > budget.TierBudget && composer.TryCompress())
                 {
-                    availableTokens = (int)(availableTokens * 0.8);
+                    prompt = composer.Render();
+                    estimated = EstimateTokens(prompt);
                 }
 
-                var librarySample = BuildSmartLibrarySample(allArtists, allAlbums, availableTokens, settings.DiscoveryMode);
-                var prompt = BuildPromptWithLibraryContext(profile, librarySample, settings, shouldRecommendArtists);
-                // If we still overshoot, include a final safety trim by replacing long lists with shorter samples
-                var est = EstimateTokens(prompt);
-                if (est > maxTokens && librarySample.Albums.Count > 0)
+                if (estimated > budget.TierBudget)
                 {
-                    var trimAlbums = Math.Max(10, librarySample.Albums.Count / 2);
-                    librarySample.Albums = librarySample.Albums.Take(trimAlbums).ToList();
-                    prompt = BuildPromptWithLibraryContext(profile, librarySample, settings, shouldRecommendArtists);
+                    result.FallbackReason = "prompt_trimmed";
                 }
 
                 result.Prompt = prompt;
-                result.SampledArtists = librarySample.Artists.Count;
-                result.SampledAlbums = librarySample.Albums.Count;
-                result.EstimatedTokens = EstimateTokens(prompt);
-
-                _logger.Debug($"Built library-aware prompt with {result.SampledArtists} artists, {result.SampledAlbums} albums (estimated {result.EstimatedTokens} tokens)");
+                result.EstimatedTokens = estimated;
+                result.Compressed = composer.Compressed;
+                result.Trimmed = composer.Trimmed;
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed to build library-aware prompt with metrics, falling back");
+                _logger.Error(ex, "Failed to build library-aware prompt, falling back to baseline prompt");
                 var prompt = BuildFallbackPrompt(profile, settings);
                 result.Prompt = prompt;
                 result.SampledArtists = 0;
                 result.SampledAlbums = 0;
                 result.EstimatedTokens = EstimateTokens(prompt);
+                result.FallbackReason = "fallback_prompt";
             }
 
             return result;
@@ -186,289 +144,943 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
 
         public int GetEffectiveTokenLimit(SamplingStrategy strategy, AIProvider provider)
         {
-            return GetTokenLimitForStrategy(strategy, provider);
+            var settings = new BrainarrSettings
+            {
+                SamplingStrategy = strategy,
+                Provider = provider
+            };
+
+            var budget = ResolvePromptBudget(settings);
+            return budget.TierBudget;
         }
 
         public int EstimateTokens(string text)
         {
             if (string.IsNullOrEmpty(text)) return 0;
             var wordCount = text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
-            return (int)(wordCount * TOKENS_PER_WORD);
+            return (int)(wordCount * 1.3);
         }
-
-        private List<string> SampleArtistsStrategically(List<Artist> allArtists, List<Album> allAlbums, int targetCount, DiscoveryMode mode)
+        private PromptBudget ResolvePromptBudget(BrainarrSettings settings)
         {
-            // Get album counts per artist for prioritization
-            var artistAlbumCounts = allAlbums
-                .GroupBy(a => a.ArtistId)
-                .ToDictionary(g => g.Key, g => g.Count());
+            var modelInfo = ResolveModelContext(settings);
+            var contextTokens = modelInfo.ContextTokens > 0
+                ? modelInfo.ContextTokens
+                : DefaultContextTokens.TryGetValue(settings.Provider, out var fallback)
+                    ? fallback
+                    : 24000;
 
-            var sampledArtists = new List<string>();
+            var completionReserve = Math.Max(512, (int)Math.Floor(contextTokens * CompletionReserveRatio));
+            var marginReserve = Math.Max(256, (int)Math.Floor(contextTokens * SafetyMarginRatio));
+            var promptBudget = Math.Max(MinimalPromptFloor, contextTokens - SystemPromptReserve - completionReserve - marginReserve);
 
-            // Weight splits based on discovery mode
-            var topPct = mode == DiscoveryMode.Similar ? 60 : mode == DiscoveryMode.Adjacent ? 40 : 30;
-            var recentPct = mode == DiscoveryMode.Similar ? 30 : mode == DiscoveryMode.Adjacent ? 30 : 30;
-            var randomPct = Math.Max(0, 100 - topPct - recentPct);
-
-            // 1. Include top artists by album count
-            var topByAlbums = allArtists
-                .Where(a => artistAlbumCounts.ContainsKey(a.Id))
-                .OrderByDescending(a => artistAlbumCounts[a.Id])
-                .Take(Math.Max(1, targetCount * topPct / 100))
-                .Select(a => a.Name);
-            sampledArtists.AddRange(topByAlbums);
-
-            // 2. Include recently added artists
-            var recentlyAdded = allArtists
-                .OrderByDescending(a => a.Added)
-                .Take(Math.Max(1, targetCount * recentPct / 100))
-                .Select(a => a.Name)
-                .Where(name => !sampledArtists.Contains(name));
-            sampledArtists.AddRange(recentlyAdded);
-
-            // 3. Random sampling from remaining artists
-            var remaining = allArtists
-                .Select(a => a.Name)
-                .Where(name => !sampledArtists.Contains(name))
-                .OrderBy(x => Guid.NewGuid())
-                .Take(Math.Max(0, targetCount - sampledArtists.Count));
-            sampledArtists.AddRange(remaining);
-
-            return sampledArtists.Where(name => !string.IsNullOrEmpty(name)).ToList();
-        }
-
-        private List<string> SampleAlbumsStrategically(List<Album> allAlbums, int targetCount, DiscoveryMode mode)
-        {
-            var sampledAlbums = new List<string>();
-
-            // Weight splits based on discovery mode
-            var topPct = mode == DiscoveryMode.Similar ? 60 : mode == DiscoveryMode.Adjacent ? 40 : 20;
-            var recentPct = mode == DiscoveryMode.Similar ? 30 : mode == DiscoveryMode.Adjacent ? 40 : 30;
-            var randomPct = Math.Max(0, 100 - topPct - recentPct);
-
-            // 1. Top-rated / most notable albums
-            var topRated = allAlbums
-                .Where(a => a.ArtistMetadata?.Value?.Name != null && a.Title != null)
-                .OrderByDescending(a => a.Ratings?.Value ?? 0)
-                .ThenByDescending(a => a.Ratings?.Votes ?? 0)
-                .Take(Math.Max(1, targetCount * topPct / 100))
-                .Select(a => $"{a.ArtistMetadata.Value.Name} - {a.Title}");
-            sampledAlbums.AddRange(topRated);
-
-            // 2. Recently added albums
-            var recentAlbums = allAlbums
-                .Where(a => a.ArtistMetadata?.Value?.Name != null && a.Title != null)
-                .OrderByDescending(a => a.Added)
-                .Select(a => $"{a.ArtistMetadata.Value.Name} - {a.Title}")
-                .Where(name => !sampledAlbums.Contains(name))
-                .Take(Math.Max(1, targetCount * recentPct / 100));
-            sampledAlbums.AddRange(recentAlbums);
-
-            // 3. Random sampling from remaining
-            var remaining = allAlbums
-                .Where(a => a.ArtistMetadata?.Value?.Name != null && a.Title != null)
-                .Select(a => $"{a.ArtistMetadata.Value.Name} - {a.Title}")
-                .Where(name => !sampledAlbums.Contains(name))
-                .OrderBy(x => Guid.NewGuid())
-                .Take(Math.Max(0, targetCount - sampledAlbums.Count));
-            sampledAlbums.AddRange(remaining);
-
-            return sampledAlbums.ToList();
-        }
-
-        private LibrarySample BuildTokenConstrainedSample(List<Artist> allArtists, List<Album> allAlbums, int tokenBudget, DiscoveryMode mode)
-        {
-            var sample = new LibrarySample();
-            var usedTokens = 0;
-
-            // Start with essential artists (most prolific)
-            var artistAlbumCounts = allAlbums
-                .GroupBy(a => a.ArtistId)
-                .ToDictionary(g => g.Key, g => g.Count());
-
-            var prioritizedArtists = allArtists
-                .Where(a => artistAlbumCounts.ContainsKey(a.Id))
-                .OrderByDescending(a => artistAlbumCounts[a.Id])
-                .Select(a => a.Name)
-                .Where(name => !string.IsNullOrEmpty(name));
-
-            // Allocate token budget between artists and albums based on discovery mode
-            // Similar: emphasize artists (avoid changing direction), Exploratory: emphasize albums (show variety)
-            var artistShare = mode switch
+            if (settings.SamplingStrategy == SamplingStrategy.Comprehensive && settings.ComprehensiveTokenBudgetOverride.HasValue)
             {
-                DiscoveryMode.Similar => 0.7,       // 70% artists / 30% albums
-                DiscoveryMode.Exploratory => 0.4,   // 40% artists / 60% albums
-                _ => 0.6                             // Adjacent/Balanced default 60% / 40%
-            };
-
-            foreach (var artist in prioritizedArtists)
-            {
-                var artistTokens = EstimateTokens(artist);
-                if (usedTokens + artistTokens > tokenBudget * artistShare) break; // Reserve share for albums
-
-                sample.Artists.Add(artist);
-                usedTokens += artistTokens;
+                promptBudget = Math.Min(promptBudget, settings.ComprehensiveTokenBudgetOverride.Value);
             }
 
-            var albumCandidates = new List<string>();
-
-            var topRatedAlbums = allAlbums
-                .Where(a => a.ArtistMetadata?.Value?.Name != null && a.Title != null)
-                .OrderByDescending(a => a.Ratings?.Value ?? 0)
-                .ThenByDescending(a => a.Ratings?.Votes ?? 0)
-                .Select(a => $"{a.ArtistMetadata.Value.Name} - {a.Title}");
-
-            var recentAlbumNames = allAlbums
-                .Where(a => a.ArtistMetadata?.Value?.Name != null && a.Title != null)
-                .OrderByDescending(a => a.Added)
-                .Select(a => $"{a.ArtistMetadata.Value.Name} - {a.Title}");
-
-            // Interleave top-rated and recent to maximize coverage
-            using (var topEnum = topRatedAlbums.GetEnumerator())
-            using (var recentEnum = recentAlbumNames.GetEnumerator())
+            var tierRatio = settings.SamplingStrategy switch
             {
-                bool hasTop = true, hasRecent = true;
-                while ((hasTop = topEnum.MoveNext()) | (hasRecent = recentEnum.MoveNext()))
+                SamplingStrategy.Minimal => MinimalRatio,
+                SamplingStrategy.Balanced => BalancedRatio,
+                _ => ComprehensiveRatio
+            };
+
+            var tierBudget = (int)Math.Max(MinimalPromptFloor * tierRatio, Math.Floor(promptBudget * tierRatio));
+            tierBudget = Math.Min(promptBudget, Math.Max(MinimalPromptFloor, tierBudget));
+
+            return new PromptBudget
+            {
+                ContextTokens = contextTokens,
+                PromptTokens = promptBudget,
+                TierBudget = tierBudget,
+                ModelKey = modelInfo.ModelKey,
+                RawModelId = modelInfo.RawModelId
+            };
+        }
+
+        private ModelContextInfo ResolveModelContext(BrainarrSettings settings)
+        {
+            var providerSlug = MapProviderToRegistrySlug(settings.Provider);
+            if (providerSlug == null)
+            {
+                return new ModelContextInfo();
+            }
+
+            var rawModelId = ResolveRawModelId(settings.Provider, settings);
+            if (string.IsNullOrWhiteSpace(rawModelId))
+            {
+                return new ModelContextInfo { ModelKey = providerSlug + ":default", RawModelId = rawModelId ?? string.Empty };
+            }
+
+            var key = BuildModelCacheKey(providerSlug, rawModelId);
+            if (_modelContextCache.Value.TryGetValue(key, out var info))
+            {
+                return info with { RawModelId = rawModelId };
+            }
+
+            return new ModelContextInfo
+            {
+                ContextTokens = 0,
+                ModelKey = key,
+                RawModelId = rawModelId
+            };
+        }
+
+        private string ResolveRawModelId(AIProvider provider, BrainarrSettings settings)
+        {
+            if (!string.IsNullOrWhiteSpace(settings.ManualModelId))
+            {
+                return settings.ManualModelId.Trim();
+            }
+
+            var friendly = settings.ModelSelection;
+            var normalized = ProviderModelNormalizer.Normalize(provider, friendly);
+            var providerSlug = MapProviderToRegistrySlug(provider);
+            if (string.IsNullOrEmpty(providerSlug))
+            {
+                return normalized;
+            }
+
+            try
+            {
+                return ModelIdMapper.ToRawId(providerSlug, normalized);
+            }
+            catch
+            {
+                return normalized;
+            }
+        }
+
+        private static string BuildModelCacheKey(string providerSlug, string rawModelId)
+        {
+            return ($"{providerSlug}:{rawModelId}").ToLowerInvariant();
+        }
+
+        private static string? MapProviderToRegistrySlug(AIProvider provider)
+        {
+            return provider switch
+            {
+                AIProvider.OpenAI => "openai",
+                AIProvider.Perplexity => "perplexity",
+                AIProvider.Anthropic => "anthropic",
+                AIProvider.OpenRouter => "openrouter",
+                AIProvider.DeepSeek => "deepseek",
+                AIProvider.Gemini => "gemini",
+                AIProvider.Groq => "groq",
+                AIProvider.Ollama => "ollama",
+                AIProvider.LMStudio => "lmstudio",
+                _ => null
+            };
+        }
+        private int ComputeSamplingSeed(
+            LibraryProfile profile,
+            List<Artist> artists,
+            List<Album> albums,
+            StyleSelectionContext selection,
+            BrainarrSettings settings)
+        {
+            var hasher = new HashCode();
+            hasher.Add(profile?.TotalArtists ?? 0);
+            hasher.Add(profile?.TotalAlbums ?? 0);
+            hasher.Add((int)settings.DiscoveryMode);
+            hasher.Add((int)settings.SamplingStrategy);
+
+            if (selection.SelectedSlugs != null)
+            {
+                foreach (var slug in selection.SelectedSlugs.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
                 {
-                    if (hasTop && !albumCandidates.Contains(topEnum.Current)) albumCandidates.Add(topEnum.Current);
-                    if (hasRecent && !albumCandidates.Contains(recentEnum.Current)) albumCandidates.Add(recentEnum.Current);
-                    if (albumCandidates.Count > 5000) break; // safety guard
+                    hasher.Add(slug);
                 }
             }
 
-            foreach (var album in albumCandidates)
+            foreach (var id in artists.Select(a => a.Id).OrderBy(id => id).Take(24))
             {
-                var albumTokens = EstimateTokens(album);
-                if (usedTokens + albumTokens > tokenBudget) break;
-                sample.Albums.Add(album);
-                usedTokens += albumTokens;
+                hasher.Add(id);
             }
 
-            _logger.Debug($"Token-constrained sampling: {sample.Artists.Count} artists, " +
-                         $"{sample.Albums.Count} albums, estimated {usedTokens} tokens");
+            foreach (var id in albums.Select(a => a.Id).OrderBy(id => id).Take(24))
+            {
+                hasher.Add(id);
+            }
+
+            return hasher.ToHashCode();
+        }
+        private StyleSelectionContext BuildStyleSelection(
+            LibraryProfile profile,
+            BrainarrSettings settings,
+            LibraryPromptResult metrics)
+        {
+            var coverage = profile?.StyleContext?.StyleCoverage ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var normalized = _styleCatalog.Normalize(settings.StyleFilters ?? Array.Empty<string>());
+            var trimmed = new List<string>();
+
+            if (normalized.Count > settings.MaxSelectedStyles)
+            {
+                var ordered = normalized
+                    .OrderByDescending(slug => coverage.TryGetValue(slug, out var count) ? count : 0)
+                    .ThenBy(slug => slug, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                var keep = ordered.Take(settings.MaxSelectedStyles).ToHashSet(StringComparer.OrdinalIgnoreCase);
+                trimmed = ordered.Skip(settings.MaxSelectedStyles).ToList();
+                normalized = keep;
+            }
+
+            var inferred = new List<string>();
+            if (normalized.Count == 0 && settings.DiscoveryMode == DiscoveryMode.Similar)
+            {
+                var dominant = profile?.StyleContext?.DominantStyles ?? new List<string>();
+                foreach (var slug in dominant)
+                {
+                    if (inferred.Count >= settings.MaxSelectedStyles) break;
+                    if (string.IsNullOrWhiteSpace(slug)) continue;
+                    inferred.Add(slug);
+                }
+
+                if (inferred.Count > 0)
+                {
+                    normalized = inferred.ToHashSet(StringComparer.OrdinalIgnoreCase);
+                }
+            }
+
+            var entries = normalized
+                .Select(slug => _styleCatalog.GetBySlug(slug) ?? new StyleEntry { Name = slug, Slug = slug })
+                .ToList();
+
+            var relaxed = settings.RelaxStyleMatching;
+            var threshold = relaxed ? RelaxedMatchThreshold : 1.0;
+
+            var expanded = new HashSet<string>(normalized, StringComparer.OrdinalIgnoreCase);
+            var adjacent = new List<StyleEntry>();
+
+            if (relaxed)
+            {
+                foreach (var slug in normalized)
+                {
+                    foreach (var similar in _styleCatalog.GetSimilarSlugs(slug))
+                    {
+                        if (similar.Score < threshold) continue;
+                        if (normalized.Contains(similar.Slug)) continue;
+
+                        if (expanded.Add(similar.Slug))
+                        {
+                            var entry = _styleCatalog.GetBySlug(similar.Slug);
+                            if (entry != null)
+                            {
+                                adjacent.Add(entry);
+                            }
+                        }
+                    }
+                }
+            }
+
+            var selection = new StyleSelectionContext(
+                normalized,
+                expanded,
+                entries,
+                adjacent,
+                coverage,
+                relaxed,
+                threshold,
+                trimmed,
+                inferred);
+
+            metrics.AppliedStyleSlugs = selection.SelectedSlugs.ToList();
+            metrics.AppliedStyleNames = selection.Entries.Select(e => e.Name).ToList();
+            metrics.TrimmedStyles = trimmed;
+            metrics.InferredStyleSlugs = inferred;
+            metrics.RelaxedStyleMatching = relaxed;
+            metrics.StyleCoverage = new Dictionary<string, int>(coverage, StringComparer.OrdinalIgnoreCase);
+
+            if (selection.HasStyles)
+            {
+                var totalCoverage = selection.SelectedSlugs.Sum(slug => coverage.TryGetValue(slug, out var count) ? count : 0);
+                if (totalCoverage < SparseStyleArtistThreshold)
+                {
+                    selection.Sparse = true;
+                }
+            }
+
+            return selection;
+        }
+        private LibrarySample BuildLibrarySample(
+            List<Artist> allArtists,
+            List<Album> allAlbums,
+            LibraryStyleContext styleContext,
+            StyleSelectionContext selection,
+            BrainarrSettings settings,
+            int tokenBudget,
+            int seed,
+            LibraryPromptResult metrics)
+        {
+            var rng = new Random(seed);
+            var sample = new LibrarySample();
+
+            var artistMatches = BuildArtistMatchList(allArtists, styleContext, selection);
+            if (selection.HasStyles && artistMatches.Count < SparseStyleArtistThreshold)
+            {
+                selection.Sparse = true;
+                var extras = allArtists
+                    .Where(a => artistMatches.All(m => m.Artist.Id != a.Id))
+                    .Select(a => new ArtistMatch(a, new HashSet<string>(StringComparer.OrdinalIgnoreCase), 0.0));
+                artistMatches.AddRange(extras);
+            }
+
+            var targetArtistCount = DetermineTargetArtistCount(allArtists.Count, tokenBudget);
+            var artistSamples = SampleArtists(
+                artistMatches,
+                allAlbums,
+                selection,
+                settings.DiscoveryMode,
+                targetArtistCount,
+                rng);
+            sample.Artists.AddRange(artistSamples);
+            metrics.SampledArtists = sample.ArtistCount;
+
+            var albumMatches = BuildAlbumMatchList(allAlbums, styleContext, selection);
+            if (selection.HasStyles && albumMatches.Count < SparseStyleArtistThreshold)
+            {
+                selection.Sparse = true;
+                var extras = allAlbums
+                    .Where(a => albumMatches.All(m => m.Album.Id != a.Id))
+                    .Select(a => new AlbumMatch(a, new HashSet<string>(StringComparer.OrdinalIgnoreCase), 0.0));
+                albumMatches.AddRange(extras);
+            }
+
+            var targetAlbumCount = DetermineTargetAlbumCount(allAlbums.Count, tokenBudget);
+            var albumSamples = SampleAlbums(
+                albumMatches,
+                selection,
+                settings.DiscoveryMode,
+                targetAlbumCount,
+                rng);
+            sample.Albums.AddRange(albumSamples);
+            metrics.SampledAlbums = sample.AlbumCount;
+
+            var artistIndex = sample.Artists.ToDictionary(a => a.ArtistId);
+            foreach (var album in albumSamples)
+            {
+                if (artistIndex.TryGetValue(album.ArtistId, out var artist))
+                {
+                    artist.Albums.Add(album);
+                }
+                else
+                {
+                    var synthetic = new LibrarySampleArtist
+                    {
+                        ArtistId = album.ArtistId,
+                        Name = album.ArtistName,
+                        MatchedStyles = new HashSet<string>(album.MatchedStyles, StringComparer.OrdinalIgnoreCase),
+                        MatchScore = album.MatchScore,
+                        Added = album.Added,
+                        Weight = 0.25
+                    };
+                    synthetic.Albums.Add(album);
+                    sample.Artists.Add(synthetic);
+                    artistIndex[synthetic.ArtistId] = synthetic;
+                }
+            }
 
             return sample;
         }
-
-        private string BuildPromptWithLibraryContext(LibraryProfile profile, LibrarySample sample, BrainarrSettings settings, bool shouldRecommendArtists = false)
+        private List<ArtistMatch> BuildArtistMatchList(List<Artist> artists, LibraryStyleContext context, StyleSelectionContext selection)
         {
-            var promptBuilder = new StringBuilder();
+            var matches = new List<ArtistMatch>(artists.Count);
 
-            // Add sampling strategy context preamble
-            var strategyPreamble = GetSamplingStrategyPreamble(settings.SamplingStrategy);
-            if (!string.IsNullOrEmpty(strategyPreamble))
+            foreach (var artist in artists)
             {
-                promptBuilder.AppendLine(strategyPreamble);
-                promptBuilder.AppendLine();
-                // Clarify sample nature to reduce duplicates on large libraries
-                promptBuilder.AppendLine("Note: The above lists are a SAMPLE of a much larger library; treat them as representative of all existing items and avoid duplicates even if not explicitly listed.");
-            }
+                var slugs = context.ArtistStyles.TryGetValue(artist.Id, out var set)
+                    ? new HashSet<string>(set, StringComparer.OrdinalIgnoreCase)
+                    : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            // Use discovery mode-specific prompt template
-            var modeTemplate = GetDiscoveryModeTemplate(settings.DiscoveryMode, settings.MaxRecommendations, shouldRecommendArtists);
-            promptBuilder.AppendLine(modeTemplate);
-            promptBuilder.AppendLine();
-
-            // Enhanced library overview with metadata
-            promptBuilder.AppendLine($"📊 COLLECTION OVERVIEW:");
-            promptBuilder.AppendLine(BuildEnhancedCollectionContext(profile));
-            promptBuilder.AppendLine();
-
-            // Musical preferences from metadata
-            promptBuilder.AppendLine($"🎵 MUSICAL DNA:");
-            promptBuilder.AppendLine(BuildMusicalDnaContext(profile));
-            promptBuilder.AppendLine();
-
-            // Collection patterns from metadata
-            if (profile.Metadata != null && profile.Metadata.Any())
-            {
-                promptBuilder.AppendLine($"📈 COLLECTION PATTERNS:");
-                promptBuilder.AppendLine(BuildCollectionPatterns(profile));
-                promptBuilder.AppendLine();
-            }
-
-            // Existing artists (for context and avoidance)
-            if (sample.Artists.Any())
-            {
-                promptBuilder.AppendLine($"🎶 LIBRARY ARTISTS ({sample.Artists.Count} sampled):");
-                promptBuilder.AppendLine(string.Join(", ", sample.Artists));
-                promptBuilder.AppendLine();
-            }
-
-            // Existing albums (to avoid duplicates)
-            if (sample.Albums.Any())
-            {
-                promptBuilder.AppendLine($"💿 Library Albums ({sample.Albums.Count} shown) - DO NOT RECOMMEND THESE:");
-
-                // Group albums to save space
-                var albumChunks = sample.Albums
-                    .Select((album, index) => new { album, index })
-                    .GroupBy(x => x.index / 5)
-                    .Select(g => string.Join(", ", g.Select(x => x.album)));
-
-                foreach (var chunk in albumChunks)
+                if (!selection.HasStyles)
                 {
-                    promptBuilder.AppendLine($"• {chunk}");
+                    matches.Add(new ArtistMatch(artist, slugs, slugs.Count > 0 ? 1.0 : 0.0));
+                    continue;
                 }
-                promptBuilder.AppendLine();
+
+                if (TryMatchStyles(slugs, selection, out var matched, out var score))
+                {
+                    selection.RegisterMatch(matched);
+                    matches.Add(new ArtistMatch(artist, matched, score));
+                }
             }
 
-            // Enhanced instructions with metadata context
-            promptBuilder.AppendLine("🎯 RECOMMENDATION REQUIREMENTS:");
-
-            if (shouldRecommendArtists)
-            {
-                promptBuilder.AppendLine($"1. DO NOT recommend any artists from the library shown above");
-                promptBuilder.AppendLine($"2. Return EXACTLY {settings.MaxRecommendations} NEW ARTIST recommendations as JSON");
-                promptBuilder.AppendLine($"3. Each must have: artist, genre, confidence (0.0-1.0), reason");
-                promptBuilder.AppendLine($"4. Focus on ARTISTS (not specific albums) - Lidarr will import all their albums");
-                promptBuilder.AppendLine($"5. Prefer studio album artists over live/compilation specialists");
-            }
-            else
-            {
-                promptBuilder.AppendLine($"1. DO NOT recommend any albums from the library shown above");
-                promptBuilder.AppendLine($"2. Return EXACTLY {settings.MaxRecommendations} specific album recommendations as JSON");
-                promptBuilder.AppendLine($"3. Each must have: artist, album, genre, year, confidence (0.0-1.0), reason");
-                promptBuilder.AppendLine($"4. Prefer studio albums over live/compilation versions");
-            }
-
-            promptBuilder.AppendLine($"6. Match the collection's {GetCollectionCharacter(profile)} character");
-            promptBuilder.AppendLine($"7. Align with {GetTemporalPreference(profile)} preferences");
-            promptBuilder.AppendLine($"8. Consider {GetDiscoveryTrend(profile)} discovery pattern");
-            promptBuilder.AppendLine();
-
-            promptBuilder.AppendLine("JSON Response Format:");
-            promptBuilder.AppendLine("[");
-            promptBuilder.AppendLine("  {");
-            promptBuilder.AppendLine("    \"artist\": \"Artist Name\",");
-
-            if (!shouldRecommendArtists)
-            {
-                promptBuilder.AppendLine("    \"album\": \"Album Title\",");
-                promptBuilder.AppendLine("    \"year\": 2024,");
-            }
-
-            promptBuilder.AppendLine("    \"genre\": \"Primary Genre\",");
-            promptBuilder.AppendLine("    \"confidence\": 0.85,");
-
-            if (shouldRecommendArtists)
-            {
-                promptBuilder.AppendLine("    \"reason\": \"New artist that matches your collection's style - Lidarr will import all their albums\"");
-            }
-            else
-            {
-                promptBuilder.AppendLine("    \"reason\": \"Specific album that matches your collection's character and preferences\"");
-            }
-
-            promptBuilder.AppendLine("  }");
-            promptBuilder.AppendLine("]");
-
-            return promptBuilder.ToString();
+            return matches;
         }
 
+        private List<AlbumMatch> BuildAlbumMatchList(List<Album> albums, LibraryStyleContext context, StyleSelectionContext selection)
+        {
+            var matches = new List<AlbumMatch>(albums.Count);
+
+            foreach (var album in albums)
+            {
+                var slugs = context.AlbumStyles.TryGetValue(album.Id, out var set)
+                    ? new HashSet<string>(set, StringComparer.OrdinalIgnoreCase)
+                    : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                if (!selection.HasStyles)
+                {
+                    matches.Add(new AlbumMatch(album, slugs, slugs.Count > 0 ? 1.0 : 0.0));
+                    continue;
+                }
+
+                if (TryMatchStyles(slugs, selection, out var matched, out var score))
+                {
+                    selection.RegisterMatch(matched);
+                    matches.Add(new AlbumMatch(album, matched, score));
+                }
+            }
+
+            return matches;
+        }
+        private bool TryMatchStyles(HashSet<string> itemSlugs, StyleSelectionContext selection, out HashSet<string> matched, out double score)
+        {
+            matched = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            score = 0.0;
+
+            if (!selection.HasStyles)
+            {
+                return true;
+            }
+
+            if (itemSlugs == null || itemSlugs.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (var slug in itemSlugs)
+            {
+                if (selection.SelectedSlugs.Contains(slug))
+                {
+                    matched.Add(slug);
+                    score = Math.Max(score, 1.0);
+                    continue;
+                }
+
+                if (selection.Relaxed)
+                {
+                    foreach (var similar in _styleCatalog.GetSimilarSlugs(slug))
+                    {
+                        if (selection.SelectedSlugs.Contains(similar.Slug) && similar.Score >= selection.Threshold)
+                        {
+                            matched.Add(similar.Slug);
+                            score = Math.Max(score, similar.Score);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (matched.Count == 0)
+            {
+                return false;
+            }
+
+            if (!selection.Relaxed)
+            {
+                return true;
+            }
+
+            return score >= selection.Threshold;
+        }
+        private int DetermineTargetArtistCount(int totalArtists, int tokenBudget)
+        {
+            if (totalArtists <= 50)
+            {
+                return Math.Min(40, totalArtists);
+            }
+
+            if (totalArtists <= 200)
+            {
+                return Math.Min(60, Math.Max(30, totalArtists / 2));
+            }
+
+            return Math.Min(90, Math.Max(32, tokenBudget / 260));
+        }
+
+        private int DetermineTargetAlbumCount(int totalAlbums, int tokenBudget)
+        {
+            if (totalAlbums <= 120)
+            {
+                return Math.Min(100, totalAlbums);
+            }
+
+            if (totalAlbums <= 400)
+            {
+                return Math.Min(160, Math.Max(60, totalAlbums / 2));
+            }
+
+            return Math.Min(220, Math.Max(70, tokenBudget / 120));
+        }
+        private List<LibrarySampleArtist> SampleArtists(
+            List<ArtistMatch> matches,
+            List<Album> allAlbums,
+            StyleSelectionContext selection,
+            DiscoveryMode mode,
+            int targetCount,
+            Random rng)
+        {
+            var result = new List<LibrarySampleArtist>();
+            if (matches.Count == 0 || targetCount <= 0)
+            {
+                return result;
+            }
+
+            var albumCounts = allAlbums
+                .GroupBy(a => a.ArtistId)
+                .ToDictionary(g => g.Key, g => g.Count());
+
+            var used = new HashSet<int>();
+
+            void AddRange(IEnumerable<ArtistMatch> source)
+            {
+                foreach (var match in source)
+                {
+                    if (used.Contains(match.Artist.Id)) continue;
+                    var sampleArtist = CreateSampleArtist(match, albumCounts);
+                    result.Add(sampleArtist);
+                    used.Add(match.Artist.Id);
+                    if (result.Count >= targetCount) break;
+                }
+            }
+
+            var topPct = mode == DiscoveryMode.Similar ? 60 : mode == DiscoveryMode.Adjacent ? 45 : 35;
+            var recentPct = mode == DiscoveryMode.Similar ? 30 : mode == DiscoveryMode.Adjacent ? 35 : 35;
+            var randomPct = Math.Max(0, 100 - topPct - recentPct);
+
+            var topCount = Math.Max(1, targetCount * topPct / 100);
+            AddRange(matches
+                .OrderByDescending(m => m.Score)
+                .ThenByDescending(m => albumCounts.TryGetValue(m.Artist.Id, out var count) ? count : 0)
+                .ThenBy(m => m.Artist.Name, StringComparer.OrdinalIgnoreCase)
+                .Take(topCount));
+
+            if (result.Count < targetCount)
+            {
+                var recentCount = Math.Max(1, targetCount * recentPct / 100);
+                AddRange(matches
+                    .Where(m => !used.Contains(m.Artist.Id))
+                    .OrderByDescending(m => m.Artist.Added ?? DateTime.MinValue)
+                    .Take(recentCount));
+            }
+
+            if (result.Count < targetCount && randomPct > 0)
+            {
+                var remaining = matches.Where(m => !used.Contains(m.Artist.Id)).OrderBy(_ => rng.NextDouble());
+                AddRange(remaining.Take(Math.Max(0, targetCount - result.Count)));
+            }
+
+            return result;
+        }
+
+        private LibrarySampleArtist CreateSampleArtist(ArtistMatch match, Dictionary<int, int> albumCounts)
+        {
+            var count = albumCounts.TryGetValue(match.Artist.Id, out var albums) ? albums : 0;
+            var weight = ComputeArtistWeight(match.Artist, count, match.Score);
+
+            return new LibrarySampleArtist
+            {
+                ArtistId = match.Artist.Id,
+                Name = string.IsNullOrWhiteSpace(match.Artist.Name) ? $"Artist {match.Artist.Id}" : match.Artist.Name,
+                MatchedStyles = new HashSet<string>(match.MatchedStyles, StringComparer.OrdinalIgnoreCase),
+                MatchScore = match.Score,
+                Added = match.Artist.Added,
+                Weight = weight
+            };
+        }
+
+        private double ComputeArtistWeight(Artist artist, int albumCount, double matchScore)
+        {
+            var recency = artist.Added.HasValue
+                ? Math.Max(0.2, 12.0 / Math.Max(1.0, (DateTime.UtcNow - artist.Added.Value).TotalDays / 30.0))
+                : 0.5;
+            var depth = Math.Log(Math.Max(1, albumCount) + 1);
+            return (matchScore * 1.5) + recency + depth;
+        }
+        private List<LibrarySampleAlbum> SampleAlbums(
+            List<AlbumMatch> matches,
+            StyleSelectionContext selection,
+            DiscoveryMode mode,
+            int targetCount,
+            Random rng)
+        {
+            var result = new List<LibrarySampleAlbum>();
+            if (matches.Count == 0 || targetCount <= 0)
+            {
+                return result;
+            }
+
+            var used = new HashSet<int>();
+
+            void AddRange(IEnumerable<AlbumMatch> source)
+            {
+                foreach (var match in source)
+                {
+                    if (used.Contains(match.Album.Id)) continue;
+                    var sample = new LibrarySampleAlbum
+                    {
+                        AlbumId = match.Album.Id,
+                        ArtistId = match.Album.ArtistId,
+                        ArtistName = match.Album.ArtistMetadata?.Value?.Name ?? match.Album.Title ?? $"Artist {match.Album.ArtistId}",
+                        Title = string.IsNullOrWhiteSpace(match.Album.Title) ? $"Album {match.Album.Id}" : match.Album.Title,
+                        MatchedStyles = new HashSet<string>(match.MatchedStyles, StringComparer.OrdinalIgnoreCase),
+                        MatchScore = match.Score,
+                        Added = match.Album.Added,
+                        Year = match.Album.ReleaseDate?.Year
+                    };
+                    result.Add(sample);
+                    used.Add(match.Album.Id);
+                    if (result.Count >= targetCount) break;
+                }
+            }
+
+            var topPct = mode == DiscoveryMode.Similar ? 55 : mode == DiscoveryMode.Adjacent ? 45 : 35;
+            var recentPct = mode == DiscoveryMode.Similar ? 30 : mode == DiscoveryMode.Adjacent ? 35 : 40;
+            var randomPct = Math.Max(0, 100 - topPct - recentPct);
+
+            var topCount = Math.Max(1, targetCount * topPct / 100);
+            AddRange(matches
+                .OrderByDescending(m => m.Score)
+                .ThenByDescending(m => m.Album.Ratings?.Value ?? 0)
+                .ThenByDescending(m => m.Album.Ratings?.Votes ?? 0)
+                .ThenBy(m => m.Album.Title, StringComparer.OrdinalIgnoreCase)
+                .Take(topCount));
+
+            if (result.Count < targetCount)
+            {
+                var recentCount = Math.Max(1, targetCount * recentPct / 100);
+                AddRange(matches
+                    .Where(m => !used.Contains(m.Album.Id))
+                    .OrderByDescending(m => m.Album.Added ?? DateTime.MinValue)
+                    .Take(recentCount));
+            }
+
+            if (result.Count < targetCount && randomPct > 0)
+            {
+                var remaining = matches.Where(m => !used.Contains(m.Album.Id)).OrderBy(_ => rng.NextDouble());
+                AddRange(remaining.Take(Math.Max(0, targetCount - result.Count)));
+            }
+
+            return result;
+        }
+        private string ComputeSampleFingerprint(LibrarySample sample)
+        {
+            var sb = new StringBuilder();
+            foreach (var artist in sample.Artists.OrderBy(a => a.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                sb.Append(artist.Name).Append('|');
+                foreach (var album in artist.Albums.OrderBy(a => a.Title, StringComparer.OrdinalIgnoreCase))
+                {
+                    sb.Append(album.Title).Append(';');
+                }
+                sb.Append('#');
+            }
+
+            foreach (var album in sample.Albums
+                .OrderBy(a => a.ArtistName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(a => a.Title, StringComparer.OrdinalIgnoreCase))
+            {
+                sb.Append(album.ArtistName).Append('-').Append(album.Title).Append('|');
+            }
+
+            using var sha = SHA256.Create();
+            var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+            var hash = sha.ComputeHash(bytes);
+            return BitConverter.ToString(hash).Replace("-", string.Empty, StringComparison.Ordinal);
+        }
+        private sealed record ArtistMatch(Artist Artist, HashSet<string> MatchedStyles, double Score);
+        private sealed record AlbumMatch(Album Album, HashSet<string> MatchedStyles, double Score);
+
+        private sealed class StyleSelectionContext
+        {
+            public StyleSelectionContext(
+                HashSet<string> selected,
+                HashSet<string> expanded,
+                List<StyleEntry> entries,
+                List<StyleEntry> adjacent,
+                Dictionary<string, int> coverage,
+                bool relaxed,
+                double threshold,
+                List<string> trimmed,
+                List<string> inferred)
+            {
+                SelectedSlugs = selected;
+                ExpandedSlugs = expanded;
+                Entries = entries;
+                AdjacentEntries = adjacent;
+                Coverage = coverage;
+                Relaxed = relaxed;
+                Threshold = threshold;
+                TrimmedSlugs = trimmed;
+                InferredSlugs = inferred;
+            }
+
+            public HashSet<string> SelectedSlugs { get; }
+            public HashSet<string> ExpandedSlugs { get; }
+            public List<StyleEntry> Entries { get; }
+            public List<StyleEntry> AdjacentEntries { get; }
+            public Dictionary<string, int> Coverage { get; }
+            public bool Relaxed { get; }
+            public double Threshold { get; }
+            public List<string> TrimmedSlugs { get; }
+            public List<string> InferredSlugs { get; }
+            public Dictionary<string, int> MatchedCounts { get; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            public bool Sparse { get; set; }
+            public bool HasStyles => SelectedSlugs.Count > 0;
+
+            public void RegisterMatch(IEnumerable<string> slugs)
+            {
+                foreach (var slug in slugs)
+                {
+                    if (string.IsNullOrWhiteSpace(slug)) continue;
+                    MatchedCounts.TryGetValue(slug, out var count);
+                    MatchedCounts[slug] = count + 1;
+                }
+            }
+        }
+
+        private sealed record ModelContextInfo
+        {
+            public int ContextTokens { get; init; }
+            public string ModelKey { get; init; } = string.Empty;
+            public string RawModelId { get; init; } = string.Empty;
+        }
+
+        private sealed record PromptBudget
+        {
+            public int ContextTokens { get; init; }
+            public int PromptTokens { get; init; }
+            public int TierBudget { get; init; }
+            public string ModelKey { get; init; } = string.Empty;
+            public string RawModelId { get; init; } = string.Empty;
+        }
+        private Dictionary<string, ModelContextInfo> LoadModelContextCache()
+        {
+            var map = new Dictionary<string, ModelContextInfo>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                var json = _modelRegistryLoader.LoadRawJson();
+                using var doc = JsonDocument.Parse(json);
+
+                var root = doc.RootElement;
+                if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("providers", out var providersProperty))
+                {
+                    PopulateModelContext(map, providersProperty);
+                }
+                else
+                {
+                    PopulateModelContext(map, root);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, "Failed to load model registry context tokens; using defaults.");
+            }
+
+            return map;
+        }
+
+        private void PopulateModelContext(Dictionary<string, ModelContextInfo> map, JsonElement element)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Array:
+                    foreach (var providerElement in element.EnumerateArray())
+                    {
+                        var slug = ExtractProviderSlug(providerElement, null);
+                        if (string.IsNullOrWhiteSpace(slug)) continue;
+                        PopulateModelEntries(map, slug!, providerElement);
+                    }
+                    break;
+                case JsonValueKind.Object:
+                    foreach (var property in element.EnumerateObject())
+                    {
+                        var slug = ExtractProviderSlug(property.Value, property.Name);
+                        if (string.IsNullOrWhiteSpace(slug)) continue;
+                        PopulateModelEntries(map, slug!, property.Value);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private static void PopulateModelEntries(Dictionary<string, ModelContextInfo> map, string slug, JsonElement providerElement)
+        {
+            if (providerElement.ValueKind == JsonValueKind.Object && providerElement.TryGetProperty("models", out var modelsElement))
+            {
+                PopulateModelEntries(map, slug, modelsElement);
+                return;
+            }
+
+            if (providerElement.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var modelProperty in providerElement.EnumerateObject())
+                {
+                    var id = !string.IsNullOrWhiteSpace(modelProperty.Name) ? modelProperty.Name : null;
+                    if (string.IsNullOrWhiteSpace(id))
+                    {
+                        if (modelProperty.Value.ValueKind == JsonValueKind.Object &&
+                            modelProperty.Value.TryGetProperty("id", out var idElement) &&
+                            idElement.ValueKind == JsonValueKind.String)
+                        {
+                            id = idElement.GetString();
+                        }
+                    }
+
+                    if (string.IsNullOrWhiteSpace(id))
+                    {
+                        continue;
+                    }
+
+                    var contextTokens = ExtractContextTokens(modelProperty.Value);
+                    if (contextTokens <= 0)
+                    {
+                        continue;
+                    }
+
+                    var key = BuildModelCacheKey(slug, id);
+                    map[key] = new ModelContextInfo
+                    {
+                        ContextTokens = contextTokens,
+                        ModelKey = key,
+                        RawModelId = id
+                    };
+                }
+
+                return;
+            }
+
+            if (providerElement.ValueKind != JsonValueKind.Array)
+            {
+                return;
+            }
+
+            foreach (var modelElement in providerElement.EnumerateArray())
+            {
+                if (modelElement.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                if (!modelElement.TryGetProperty("id", out var idElement) || idElement.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+
+                var id = idElement.GetString();
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    continue;
+                }
+
+                var contextTokens = ExtractContextTokens(modelElement);
+                if (contextTokens <= 0)
+                {
+                    continue;
+                }
+
+                var key = BuildModelCacheKey(slug, id);
+                map[key] = new ModelContextInfo
+                {
+                    ContextTokens = contextTokens,
+                    ModelKey = key,
+                    RawModelId = id
+                };
+            }
+        }
+
+        private static string? ExtractProviderSlug(JsonElement providerElement, string? fallbackName)
+        {
+            if (providerElement.ValueKind == JsonValueKind.Object)
+            {
+                if (providerElement.TryGetProperty("slug", out var slugElement) && slugElement.ValueKind == JsonValueKind.String)
+                {
+                    var slug = slugElement.GetString();
+                    if (!string.IsNullOrWhiteSpace(slug))
+                    {
+                        return slug;
+                    }
+                }
+
+                if (providerElement.TryGetProperty("name", out var nameElement) && nameElement.ValueKind == JsonValueKind.String)
+                {
+                    var name = nameElement.GetString();
+                    if (!string.IsNullOrWhiteSpace(name))
+                    {
+                        return name.Trim().ToLowerInvariant().Replace(' ', '-');
+                    }
+                }
+            }
+
+            return string.IsNullOrWhiteSpace(fallbackName) ? null : fallbackName.Trim();
+        }
+
+        private static int ExtractContextTokens(JsonElement modelElement)
+        {
+            if (modelElement.ValueKind == JsonValueKind.Number)
+            {
+                if (modelElement.TryGetInt32(out var directInt))
+                {
+                    return directInt;
+                }
+
+                try
+                {
+                    var asDouble = modelElement.GetDouble();
+                    return (int)Math.Round(asDouble, MidpointRounding.AwayFromZero);
+                }
+                catch
+                {
+                    return 0;
+                }
+            }
+
+            if (modelElement.ValueKind == JsonValueKind.String)
+            {
+                var raw = modelElement.GetString();
+                if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var direct))
+                {
+                    return direct;
+                }
+            }
+
+            if (modelElement.TryGetProperty("context_tokens", out var contextElement))
+            {
+                if (contextElement.ValueKind == JsonValueKind.Number)
+                {
+                    if (contextElement.TryGetInt32(out var asInt))
+                    {
+                        return asInt;
+                    }
+
+                    try
+                    {
+                        var asDouble = contextElement.GetDouble();
+                        return (int)Math.Round(asDouble, MidpointRounding.AwayFromZero);
+                    }
+                    catch
+                    {
+                        return 0;
+                    }
+                }
+
+                if (contextElement.ValueKind == JsonValueKind.String)
+                {
+                    var raw = contextElement.GetString();
+                    if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+                    {
+                        return parsed;
+                    }
+                }
+            }
+
+            return 0;
+        }
         private string BuildFallbackPrompt(LibraryProfile profile, BrainarrSettings settings)
         {
-            // Fallback to original simple prompt if library-aware building fails
             return $@"Based on this music library, recommend {settings.MaxRecommendations} new albums to discover:
 
 Library: {profile.TotalArtists} artists, {profile.TotalAlbums} albums
@@ -497,42 +1109,38 @@ Example format:
             };
         }
 
-        private string GetDiscoveryModeTemplate(DiscoveryMode mode, int maxRecommendations, bool artists)
+        private string GetDiscoveryModeTemplate(DiscoveryMode mode, int maxRecommendations, bool artists, bool styleLocked)
         {
             var target = artists ? "artists" : "albums";
             return mode switch
             {
-                DiscoveryMode.Similar =>
-                        $@"You are a music connoisseur tasked with finding {maxRecommendations} {target} that perfectly match this user's established taste.
+                DiscoveryMode.Similar when styleLocked =>
+                    $@"You are a music connoisseur tasked with finding {maxRecommendations} {target} that sit inside the listener's existing style cluster.
+OBJECTIVE: Recommend {target} that have tangible ties to the user's current collection (collaborators, side projects, labelmates, shared producers, or historically linked acts).
+- Stay inside the listed styles unless explicitly told otherwise.
+- Highlight the concrete connection for every recommendation.
+- Avoid generic genre matches without specific adjacency.",
 
-OBJECTIVE: Recommend {target} from the EXACT SAME subgenres and styles already in the collection.
-- Look for artists frequently mentioned alongside their favorites
-- Match production styles, era, and sonic characteristics precisely
-- Prioritize artists who have collaborated with or influenced their collection
-- NO genre-hopping; stay within their comfort zone
-Example: If they love 80s synth-pop (Depeche Mode, New Order), recommend more 80s synth-pop, NOT modern synthwave or general electronic.",
+                DiscoveryMode.Similar =>
+                    $@"You are a music connoisseur tasked with finding {maxRecommendations} {target} that perfectly match this user's established taste.
+OBJECTIVE: Recommend {target} from the exact same subgenres and scenes already in the collection.
+- Look for artists frequently mentioned alongside their favourites.
+- Match production styles, era, and sonic characteristics precisely.
+- Prioritise artists who have collaborated with or influenced their collection.",
 
                 DiscoveryMode.Adjacent =>
                     $@"You are a music discovery expert helping expand this user's horizons into ADJACENT musical territories.
-
-OBJECTIVE: Recommend {maxRecommendations} {target} from related but unexplored genres.
-- Find the bridges between their current genres
-- Recommend fusion genres that combine their interests
-- Look for artists who started in their genres but evolved differently
-- Include ""gateway"" albums that ease the transition
-Example: If they love prog rock, suggest jazz fusion albums that prog fans typically enjoy (like Return to Forever or Mahavishnu Orchestra).",
+OBJECTIVE: Recommend {target} that bridge from their core collection into closely related scenes.
+- Use gateway releases that share personnel, labels, or stylistic DNA.
+- Explain why each recommendation is a comfortable stretch rather than a leap.",
 
                 DiscoveryMode.Exploratory =>
                     $@"You are a bold music curator introducing this user to completely NEW musical experiences.
+OBJECTIVE: Recommend {target} from genres outside their current collection but with a compelling reason to explore.
+- Provide accessible entry points into new styles.
+- Highlight cultural or historical relevance that might resonate with the listener.",
 
-OBJECTIVE: Recommend {maxRecommendations} {target} from genres OUTSIDE their current collection.
-- Choose critically acclaimed {target} from unexplored genres
-- Find ""entry points"" - accessible {target} in new genres
-- Consider opposites: If they're heavy on electronic, suggest acoustic
-- Include world music, experimental, or niche genres they've never tried
-Example: For a rock/metal fan, suggest Afrobeat (Fela Kuti), Bossa Nova (João Gilberto), or Ambient (Brian Eno).",
-
-                _ => $"Analyze this music library and recommend {maxRecommendations} NEW albums that would enhance the collection:"
+                _ => $"Analyze this music library and recommend {maxRecommendations} NEW {target} that would enhance the collection."
             };
         }
 
@@ -546,7 +1154,7 @@ Based on this limited information, provide broad recommendations that align with
 
                 SamplingStrategy.Comprehensive =>
                     @"CONTEXT SCOPE: You have been provided with a highly detailed and comprehensive analysis of the user's music library.
-Use ALL available details (genre distributions, collection patterns, temporal preferences, completionist behavior) to generate deeply personalized recommendations.",
+Use ALL available details (genre distributions, collection patterns, temporal preferences, completionist behaviour) to generate deeply personalised recommendations.",
 
                 SamplingStrategy.Balanced =>
                     @"CONTEXT SCOPE: You have been provided with a balanced overview of the user's library including key artists, genre preferences, and collection patterns.
@@ -555,33 +1163,6 @@ Use this information to provide well-informed recommendations that respect their
                 _ => string.Empty
             };
         }
-
-        private int GetTokenLimitForStrategy(SamplingStrategy strategy, AIProvider provider)
-        {
-            // Adjust token limits based on sampling strategy and provider capabilities
-            // Local providers can handle larger prompts on modern setups; scale conservatively
-            return (strategy, provider) switch
-            {
-                // Local providers: provide even more headroom (Qwen/Llama often handle 32–40k tokens)
-                (SamplingStrategy.Minimal, AIProvider.Ollama) => (int)(MINIMAL_TOKEN_LIMIT * 1.4),
-                (SamplingStrategy.Balanced, AIProvider.Ollama) => (int)(BALANCED_TOKEN_LIMIT * 1.6),
-                (SamplingStrategy.Comprehensive, AIProvider.Ollama) => (int)(COMPREHENSIVE_TOKEN_LIMIT * 2.0),
-
-                (SamplingStrategy.Minimal, AIProvider.LMStudio) => (int)(MINIMAL_TOKEN_LIMIT * 1.4),
-                (SamplingStrategy.Balanced, AIProvider.LMStudio) => (int)(BALANCED_TOKEN_LIMIT * 1.6),
-                (SamplingStrategy.Comprehensive, AIProvider.LMStudio) => (int)(COMPREHENSIVE_TOKEN_LIMIT * 2.0),
-
-                // Premium/balanced cloud providers
-                (SamplingStrategy.Minimal, _) => MINIMAL_TOKEN_LIMIT,
-                (SamplingStrategy.Balanced, _) => BALANCED_TOKEN_LIMIT,
-                (SamplingStrategy.Comprehensive, _) => COMPREHENSIVE_TOKEN_LIMIT,
-
-                _ => BALANCED_TOKEN_LIMIT
-            };
-        }
-
-        // Note: EstimateTokens exposed publicly via ILibraryAwarePromptBuilder.EstimateTokens
-
         private string BuildEnhancedCollectionContext(LibraryProfile profile)
         {
             var context = new StringBuilder();
@@ -596,37 +1177,47 @@ Use this information to provide well-informed recommendations that respect their
 
             context.AppendLine($"• Size: {collectionSize} ({profile.TotalArtists} artists, {profile.TotalAlbums} albums)");
 
-            // Enhanced genre display with distribution
-            if (profile.Metadata?.ContainsKey("GenreDistribution") == true)
+            if (profile.Metadata?.ContainsKey("GenreDistribution") == true &&
+                profile.Metadata["GenreDistribution"] is Dictionary<string, double> genreDistribution &&
+                genreDistribution.Any())
             {
-                var genreDistribution = profile.Metadata["GenreDistribution"] as Dictionary<string, double>;
-                if (genreDistribution?.Any() == true)
-                {
-                    var topGenres = string.Join(", ", genreDistribution.Take(5).Select(g => $"{g.Key} ({g.Value:F1}%)"));
-                    context.AppendLine($"• Genres: {topGenres}");
-                }
+                var topGenres = string.Join(", ", genreDistribution
+                    .Where(kv => !kv.Key.EndsWith("_significance", StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(kv => kv.Value)
+                    .Take(5)
+                    .Select(kv => $"{kv.Key} ({kv.Value:F1}%)"));
+                context.AppendLine($"• Genres: {topGenres}");
             }
             else
             {
                 context.AppendLine($"• Genres: {string.Join(", ", profile.TopGenres.Take(5).Select(g => g.Key))}");
             }
 
-            // Collection style and completionist behavior
             if (profile.Metadata?.ContainsKey("CollectionStyle") == true)
             {
-                var collectionStyle = profile.Metadata["CollectionStyle"].ToString();
-                var completionistScore = profile.Metadata?.ContainsKey("CompletionistScore") == true
-                    ? profile.Metadata["CompletionistScore"]
-                    : null;
-
-                context.AppendLine($"• Collection style: {collectionStyle}");
-                if (completionistScore != null && double.TryParse(completionistScore.ToString(), out var score))
+                var style = profile.Metadata["CollectionStyle"].ToString();
+                var completion = profile.Metadata?.ContainsKey("CompletionistScore") == true
+                    ? Convert.ToDouble(profile.Metadata["CompletionistScore"])
+                    : (double?)null;
+                if (completion.HasValue)
                 {
-                    context.AppendLine($"• Completionist score: {score:F1}% (avg {profile.Metadata?["AverageAlbumsPerArtist"]:F1} albums per artist)");
+                    context.AppendLine($"• Collection style: {style} (completionist score: {completion.Value:F1}%)");
+                }
+                else
+                {
+                    context.AppendLine($"• Collection style: {style}");
                 }
             }
+            else
+            {
+                context.AppendLine($"• Collection style: {collectionFocus}");
+            }
 
-            context.AppendLine($"• Collection type: {collectionFocus}");
+            if (profile.Metadata?.ContainsKey("AverageAlbumsPerArtist") == true)
+            {
+                var avg = Convert.ToDouble(profile.Metadata["AverageAlbumsPerArtist"]);
+                context.AppendLine($"• Collection depth: avg {avg:F1} albums per artist");
+            }
 
             return context.ToString().TrimEnd();
         }
@@ -635,38 +1226,22 @@ Use this information to provide well-informed recommendations that respect their
         {
             var context = new StringBuilder();
 
-            // Release decades
-            if (profile.Metadata?.ContainsKey("ReleaseDecades") == true)
+            if (profile.Metadata?.ContainsKey("PreferredEras") == true &&
+                profile.Metadata["PreferredEras"] is List<string> eras && eras.Any())
             {
-                var decades = profile.Metadata["ReleaseDecades"] as List<string>;
-                if (decades?.Any() == true)
-                {
-                    context.AppendLine($"• Era focus: {string.Join(", ", decades)}");
-                }
+                context.AppendLine($"• Era preference: {string.Join(", ", eras)}");
             }
 
-            // Preferred eras
-            if (profile.Metadata?.ContainsKey("PreferredEras") == true)
+            if (profile.Metadata?.ContainsKey("AlbumTypes") == true &&
+                profile.Metadata["AlbumTypes"] is Dictionary<string, int> albumTypes && albumTypes.Any())
             {
-                var eras = profile.Metadata["PreferredEras"] as List<string>;
-                if (eras?.Any() == true)
-                {
-                    context.AppendLine($"• Era preference: {string.Join(", ", eras)}");
-                }
+                var topTypes = string.Join(", ", albumTypes
+                    .OrderByDescending(kv => kv.Value)
+                    .Take(3)
+                    .Select(kv => $"{kv.Key} ({kv.Value})"));
+                context.AppendLine($"• Album types: {topTypes}");
             }
 
-            // Album types
-            if (profile.Metadata?.ContainsKey("AlbumTypes") == true)
-            {
-                var albumTypes = profile.Metadata["AlbumTypes"] as Dictionary<string, int>;
-                if (albumTypes?.Any() == true)
-                {
-                    var topTypes = string.Join(", ", albumTypes.Take(3).Select(t => $"{t.Key} ({t.Value})"));
-                    context.AppendLine($"• Album types: {topTypes}");
-                }
-            }
-
-            // New release interest
             if (profile.Metadata?.ContainsKey("NewReleaseRatio") == true)
             {
                 var ratio = Convert.ToDouble(profile.Metadata["NewReleaseRatio"]);
@@ -674,7 +1249,6 @@ Use this information to provide well-informed recommendations that respect their
                 context.AppendLine($"• New release interest: {interest} ({ratio:P0} recent)");
             }
 
-            // Recently added artists (steer towards up-to-date tastes)
             if (profile.RecentlyAdded != null && profile.RecentlyAdded.Any())
             {
                 var recent = string.Join(", ", profile.RecentlyAdded.Take(10));
@@ -688,13 +1262,11 @@ Use this information to provide well-informed recommendations that respect their
         {
             var context = new StringBuilder();
 
-            // Discovery trend
             if (profile.Metadata?.ContainsKey("DiscoveryTrend") == true)
             {
                 context.AppendLine($"• Discovery trend: {profile.Metadata["DiscoveryTrend"]}");
             }
 
-            // Collection quality
             if (profile.Metadata?.ContainsKey("CollectionCompleteness") == true)
             {
                 var completeness = Convert.ToDouble(profile.Metadata["CollectionCompleteness"]);
@@ -702,31 +1274,20 @@ Use this information to provide well-informed recommendations that respect their
                 context.AppendLine($"• Collection quality: {quality} ({completeness:P0} complete)");
             }
 
-            // Monitoring ratio
             if (profile.Metadata?.ContainsKey("MonitoredRatio") == true)
             {
                 var ratio = Convert.ToDouble(profile.Metadata["MonitoredRatio"]);
                 context.AppendLine($"• Active tracking: {ratio:P0} of collection");
             }
 
-            // Average depth
-            if (profile.Metadata?.ContainsKey("AverageAlbumsPerArtist") == true)
+            if (profile.Metadata?.ContainsKey("TopCollectedArtistNames") == true &&
+                profile.Metadata["TopCollectedArtistNames"] is Dictionary<string, int> nameCounts && nameCounts.Any())
             {
-                var avg = Convert.ToDouble(profile.Metadata["AverageAlbumsPerArtist"]);
-                context.AppendLine($"• Collection depth: {avg:F1} albums per artist");
-            }
-
-            // Top collected artists (names with counts) if available
-            if (profile.Metadata?.ContainsKey("TopCollectedArtistNames") == true)
-            {
-                if (profile.Metadata["TopCollectedArtistNames"] is Dictionary<string, int> nameCounts && nameCounts.Any())
-                {
-                    var line = string.Join(", ", nameCounts
-                        .OrderByDescending(kv => kv.Value)
-                        .Take(5)
-                        .Select(kv => $"{kv.Key} ({kv.Value})"));
-                    context.AppendLine($"• Top collected artists: {line}");
-                }
+                var line = string.Join(", ", nameCounts
+                    .OrderByDescending(kv => kv.Value)
+                    .Take(5)
+                    .Select(kv => $"{kv.Key} ({kv.Value})"));
+                context.AppendLine($"• Top collected artists: {line}");
             }
 
             return context.ToString().TrimEnd();
@@ -743,13 +1304,10 @@ Use this information to provide well-informed recommendations that respect their
 
         private string GetTemporalPreference(LibraryProfile profile)
         {
-            if (profile.Metadata?.ContainsKey("PreferredEras") == true)
+            if (profile.Metadata?.ContainsKey("PreferredEras") == true &&
+                profile.Metadata["PreferredEras"] is List<string> eras && eras.Any())
             {
-                var eras = profile.Metadata["PreferredEras"] as List<string>;
-                if (eras?.Any() == true)
-                {
-                    return string.Join("/", eras).ToLower();
-                }
+                return string.Join("/", eras).ToLowerInvariant();
             }
             return "mixed era";
         }
@@ -762,11 +1320,219 @@ Use this information to provide well-informed recommendations that respect their
             }
             return "steady";
         }
-    }
+        private sealed class PromptComposer
+        {
+            private readonly LibraryAwarePromptBuilder _parent;
+            private readonly LibraryProfile _profile;
+            private readonly LibrarySample _sample;
+            private readonly BrainarrSettings _settings;
+            private readonly StyleSelectionContext _styles;
+            private readonly bool _shouldRecommendArtists;
+            private readonly LibraryPromptResult _metrics;
 
-    public class LibrarySample
-    {
-        public List<string> Artists { get; set; } = new List<string>();
-        public List<string> Albums { get; set; } = new List<string>();
+            private int _maxArtists;
+            private int _maxAlbumGroups;
+            private int _maxAlbumsPerGroup = 5;
+            private bool _compressed;
+            private bool _trimmed;
+
+            public PromptComposer(
+                LibraryAwarePromptBuilder parent,
+                LibraryProfile profile,
+                LibrarySample sample,
+                BrainarrSettings settings,
+                StyleSelectionContext styles,
+                bool shouldRecommendArtists,
+                LibraryPromptResult metrics)
+            {
+                _parent = parent;
+                _profile = profile;
+                _sample = sample;
+                _settings = settings;
+                _styles = styles;
+                _shouldRecommendArtists = shouldRecommendArtists;
+                _metrics = metrics;
+
+                _maxArtists = Math.Max(1, sample.ArtistCount);
+                _maxAlbumGroups = Math.Max(1, sample.ArtistCount);
+            }
+
+            public bool Compressed => _compressed;
+            public bool Trimmed => _trimmed;
+
+            public string Render()
+            {
+                var builder = new StringBuilder();
+
+                var strategyPreamble = _parent.GetSamplingStrategyPreamble(_settings.SamplingStrategy);
+                if (!string.IsNullOrEmpty(strategyPreamble))
+                {
+                    builder.AppendLine(strategyPreamble);
+                    builder.AppendLine();
+                    builder.AppendLine("Note: Items below are representative samples of a much larger library; avoid recommending duplicates even if not explicitly listed.");
+                    builder.AppendLine();
+                }
+
+                builder.AppendLine(_parent.GetDiscoveryModeTemplate(_settings.DiscoveryMode, _settings.MaxRecommendations, _shouldRecommendArtists, _styles.HasStyles));
+                builder.AppendLine();
+
+                if (_styles.HasStyles)
+                {
+                    builder.AppendLine("🎨 STYLE FILTERS (library-aligned):");
+                    foreach (var entry in _styles.Entries)
+                    {
+                        var aliasText = entry.Aliases != null && entry.Aliases.Any()
+                            ? $" (aliases: {string.Join(", ", entry.Aliases.Take(5))})"
+                            : string.Empty;
+                        var coverage = _styles.Coverage.TryGetValue(entry.Slug, out var count) ? $" • coverage: {count}" : string.Empty;
+                        builder.AppendLine($"• {entry.Name}{aliasText}{coverage}");
+                    }
+                    if (_styles.AdjacentEntries.Any())
+                    {
+                        builder.AppendLine($"Adjacent context (only if needed): {string.Join(", ", _styles.AdjacentEntries.Select(a => a.Name))}");
+                    }
+                    if (_styles.Sparse)
+                    {
+                        builder.AppendLine("Sparse library coverage detected for these styles. Stay inside the cluster and prefer concrete connections (collaborators, side projects, shared labels).");
+                    }
+                    builder.AppendLine("Rule: Recommendations must live inside these styles and be grounded in the user's existing collection footprint.");
+                    builder.AppendLine();
+                }
+
+                builder.AppendLine("📊 COLLECTION OVERVIEW:");
+                builder.AppendLine(_parent.BuildEnhancedCollectionContext(_profile));
+                builder.AppendLine();
+
+                builder.AppendLine("🎵 MUSICAL DNA:");
+                builder.AppendLine(_parent.BuildMusicalDnaContext(_profile));
+                builder.AppendLine();
+
+                var patterns = _parent.BuildCollectionPatterns(_profile);
+                if (!string.IsNullOrEmpty(patterns))
+                {
+                    builder.AppendLine("📈 COLLECTION PATTERNS:");
+                    builder.AppendLine(patterns);
+                    builder.AppendLine();
+                }
+
+                var artistLines = BuildArtistGroups();
+                builder.AppendLine($"🎶 LIBRARY ARTISTS & KEY ALBUMS ({artistLines.Count} groups shown):");
+                foreach (var line in artistLines)
+                {
+                    builder.AppendLine(line);
+                }
+                builder.AppendLine();
+
+                builder.AppendLine("🎯 RECOMMENDATION REQUIREMENTS:");
+                if (_shouldRecommendArtists)
+                {
+                    builder.AppendLine("1. DO NOT recommend any artists already listed above (they represent a much larger library).");
+                    builder.AppendLine($"2. Return EXACTLY {_settings.MaxRecommendations} NEW ARTIST recommendations as JSON.");
+                    builder.AppendLine("3. Each entry must include: artist, genre, confidence (0.0-1.0), adjacency_source, reason.");
+                    builder.AppendLine("4. Focus on artists – Lidarr will import their releases.");
+                    builder.AppendLine("5. Highlight the concrete connection to the user's library (collaborations, side projects, shared producers, labelmates).");
+                }
+                else
+                {
+                    builder.AppendLine("1. DO NOT recommend any albums already listed above (treat the list as representative).");
+                    builder.AppendLine($"2. Return EXACTLY {_settings.MaxRecommendations} NEW ALBUM recommendations as JSON.");
+                    builder.AppendLine("3. Each entry must include: artist, album, genre, year, confidence (0.0-1.0), adjacency_source, reason.");
+                    builder.AppendLine("4. Prefer studio albums over live or compilation releases.");
+                }
+                builder.AppendLine("6. Keep every recommendation inside the style cluster defined above.");
+                builder.AppendLine($"7. Match the collection's {_parent.GetCollectionCharacter(_profile)} character.");
+                builder.AppendLine($"8. Align with {_parent.GetTemporalPreference(_profile)} temporal preferences.");
+                builder.AppendLine($"9. Consider {_parent.GetDiscoveryTrend(_profile)} discovery pattern.");
+                builder.AppendLine();
+
+                builder.AppendLine("JSON Response Format:");
+                builder.AppendLine("[");
+                builder.AppendLine("  {");
+                builder.AppendLine("    \"artist\": \"Artist Name\",");
+                if (!_shouldRecommendArtists)
+                {
+                    builder.AppendLine("    \"album\": \"Album Title\",");
+                    builder.AppendLine("    \"year\": 2024,");
+                }
+                builder.AppendLine("    \"genre\": \"Primary Genre\",");
+                builder.AppendLine("    \"confidence\": 0.85,");
+                builder.AppendLine("    \"adjacency_source\": \"Shared producer with <existing artist>\",");
+                builder.AppendLine("    \"reason\": \"Explain the concrete connection to the user's library\"");
+                builder.AppendLine("  }");
+                builder.AppendLine("]");
+
+                return builder.ToString();
+            }
+
+            public bool TryCompress()
+            {
+                if (_maxAlbumsPerGroup > 3)
+                {
+                    _maxAlbumsPerGroup--;
+                    _compressed = true;
+                    return true;
+                }
+
+                if (_maxAlbumGroups > Math.Min(12, _sample.Artists.Count))
+                {
+                    _maxAlbumGroups = Math.Max(Math.Min(12, _sample.Artists.Count), _maxAlbumGroups - 3);
+                    _compressed = true;
+                    _trimmed = true;
+                    return true;
+                }
+
+                if (_maxArtists > Math.Min(15, _sample.Artists.Count))
+                {
+                    _maxArtists = Math.Max(Math.Min(15, _sample.Artists.Count), _maxArtists - 3);
+                    _compressed = true;
+                    _trimmed = true;
+                    return true;
+                }
+
+                return false;
+            }
+
+            private List<string> BuildArtistGroups()
+            {
+                var lines = new List<string>();
+                var ordered = _sample.Artists
+                    .OrderByDescending(a => a.Weight)
+                    .ThenBy(a => a.Name, StringComparer.OrdinalIgnoreCase)
+                    .Take(_maxArtists)
+                    .ToList();
+
+                foreach (var artist in ordered)
+                {
+                    var albums = artist.Albums
+                        .OrderByDescending(a => a.Added ?? DateTime.MinValue)
+                        .ThenBy(a => a.Title, StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+                    var line = new StringBuilder();
+                    var styleText = artist.MatchedStyles.Count > 0 ? $" [{string.Join("/", artist.MatchedStyles)}]" : string.Empty;
+                    line.Append("• ").Append(artist.Name).Append(styleText);
+                    line.Append(BuildAlbumText(albums));
+                    lines.Add(line.ToString());
+                }
+
+                if (lines.Count > _maxAlbumGroups)
+                {
+                    lines = lines.Take(_maxAlbumGroups).ToList();
+                }
+
+                return lines;
+            }
+
+            private string BuildAlbumText(List<LibrarySampleAlbum> albums)
+            {
+                if (albums.Count == 0) return string.Empty;
+
+                var slice = albums
+                    .Take(_maxAlbumsPerGroup)
+                    .Select(a => a.Year.HasValue ? $"{a.Title} ({a.Year.Value})" : a.Title);
+                var more = albums.Count - _maxAlbumsPerGroup;
+                var suffix = more > 0 ? $"; +{more} more" : string.Empty;
+                return $" — [{string.Join("; ", slice)}{suffix}]";
+            }
+        }
     }
 }

--- a/Brainarr.Plugin/Services/Tokenization/ITokenizer.cs
+++ b/Brainarr.Plugin/Services/Tokenization/ITokenizer.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Services.Tokenization
+{
+    public interface ITokenizer
+    {
+        int CountTokens(string text);
+    }
+
+    public interface ITokenizerRegistry
+    {
+        ITokenizer Get(string? modelKey);
+    }
+
+    internal sealed class BasicTokenizer : ITokenizer
+    {
+        private static readonly Regex TokenRegex = new Regex(@"\w+|\S", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        public int CountTokens(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return 0;
+            }
+
+            return TokenRegex.Matches(text).Count;
+        }
+    }
+
+    public sealed class ModelTokenizerRegistry : ITokenizerRegistry
+    {
+        private readonly ConcurrentDictionary<string, ITokenizer> _tokenizers;
+        private readonly ITokenizer _defaultTokenizer;
+
+        public ModelTokenizerRegistry(IDictionary<string, ITokenizer>? overrides = null)
+        {
+            _defaultTokenizer = new BasicTokenizer();
+            _tokenizers = new ConcurrentDictionary<string, ITokenizer>(StringComparer.OrdinalIgnoreCase);
+
+            if (overrides != null)
+            {
+                foreach (var kvp in overrides)
+                {
+                    _tokenizers[kvp.Key] = kvp.Value ?? _defaultTokenizer;
+                }
+            }
+        }
+
+        public ITokenizer Get(string? modelKey)
+        {
+            if (string.IsNullOrWhiteSpace(modelKey))
+            {
+                return _defaultTokenizer;
+            }
+
+            if (_tokenizers.TryGetValue(modelKey, out var tokenizer))
+            {
+                return tokenizer;
+            }
+
+            var providerKey = modelKey.Split(':')[0];
+            if (_tokenizers.TryGetValue(providerKey, out tokenizer))
+            {
+                return tokenizer;
+            }
+
+            return _defaultTokenizer;
+        }
+    }
+}

--- a/Brainarr.Tests/BugFixes/DuplicateRecommendationFixTests.cs
+++ b/Brainarr.Tests/BugFixes/DuplicateRecommendationFixTests.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.ImportLists.Brainarr.Configuration;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.ImportLists.Brainarr.Services;
 using NzbDrone.Core.ImportLists.Brainarr.Services.Core;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Styles;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Music;
 using Xunit;
@@ -93,7 +94,8 @@ namespace Brainarr.Tests.BugFixes
             albumServiceMock.Setup(x => x.GetAllAlbums()).Returns(mockAlbums);
 
             // Create real LibraryAnalyzer
-            var libraryAnalyzer = new LibraryAnalyzer(artistServiceMock.Object, albumServiceMock.Object, _logger);
+            var styleCatalog = new Mock<IStyleCatalogService>();
+            var libraryAnalyzer = new LibraryAnalyzer(artistServiceMock.Object, albumServiceMock.Object, _logger, styleCatalog.Object);
 
             // Create mocks
             var providerFactoryMock = new Mock<IProviderFactory>();
@@ -143,7 +145,8 @@ namespace Brainarr.Tests.BugFixes
                 validatorMock.Object,
                 modelDetectionMock.Object,
                 httpClientMock.Object,
-                null); // Use default DuplicationPreventionService
+                null,
+                styleCatalog: styleCatalog.Object); // Use default DuplicationPreventionService
 
             var settings = new BrainarrSettings
             {

--- a/Brainarr.Tests/EdgeCases/ChaosMonkeyStressTests.cs
+++ b/Brainarr.Tests/EdgeCases/ChaosMonkeyStressTests.cs
@@ -9,6 +9,7 @@ using NLog;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Styles;
 using NzbDrone.Core.ImportLists.Brainarr.Services.Providers;
 using NzbDrone.Core.ImportLists.Brainarr.Services.Support;
 using static NzbDrone.Core.ImportLists.Brainarr.Services.Support.RecommendationHistory;
@@ -97,7 +98,8 @@ namespace Brainarr.Tests.EdgeCases
             artistServiceMock.Setup(x => x.GetAllArtists()).Returns(artists);
             albumServiceMock.Setup(x => x.GetAllAlbums()).Returns(albums);
 
-            var analyzer = new LibraryAnalyzer(artistServiceMock.Object, albumServiceMock.Object, _logger);
+            var styleCatalog = new Mock<IStyleCatalogService>();
+            var analyzer = new LibraryAnalyzer(artistServiceMock.Object, albumServiceMock.Object, _logger, styleCatalog.Object);
 
             // Act - Should complete within reasonable time
             var startTime = DateTime.UtcNow;
@@ -136,7 +138,8 @@ namespace Brainarr.Tests.EdgeCases
             artistServiceMock.Setup(x => x.GetAllArtists()).Returns(artists);
             albumServiceMock.Setup(x => x.GetAllAlbums()).Returns(albums);
 
-            var analyzer = new LibraryAnalyzer(artistServiceMock.Object, albumServiceMock.Object, _logger);
+            var styleCatalog2 = new Mock<IStyleCatalogService>();
+            var analyzer = new LibraryAnalyzer(artistServiceMock.Object, albumServiceMock.Object, _logger, styleCatalog2.Object);
 
             // Act - Should not throw exceptions
             Action act = () => analyzer.AnalyzeLibrary();
@@ -173,7 +176,8 @@ namespace Brainarr.Tests.EdgeCases
             artistServiceMock.Setup(x => x.GetAllArtists()).Returns(artists);
             albumServiceMock.Setup(x => x.GetAllAlbums()).Returns(albums);
 
-            var analyzer = new LibraryAnalyzer(artistServiceMock.Object, albumServiceMock.Object, _logger);
+            var styleCatalog3 = new Mock<IStyleCatalogService>();
+            var analyzer = new LibraryAnalyzer(artistServiceMock.Object, albumServiceMock.Object, _logger, styleCatalog3.Object);
 
             // Act - Should handle Unicode without breaking
             Action act = () => analyzer.AnalyzeLibrary();

--- a/Brainarr.Tests/Integration/EnhancedLibraryAnalysisTests.cs
+++ b/Brainarr.Tests/Integration/EnhancedLibraryAnalysisTests.cs
@@ -11,6 +11,9 @@ using NzbDrone.Core.ImportLists.Brainarr;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Registry;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Styles;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Tokenization;
 using NzbDrone.Core.Music;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Datastore;
@@ -21,6 +24,7 @@ namespace Brainarr.Tests.Integration
     {
         private readonly Mock<IArtistService> _artistService;
         private readonly Mock<IAlbumService> _albumService;
+        private readonly Mock<IStyleCatalogService> _styleCatalog;
         private readonly Logger _logger;
         private readonly LibraryAnalyzer _analyzer;
         private readonly LibraryAwarePromptBuilder _promptBuilder;
@@ -29,9 +33,10 @@ namespace Brainarr.Tests.Integration
         {
             _artistService = new Mock<IArtistService>();
             _albumService = new Mock<IAlbumService>();
+            _styleCatalog = new Mock<IStyleCatalogService>();
             _logger = TestLogger.CreateNullLogger();
-            _analyzer = new LibraryAnalyzer(_artistService.Object, _albumService.Object, _logger);
-            _promptBuilder = new LibraryAwarePromptBuilder(_logger);
+            _analyzer = new LibraryAnalyzer(_artistService.Object, _albumService.Object, _logger, _styleCatalog.Object);
+            _promptBuilder = new LibraryAwarePromptBuilder(_logger, _styleCatalog.Object, new ModelRegistryLoader(logger: _logger), new ModelTokenizerRegistry());
         }
 
         [Fact]

--- a/Brainarr.Tests/Services/Core/ArtistModeMbidsGateTests.cs
+++ b/Brainarr.Tests/Services/Core/ArtistModeMbidsGateTests.cs
@@ -10,6 +10,7 @@ using NzbDrone.Core.ImportLists.Brainarr;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Styles;
 using NzbDrone.Core.ImportLists.Brainarr.Services.Core;
 using NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment;
 using NzbDrone.Core.Music;
@@ -89,10 +90,11 @@ namespace Brainarr.Tests.Services.Core
                               return enriched;
                           });
 
+            var styleCatalog = new Mock<IStyleCatalogService>();
             var orchestrator = new BrainarrOrchestrator(
                 _logger,
                 providerFactory.Object,
-                new LibraryAnalyzer(artistService.Object, albumService.Object, _logger),
+                new LibraryAnalyzer(artistService.Object, albumService.Object, _logger, styleCatalog.Object),
                 cache.Object,
                 health.Object,
                 validator.Object,
@@ -100,7 +102,8 @@ namespace Brainarr.Tests.Services.Core
                 http.Object,
                 null,
                 null,
-                artistResolver.Object);
+                artistResolver.Object,
+                styleCatalog: styleCatalog.Object);
 
             var settings = new BrainarrSettings
             {

--- a/Brainarr.Tests/Services/Core/BrainarrOrchestratorTests.cs
+++ b/Brainarr.Tests/Services/Core/BrainarrOrchestratorTests.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.ImportLists.Brainarr.Services.Support;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Styles;
 using NzbDrone.Core.ImportLists.Brainarr;
 using AIProvider = NzbDrone.Core.ImportLists.Brainarr.AIProvider;
 using NzbDrone.Core.Parser.Model;
@@ -62,7 +63,8 @@ namespace Brainarr.Tests.Services.Core
                 .Returns<List<ImportListItemInfo>>(items => items);
 
             // Use REAL LibraryAnalyzer so it calls the mocked artist/album services
-            var libraryAnalyzer = new LibraryAnalyzer(_artistServiceMock.Object, _albumServiceMock.Object, _logger);
+            var styleCatalog = new Mock<IStyleCatalogService>();
+            var libraryAnalyzer = new LibraryAnalyzer(_artistServiceMock.Object, _albumServiceMock.Object, _logger, styleCatalog.Object);
 
             // Set up provider factory to return a mock provider with dynamic name based on settings
             providerFactoryMock.Setup(f => f.CreateProvider(It.IsAny<BrainarrSettings>(), It.IsAny<IHttpClient>(), It.IsAny<Logger>()))
@@ -123,7 +125,8 @@ namespace Brainarr.Tests.Services.Core
                 validatorMock.Object,
                 modelDetectionMock.Object,
                 _httpClientMock.Object,
-                null); // Use default DuplicationPreventionService instead of mock
+                null,
+                styleCatalog: styleCatalog.Object); // Use default DuplicationPreventionService instead of mock
         }
 
         [Fact]

--- a/Brainarr.Tests/Services/Core/BrainarrOrchestratorTopUpTests.cs
+++ b/Brainarr.Tests/Services/Core/BrainarrOrchestratorTopUpTests.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.ImportLists.Brainarr;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Styles;
 using NzbDrone.Core.ImportLists.Brainarr.Services.Core;
 using NzbDrone.Core.Music;
 using NzbDrone.Core.Parser.Model;
@@ -47,7 +48,8 @@ namespace Brainarr.Tests.Services.Core
             });
 
             // Real LibraryAnalyzer for duplicate filtering against mocks
-            var libraryAnalyzer = new LibraryAnalyzer(artistService.Object, albumService.Object, _logger);
+            var styleCatalog = new Mock<IStyleCatalogService>();
+            var libraryAnalyzer = new LibraryAnalyzer(artistService.Object, albumService.Object, _logger, styleCatalog.Object);
 
             // Cache miss
             cache.Setup(c => c.TryGet(It.IsAny<string>(), out It.Ref<List<ImportListItemInfo>>.IsAny))
@@ -94,7 +96,8 @@ namespace Brainarr.Tests.Services.Core
                 validator.Object,
                 modelDetection.Object,
                 http.Object,
-                null);
+                null,
+                styleCatalog: styleCatalog.Object);
 
             var settings = new BrainarrSettings
             {

--- a/Brainarr.Tests/Services/Core/EnhancedLibraryAnalyzerTests.cs
+++ b/Brainarr.Tests/Services/Core/EnhancedLibraryAnalyzerTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using NLog;
 using Brainarr.Tests.Helpers;
 using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Styles;
 using NzbDrone.Core.Music;
 using Xunit;
 
@@ -16,6 +17,7 @@ namespace Brainarr.Tests.Services.Core
     {
         private readonly Mock<IArtistService> _artistServiceMock;
         private readonly Mock<IAlbumService> _albumServiceMock;
+        private readonly Mock<IStyleCatalogService> _styleCatalog;
         private readonly Logger _logger;
         private readonly LibraryAnalyzer _analyzer;
 
@@ -23,8 +25,9 @@ namespace Brainarr.Tests.Services.Core
         {
             _artistServiceMock = new Mock<IArtistService>();
             _albumServiceMock = new Mock<IAlbumService>();
+            _styleCatalog = new Mock<IStyleCatalogService>();
             _logger = TestLogger.CreateNullLogger();
-            _analyzer = new LibraryAnalyzer(_artistServiceMock.Object, _albumServiceMock.Object, _logger);
+            _analyzer = new LibraryAnalyzer(_artistServiceMock.Object, _albumServiceMock.Object, _logger, _styleCatalog.Object);
         }
 
         [Fact]

--- a/Brainarr.Tests/Services/Core/LibraryAnalyzerTests.cs
+++ b/Brainarr.Tests/Services/Core/LibraryAnalyzerTests.cs
@@ -10,6 +10,7 @@ using NzbDrone.Core.ImportLists.Brainarr;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Styles;
 using NzbDrone.Core.Music;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Datastore;
@@ -20,6 +21,7 @@ namespace Brainarr.Tests.Services.Core
     {
         private readonly Mock<IArtistService> _artistService;
         private readonly Mock<IAlbumService> _albumService;
+        private readonly Mock<IStyleCatalogService> _styleCatalog;
         private readonly Logger _logger;
         private readonly LibraryAnalyzer _analyzer;
 
@@ -27,8 +29,9 @@ namespace Brainarr.Tests.Services.Core
         {
             _artistService = new Mock<IArtistService>();
             _albumService = new Mock<IAlbumService>();
+            _styleCatalog = new Mock<IStyleCatalogService>();
             _logger = TestLogger.CreateNullLogger();
-            _analyzer = new LibraryAnalyzer(_artistService.Object, _albumService.Object, _logger);
+            _analyzer = new LibraryAnalyzer(_artistService.Object, _albumService.Object, _logger, _styleCatalog.Object);
         }
 
         [Fact]

--- a/Brainarr.Tests/Services/SimpleEnhancedTests.cs
+++ b/Brainarr.Tests/Services/SimpleEnhancedTests.cs
@@ -7,6 +7,7 @@ using Brainarr.Tests.Helpers;
 using NzbDrone.Core.ImportLists.Brainarr;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Styles;
 using NzbDrone.Core.Music;
 using Xunit;
 
@@ -17,12 +18,14 @@ namespace Brainarr.Tests.Services
     {
         private readonly Mock<IArtistService> _artistServiceMock;
         private readonly Mock<IAlbumService> _albumServiceMock;
+        private readonly Mock<IStyleCatalogService> _styleCatalog;
         private readonly Logger _logger;
 
         public SimpleEnhancedTests()
         {
             _artistServiceMock = new Mock<IArtistService>();
             _albumServiceMock = new Mock<IAlbumService>();
+            _styleCatalog = new Mock<IStyleCatalogService>();
             _logger = TestLogger.CreateNullLogger();
         }
 
@@ -44,7 +47,7 @@ namespace Brainarr.Tests.Services
             _artistServiceMock.Setup(x => x.GetAllArtists()).Returns(artists);
             _albumServiceMock.Setup(x => x.GetAllAlbums()).Returns(albums);
 
-            var analyzer = new LibraryAnalyzer(_artistServiceMock.Object, _albumServiceMock.Object, _logger);
+            var analyzer = new LibraryAnalyzer(_artistServiceMock.Object, _albumServiceMock.Object, _logger, _styleCatalog.Object);
 
             // Act
             var profile = analyzer.AnalyzeLibrary();
@@ -141,7 +144,7 @@ namespace Brainarr.Tests.Services
             _artistServiceMock.Setup(x => x.GetAllArtists()).Returns(artists);
             _albumServiceMock.Setup(x => x.GetAllAlbums()).Returns(albums);
 
-            var analyzer = new LibraryAnalyzer(_artistServiceMock.Object, _albumServiceMock.Object, _logger);
+            var analyzer = new LibraryAnalyzer(_artistServiceMock.Object, _albumServiceMock.Object, _logger, _styleCatalog.Object);
 
             // Act
             var profile = analyzer.AnalyzeLibrary();

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -567,7 +567,8 @@ foreach (var (provider, info) in health)
 ### Library Analysis
 
 ```csharp
-var analyzer = new LibraryAnalyzer(artistService, albumService, logger);
+var styleCatalog = new StyleCatalogService(logger, httpClient);
+var analyzer = new LibraryAnalyzer(artistService, albumService, logger, styleCatalog);
 
 // Analyze library
 var profile = analyzer.AnalyzeLibrary();


### PR DESCRIPTION
## Summary
- add a `LibraryStyleContext` model so analyzer precomputes normalized style coverage for the library
- rework `LibraryAwarePromptBuilder` to enforce style-aware sampling, deterministic seeding, compression, and model-aware token budgeting while emitting richer metrics
- harden the style catalog service with locking, adjacency lookups, and helpers consumed by the new prompt builder
- extend metrics contracts and analyzer plumbing so downstream strategies receive matched style counts and sparse coverage flags

## Testing
- `dotnet build` *(fails: `command not found: dotnet` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7c016ff48331b8f57e8dc4735719