### PR TITLE
Ensure deterministic ordering for recent artist sampling

### DIFF
--- a/Brainarr.Plugin/Services/Prompting/LibraryPromptPlanner.cs
+++ b/Brainarr.Plugin/Services/Prompting/LibraryPromptPlanner.cs
@@ -744,6 +744,7 @@ public class LibraryPromptPlanner : IPromptPlanner
             AddRange(matches
                 .Where(m => !used.Contains(m.Artist.Id))
                 .OrderByDescending(m => DateUtil.NormalizeMin(m.Artist.Added))
+                .ThenBy(m => m.Artist.Id)
                 .Take(recentCount));
         }
 


### PR DESCRIPTION
## Summary
- ensure the SampleArtists recent bucket uses artist IDs as a deterministic tiebreaker

## Testing
- `dotnet test Brainarr.sln --filter "Category=Unit"` *(fails: missing Lidarr assemblies and FieldDefinition symbols in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d982735f888331b90366c5803d29ad