### PR TITLE
Refresh technical docs and CI guidance for Brainarr

### DIFF
--- a/BUILD_REQUIREMENTS.md
+++ b/BUILD_REQUIREMENTS.md
@@ -17,23 +17,30 @@
 ### Option 1: Automated Setup (Recommended)
 
 ```powershell
-# Windows - This will clone and build real Lidarr
-.\setup-lidarr.ps1
+# Windows
+./setup.ps1
 
 # Linux/macOS
-chmod +x setup-lidarr.sh
-./setup-lidarr.sh
+chmod +x ./setup.sh
+./setup.sh
 ```
 
 ### Option 2: Manual Setup
 
-1. Clone Lidarr's plugin branch:
+1. Prefer Docker-based extraction of the plugins/nightly assemblies (no full source clone required):
+
+```bash
+bash ./scripts/extract-lidarr-assemblies.sh
+# Assemblies land in ext/Lidarr-docker/_output/net6.0/
+```
+
+2. Alternatively, clone Lidarr's plugins branch (advanced):
 
 ```bash
 git clone --branch plugins https://github.com/Lidarr/Lidarr.git ext/Lidarr
 ```
 
-1. Build Lidarr:
+3. Build Lidarr (only if cloning source):
 
 ```bash
 cd ext/Lidarr
@@ -42,14 +49,14 @@ dotnet build -c Release
 cd ../..
 ```
 
-1. Set environment variable:
+4. Set environment variable:
 
 ```bash
-# Find where Lidarr built to (usually _output/net6.0 or src/Lidarr/bin/Release/net6.0)
-export LIDARR_PATH=/path/to/lidarr/build/output
+# Prefer Docker output: ext/Lidarr-docker/_output/net6.0
+export LIDARR_PATH="$(pwd)/ext/Lidarr-docker/_output/net6.0"
 ```
 
-1. Now build Brainarr:
+5. Now build Brainarr:
 
 ```bash
 cd Brainarr.Plugin
@@ -68,14 +75,9 @@ This is intentional! We want compilation to fail fast rather than runtime failur
 
 ## CI/CD Integration
 
-Our GitHub Actions workflow automatically:
+Our GitHub Actions workflows extract real Lidarr assemblies from Docker image `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` into `ext/Lidarr-docker/_output/net6.0/`, then build Brainarr against those binaries and run tests. Jobs fail fast if assemblies are missing.
 
-1. Clones real Lidarr source
-1. Builds Lidarr
-1. Builds Brainarr against real Lidarr
-1. Runs integration tests with real types
-
-See `.github/workflows/build.yml` for the complete pipeline.
+See `.github/workflows/` (`plugin-package.yml`, `test-and-coverage.yml`, `sanity-build.yml`) for the pipelines.
 
 ## For Developers
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Out of the box Brainarr stays purely local through Ollama/LM Studio, including i
 
 Cloud integrations (OpenAI, Anthropic, Gemini, Perplexity, Groq, DeepSeek, OpenRouter) inherit the same guardrails: optional by design, API key redaction, and planner headroom enforcement. Provider availability and notes remain single-sourced via the generated [provider matrix](./docs/PROVIDER_MATRIX.md).
 
-Setup scripts (`setup.ps1` / `setup.sh`) fetch Lidarr nightly assemblies, build the plugin against real binaries, and keep `LIDARR_PATH` consistent. The [development docs](./docs/BUILD.md) describe how to bootstrap from scratch.
+Setup scripts (`setup.ps1` / `setup.sh`) fetch Lidarr nightly assemblies, build the plugin against real binaries, and keep `LIDARR_PATH` consistent. For a full bootstrap and local workflows, see [BUILD.md](./BUILD.md) and [DEVELOPMENT.md](./DEVELOPMENT.md).
 
 Documentation guardrails—`scripts/sync-provider-matrix.ps1`, `scripts/check-docs-consistency.ps1` / `scripts/check-docs-consistency.sh`, and markdown lint/link checks—keep README, docs, and wiki in sync. Contributors can follow the workflow outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).
 


### PR DESCRIPTION
## Summary
Refresh and standardize Brainarr’s technical documentation to reflect Docker-based Lidarr assemblies, updated build/bootstrap flows, and streamlined CI/CD notes. Includes updated plugin metadata references and clearer setup instructions.

## Changes
- BUILD.md
  - Prerequisites updated: .NET SDK 6.0+ (8.0 recommended) and real Lidarr assemblies.
  - Reworked Quick Build:
    - Added One-command setup using setup.ps1/setup.sh to bootstrap Lidarr assemblies into ext/Lidarr-docker/_output/net6.0 and set LIDARR_PATH.
    - Replaced older Option 2 with explicit LIDARR_PATH usage.
  - Docker/bootstrap paths clarified (default bootstrap output: ext/Lidarr-docker/_output/net6.0/; inside container: /app/bin).
  - Build, Package, and Deploy section updated to use build.ps1 / build.sh with -Test, -Package, -Deploy flows.
  - Troubleshooting guidance updated to .NET SDK 6.0+ (8.0 recommended) and Lidarr assemblies version note (nightly/plugins assemblies minimum 2.14.2.4786).
  - CI/CD Notes revised: CI compiles against Lidarr assemblies extracted from Docker image ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION} into ext/Lidarr-docker/_output/net6.0/; fast-fail if missing; see .github/workflows for sanity-build, plugin-package, test jobs.
- BUILD_REQUIREMENTS.md
  - Option 1/2 updated to reflect Docker-based extraction of Lidarr assemblies (no full source clone required).
  - Added scripts/extract-lidarr-assemblies.sh usage to land assemblies in ext/Lidarr-docker/_output/net6.0.
  - Steps now prefer Docker output and explicit LIDARR_PATH, with CI guidance pointing to workflows.
- DEVELOPMENT.md
  - Prerequisites updated: .NET SDK 6.0+ (8.0 recommended).
  - First-time setup instructions aligned to setup.ps1/setup.sh (no longer implying full source clone as default).
  - Updated plugin metadata snippet to Brainarr 1.3.0 with minimumVersion 2.14.2.4786; entryPoint remains Lidarr.Plugin.Brainarr.dll.
  - CI/CD Pipeline section rewritten: GitHub Actions extract Lidarr assemblies from Docker image ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION} into ext/Lidarr-docker/_output/net6.0/, build Brainarr against those binaries, run tests, and publish artifacts. See .github/workflows for details.
- README.md
  - Setup guidance line updated to reference BUILD.md and DEVELOPMENT.md for full bootstrap and local workflows.

> Note: These docs changes reflect a shift toward Docker-based assembly extraction for Lidarr, removing the need to clone Lidarr sources in CI/CD and providing clearer bootstrap and path guidance.

## Rationale
- Align documentation with the current Bootstrap workflow that uses Docker-hosted Lidarr assemblies, reducing setup friction and CI complexity.
- Improve accuracy of prerequisites, paths, and CLI options to minimize build-time surprises for contributors.
- Update plugin metadata references to reflect Brainarr’s current version and compatible Lidarr minimum version.

## Impact
- Documentation-only changes. No code changes.
- CI/CD references now rely on Docker-based assembly extraction, which may affect local setup expectations and CI runners that previously cloned Lidarr.

## How to test locally
1. On Windows: ./setup.ps1  | on macOS/Linux: ./setup.sh
2. Verify LIDARR_PATH is set to ext/Lidarr-docker/_output/net6.0 (or the appropriate Docker/bootstrap output).
3. Build Brainarr.Plugin: cd Brainarr.Plugin; dotnet build -c Release
4. Optionally run packaging or deploy flows:
   - Windows/macOS/Linux: ./build.ps1 -Test        # Build + test
   - ./build.ps1 -Package      # Build + package (tar.gz/zip)
   - ./build.ps1 -Deploy       # Deploy to local Lidarr plugins folder

## Test plan (CI)
- Validate that GitHub Actions workflows extract Lidarr assemblies from Docker (ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}) into ext/Lidarr-docker/_output/net6.0/ and build Brainarr against those binaries.
- Confirm tests run and release artifacts are published when appropriate.

## Reference
- Branch: terragon/update-docs-and-wiki-nmvaaa
- Updated files: BUILD.md, BUILD_REQUIREMENTS.md, DEVELOPMENT.md, README.md
- Plugin metadata example updated in DEVELOPMENT.md to Brainarr 1.3.0 with minimumVersion 2.14.2.4786.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b3ce831a-e84c-4a2c-9886-5d4189ba2fb7