### PR TITLE
Ensure library sample fingerprint ordering is stable

### DIFF
--- a/Brainarr.Plugin/Services/Prompting/LibraryPromptPlanner.cs
+++ b/Brainarr.Plugin/Services/Prompting/LibraryPromptPlanner.cs
@@ -882,10 +882,14 @@ public class LibraryPromptPlanner : IPromptPlanner
     private string ComputeSampleFingerprint(LibrarySample sample)
     {
         var sb = new StringBuilder();
-        foreach (var artist in sample.Artists.OrderBy(a => a.Name, StringComparer.OrdinalIgnoreCase))
+        foreach (var artist in sample.Artists
+            .OrderBy(a => a.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(a => a.ArtistId))
         {
             sb.Append(artist.Name).Append('|');
-            foreach (var album in artist.Albums.OrderBy(a => a.Title, StringComparer.OrdinalIgnoreCase))
+            foreach (var album in artist.Albums
+                .OrderBy(a => a.Title, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(a => a.AlbumId))
             {
                 sb.Append(album.Title).Append(';');
             }
@@ -894,7 +898,8 @@ public class LibraryPromptPlanner : IPromptPlanner
 
         foreach (var album in sample.Albums
             .OrderBy(a => a.ArtistName, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(a => a.Title, StringComparer.OrdinalIgnoreCase))
+            .ThenBy(a => a.Title, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(a => a.AlbumId))
         {
             sb.Append(album.ArtistName).Append('-').Append(album.Title).Append('|');
         }


### PR DESCRIPTION
## Summary
- add deterministic secondary ordering to ComputeSampleFingerprint to include artist and album identifiers

## Testing
- dotnet test Brainarr.sln --filter "Category=Unit" *(fails: missing Lidarr assemblies and IHttpClient abstractions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d982747fb48331a27a6826da7c0281