### PR TITLE
docs(wiki): add Install via Lidarr UI flow to Home + Installation

### DIFF
--- a/wiki-content/Home.md
+++ b/wiki-content/Home.md
@@ -8,6 +8,17 @@ The canonical docs now live in the repository so we avoid duplicated truth.
 Latest release: **v1.3.1**
 Requires Lidarr 2.14.2.4786+ on the plugins/nightly branch.
 
+## Install via Lidarr UI (recommended)
+
+You can install Brainarr directly from Lidarr without downloading a ZIP:
+
+1. Ensure Lidarr is on the plugins/nightly branch and at least version 2.14.2.4786 (Settings > General > Updates > Branch = nightly).
+2. Go to Settings > Plugins.
+3. Click Add Plugin.
+4. Paste the repository URL: <https://github.com/RicherTunes/Brainarr>
+5. Click Install, then Restart when prompted.
+6. Go to Settings > Import Lists and add Brainarr.
+
 ## Provider compatibility
 
 <!-- GENERATED: scripts/sync-provider-matrix.ps1 -->

--- a/wiki-content/Installation.md
+++ b/wiki-content/Installation.md
@@ -1,10 +1,23 @@
 # Installation
 
-Installation instructions now live in the repository README so we only maintain one source of truth.
-
 Requires Lidarr 2.14.2.4786+ on the plugins/nightly branch.
 
-- Follow the [Quickstart](../README.md#quickstart) steps for installing Brainarr and validating the default local provider.
-- Review [docs/configuration.md](../docs/configuration.md) if you need to tune planner cache or switch providers.
+## Install via Lidarr UI (recommended)
 
-Update the docs first if anything changes, then keep this page as a pointer.
+You can install Brainarr directly from Lidarr without downloading a ZIP:
+
+1. Ensure Lidarr is on the plugins/nightly branch and at least version 2.14.2.4786 (Settings > General > Updates > Branch = nightly).
+2. Go to Settings > Plugins.
+3. Click Add Plugin.
+4. Paste the repository URL: <https://github.com/RicherTunes/Brainarr>
+5. Click Install, then Restart when prompted.
+6. Go to Settings > Import Lists and add Brainarr.
+
+## Manual install from Releases (alternative)
+
+If you prefer manual installation, follow the steps in the repository README:
+
+- [Installing from Releases](../README.md#installing-from-releases)
+- Then continue with the [Quickstart](../README.md#quickstart) to validate the default local provider.
+
+For configuration details (timeouts, providers, planner/cache), see [docs/configuration.md](../docs/configuration.md).


### PR DESCRIPTION
This brings the wiki in line with the README by documenting the recommended install path directly from Lidarr:

- Settings ▸ Plugins ▸ Add Plugin ▸ paste <https://github.com/RicherTunes/Brainarr>
- Install ▸ Restart ▸ Add import list

Manual install remains linked to the README section as an alternative.