### PR TITLE
docs: convert provider status callout to heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Brainarr is a local-first, multi-provider AI-powered import list plugin for Lida
 >
 > The plugin fails closed on unsupported Lidarr versions. If Brainarr does not appear after install, check **System → Logs** for `Brainarr: minVersion` messages and confirm Lidarr is tracking the `nightly` branch.
 >
-**Provider status**
+## Provider status
 
 - Latest release: **v1.2.7** (tagged)
 - Main branch: **v1.2.7** with nightly patches in progress


### PR DESCRIPTION
## Summary
- update the provider status callout in the README to use a proper heading instead of bold text

## Testing
- pre-commit run docs-markdownlint
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68d96d6cf92c833190db8981d67c0373