### PR TITLE
Adjust stable hash seed expectation

### DIFF
--- a/Brainarr.Plugin/Services/LibraryAwarePromptBuilder.cs
+++ b/Brainarr.Plugin/Services/LibraryAwarePromptBuilder.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Globalization;
+using System.Security.Cryptography;
 using Newtonsoft.Json;
 using NzbDrone.Core.Music;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
@@ -984,6 +986,16 @@ Use this information to provide well-informed recommendations that respect their
             }
 
             return context.ToString().TrimEnd();
+        }
+
+        internal static int ComputeStableHash(string value)
+        {
+            value ??= string.Empty;
+
+            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+            var rawSeed = BinaryPrimitives.ReadInt32LittleEndian(hash.AsSpan(0, sizeof(int)));
+
+            return rawSeed & int.MaxValue;
         }
 
         private string GetCollectionCharacter(LibraryProfile profile)

--- a/Brainarr.Tests/Services/LibraryAwarePromptBuilderTests.cs
+++ b/Brainarr.Tests/Services/LibraryAwarePromptBuilderTests.cs
@@ -150,5 +150,16 @@ namespace Brainarr.Tests.Services
             Assert.True(res.SampledArtists + res.SampledAlbums > 0);
             Assert.Contains("LIBRARY ARTISTS", res.Prompt);
         }
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        [Trait("Category", "PromptBuilder")]
+        public void ComputeStableHash_MasksHighBitToKeepSeedNonNegative()
+        {
+            var seed = LibraryAwarePromptBuilder.ComputeStableHash("hello");
+
+            Assert.Equal(978186796, seed);
+            Assert.InRange(seed, 0, int.MaxValue);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a stable hash helper on `LibraryAwarePromptBuilder` that masks the SHA-256 seed to 31 bits
- update the prompt builder tests to expect the non-negative seed value for "hello"

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0b39f96c8331afa3c246a597d3d8