### PR TITLE
docs(wiki): add synced banner + spacing across wiki pages (do not edit in Wiki UI)

### DIFF
--- a/wiki-content/Advanced-Settings.md
+++ b/wiki-content/Advanced-Settings.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Advanced Settings
 
 > Advanced options appear under **Import Lists → Brainarr → Advanced** (and the hidden section). Default values live in `Brainarr.Plugin/BrainarrSettings.cs`; unit tests in `Brainarr.Tests/Services/Prompting` pin expected behaviour. Treat those as the canonical source when adjusting settings or updating docs.

--- a/wiki-content/Cloud-Providers.md
+++ b/wiki-content/Cloud-Providers.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Cloud providers
 
 All cloud provider guidance now lives in the repo so it stays versioned with the code.

--- a/wiki-content/Documentation-Workflow.md
+++ b/wiki-content/Documentation-Workflow.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Documentation Workflow
 
 > Follow this checklist whenever you touch README/docs/wiki content so everything stays generated from the same inputs.

--- a/wiki-content/First-Run-Guide.md
+++ b/wiki-content/First-Run-Guide.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # 🚀 First Run Guide
 
 Get your first AI-powered music recommendations working perfectly. This guide walks through your initial setup, testing, and optimization.

--- a/wiki-content/Hallucination-Reduction.md
+++ b/wiki-content/Hallucination-Reduction.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # 🎯 Reducing Hallucinations (Local Models)
 
 Practical settings and prompts to keep LM Studio and Ollama recommendations grounded in real, existing albums.

--- a/wiki-content/Home.md
+++ b/wiki-content/Home.md
@@ -1,3 +1,6 @@
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Brainarr wiki home
 
 The canonical docs now live in the repository so we avoid duplicated truth.
@@ -37,3 +40,6 @@ You can install Brainarr directly from Lidarr without downloading a ZIP:
 <!-- PROVIDER_MATRIX_END -->
 
 If you need to expand a topic, update the repo docs first, then add a short pointer here.
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.

--- a/wiki-content/Installation.md
+++ b/wiki-content/Installation.md
@@ -1,5 +1,8 @@
 # Installation
 
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 Requires Lidarr 2.14.2.4786+ on the plugins/nightly branch.
 
 ## Install via Lidarr UI (recommended)

--- a/wiki-content/Local-Providers.md
+++ b/wiki-content/Local-Providers.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Local providers
 
 See the repository docs for the maintained guidance:

--- a/wiki-content/Observability-and-Metrics.md
+++ b/wiki-content/Observability-and-Metrics.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Observability & Metrics (Preview)
 
 > Canonical docs: [`docs/troubleshooting.md`](../docs/troubleshooting.md) for walkthroughs, [`docs/METRICS_REFERENCE.md`](../docs/METRICS_REFERENCE.md) for metric names, and `dashboards/README.md` for dashboards. Update those first, then mirror essential notes here.

--- a/wiki-content/Operations.md
+++ b/wiki-content/Operations.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Operations Playbook
 
 > Use this page as your runbook from first install through ongoing operations. Every workflow links back to the canonical docs/tests so the information stays in sync.

--- a/wiki-content/Provider-Basics.md
+++ b/wiki-content/Provider-Basics.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Provider basics
 
 Provider status, defaults, and configuration live in repo docs so the generator keeps everything in sync.

--- a/wiki-content/Provider-Selector.md
+++ b/wiki-content/Provider-Selector.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Provider Selector
 
 > Use this quick decision tree to choose a starting provider. Each outcome links to the detailed setup guides.

--- a/wiki-content/Provider-Setup-Guide.md
+++ b/wiki-content/Provider-Setup-Guide.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # ⚙️ Provider Setup Guide
 
 Complete configuration guide for all 9 supported AI providers.

--- a/wiki-content/Provider-Setup.md
+++ b/wiki-content/Provider-Setup.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Provider Setup Hub
 
 > Canonical provider data lives in `docs/providers.yaml`. After editing status or defaults, run `pwsh ./scripts/sync-provider-matrix.ps1` to regenerate the README, docs, and wiki fragments.

--- a/wiki-content/Review-Queue.md
+++ b/wiki-content/Review-Queue.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Review Queue
 
 > Compatibility

--- a/wiki-content/Settings-Best-Practices.md
+++ b/wiki-content/Settings-Best-Practices.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # ⚙️ Settings Best Practices
 
 Opinionated defaults that work well in practice, tuned for quality and simplicity. Use this as a quick reference when configuring Brainarr.

--- a/wiki-content/Start-Here.md
+++ b/wiki-content/Start-Here.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Start here
 
 Use the repository docs for the authoritative onboarding flow.

--- a/wiki-content/Timeouts-and-Retries.md
+++ b/wiki-content/Timeouts-and-Retries.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Timeouts & Retries (summary)
 
 This page summarizes the default timeouts and retries for Brainarr and is kept in sync with the repository README and code defaults.

--- a/wiki-content/Troubleshooting.md
+++ b/wiki-content/Troubleshooting.md
@@ -1,3 +1,7 @@
+
+<!-- SYNCED_WIKI_PAGE: Do not edit in the GitHub Wiki UI. This page is synced from wiki-content/ in the repository. -->
+> Source of truth lives in README.md and docs/. Make changes via PRs to the repo; CI auto-publishes to the Wiki.
+
 # Troubleshooting
 
 Start with the full playbook in [docs/troubleshooting.md](../docs/troubleshooting.md). Below is a quick triage you can follow inside Lidarr.


### PR DESCRIPTION
Adds a small, consistent banner to every wiki page indicating:
- Do not edit in the GitHub Wiki UI
- Source of truth is README/docs with content mirrored from wiki-content/

Also normalizes line endings and ensures blank lines around headings for markdownlint.