### PR TITLE
fix: Update to .NET 8.0 for Lidarr plugins branch compatibility

### DIFF
--- a/.github/actions/verify-assemblies-manifest/action.yml
+++ b/.github/actions/verify-assemblies-manifest/action.yml
@@ -4,7 +4,7 @@ inputs:
   path:
     description: Path to MANIFEST.txt
     required: false
-    default: ext/Lidarr-docker/_output/net6.0/MANIFEST.txt
+    default: ext/Lidarr-docker/_output/net8.0/MANIFEST.txt
   strict:
     description: Enforce tag/digest and no tarball fallback
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,14 +80,14 @@ jobs:
         fi
 
     - name: Extract Lidarr assemblies (shared script)
-      run: timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net6.0
+      run: timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
       shell: bash
 
     - name: Upload assemblies artifact
       uses: actions/upload-artifact@v4
       with:
         name: lidarr-assemblies
-        path: ext/Lidarr-docker/_output/net6.0/
+        path: ext/Lidarr-docker/_output/net8.0/
         if-no-files-found: error
 
   test:
@@ -226,24 +226,24 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: lidarr-assemblies
-        path: ext/Lidarr-docker/_output/net6.0/
+        path: ext/Lidarr-docker/_output/net8.0/
 
     - name: Assemblies sanity check (script, security scan)
       shell: bash
       run: |
-        bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net6.0 --expect-tag "ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}"
+        bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net8.0 --expect-tag "ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}"
 
     - name: Verify assemblies present
       shell: bash
       run: |
         set -euo pipefail
-        test -f ext/Lidarr-docker/_output/net6.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll in assemblies artifact"; exit 1; }
-        ls -la ext/Lidarr-docker/_output/net6.0/
+        test -f ext/Lidarr-docker/_output/net8.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll in assemblies artifact"; exit 1; }
+        ls -la ext/Lidarr-docker/_output/net8.0/
 
     - name: Sanity check assemblies manifest
       uses: ./.github/actions/verify-assemblies-manifest
       with:
-        path: ext/Lidarr-docker/_output/net6.0/MANIFEST.txt
+        path: ext/Lidarr-docker/_output/net8.0/MANIFEST.txt
         strict: 'true'
 
     - name: Extract Lidarr assemblies (Docker on Ubuntu, tar.gz fallback on others)
@@ -260,39 +260,39 @@ jobs:
           docker create --name temp-lidarr ghcr.io/hotio/lidarr:$LIDARR_DOCKER_VERSION
 
           # Create output directory
-          mkdir -p ext/Lidarr-docker/_output/net6.0
+          mkdir -p ext/Lidarr-docker/_output/net8.0
 
           # Extract required assemblies directly from Docker container
           echo "📦 Extracting core Lidarr assemblies..."
-          docker cp temp-lidarr:/app/bin/Lidarr.dll ext/Lidarr-docker/_output/net6.0/
-          docker cp temp-lidarr:/app/bin/Lidarr.Common.dll ext/Lidarr-docker/_output/net6.0/
-          docker cp temp-lidarr:/app/bin/Lidarr.Core.dll ext/Lidarr-docker/_output/net6.0/
-          docker cp temp-lidarr:/app/bin/Lidarr.Http.dll ext/Lidarr-docker/_output/net6.0/
-          docker cp temp-lidarr:/app/bin/Lidarr.Api.V1.dll ext/Lidarr-docker/_output/net6.0/
+          docker cp temp-lidarr:/app/bin/Lidarr.dll ext/Lidarr-docker/_output/net8.0/
+          docker cp temp-lidarr:/app/bin/Lidarr.Common.dll ext/Lidarr-docker/_output/net8.0/
+          docker cp temp-lidarr:/app/bin/Lidarr.Core.dll ext/Lidarr-docker/_output/net8.0/
+          docker cp temp-lidarr:/app/bin/Lidarr.Http.dll ext/Lidarr-docker/_output/net8.0/
+          docker cp temp-lidarr:/app/bin/Lidarr.Api.V1.dll ext/Lidarr-docker/_output/net8.0/
 
           # Extract Microsoft.Extensions assemblies (conditional)
           echo "🔧 Extracting Microsoft.Extensions assemblies..."
-          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Caching.Memory.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.Caching.Memory.dll not found"
-          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Caching.Abstractions.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.Caching.Abstractions.dll not found"
-          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.DependencyInjection.Abstractions.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.DependencyInjection.Abstractions.dll not found"
-          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Logging.Abstractions.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.Logging.Abstractions.dll not found"
-          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Options.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.Options.dll not found"
-          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Primitives.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.Primitives.dll not found"
+          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Caching.Memory.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.Caching.Memory.dll not found"
+          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Caching.Abstractions.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.Caching.Abstractions.dll not found"
+          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.DependencyInjection.Abstractions.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.DependencyInjection.Abstractions.dll not found"
+          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Logging.Abstractions.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.Logging.Abstractions.dll not found"
+          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Options.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.Options.dll not found"
+          docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Primitives.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || echo "⚠ Microsoft.Extensions.Primitives.dll not found"
 
           # Extract additional assemblies that may be needed
-          docker cp temp-lidarr:/app/bin/Lidarr.Host.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || echo "⚠ Lidarr.Host.dll not found (optional)"
+          docker cp temp-lidarr:/app/bin/Lidarr.Host.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || echo "⚠ Lidarr.Host.dll not found (optional)"
 
           # Cleanup Docker container
           docker rm temp-lidarr
 
           echo "✅ Docker assembly extraction completed"
           echo "📁 Final assemblies in target directory:"
-          ls -la ext/Lidarr-docker/_output/net6.0/
+          ls -la ext/Lidarr-docker/_output/net8.0/
         else
           echo "📦 Extracting Lidarr assemblies from tar.gz (macOS/Windows fallback)..."
 
           # Create output directory
-          mkdir -p ext/Lidarr-docker/_output/net6.0
+          mkdir -p ext/Lidarr-docker/_output/net8.0
 
           # Use latest stable Lidarr version for non-Linux platforms
           LIDARR_URL="https://github.com/Lidarr/Lidarr/releases/download/v2.12.4.4658/Lidarr.master.2.12.4.4658.linux-core-x64.tar.gz"
@@ -309,22 +309,22 @@ jobs:
 
           if [ -d "Lidarr" ]; then
             # Copy core Lidarr assemblies
-            cp Lidarr/Lidarr.Core.dll ext/Lidarr-docker/_output/net6.0/
-            cp Lidarr/Lidarr.Common.dll ext/Lidarr-docker/_output/net6.0/
-            cp Lidarr/Lidarr.Http.dll ext/Lidarr-docker/_output/net6.0/
-            cp Lidarr/Lidarr.Api.V1.dll ext/Lidarr-docker/_output/net6.0/
+            cp Lidarr/Lidarr.Core.dll ext/Lidarr-docker/_output/net8.0/
+            cp Lidarr/Lidarr.Common.dll ext/Lidarr-docker/_output/net8.0/
+            cp Lidarr/Lidarr.Http.dll ext/Lidarr-docker/_output/net8.0/
+            cp Lidarr/Lidarr.Api.V1.dll ext/Lidarr-docker/_output/net8.0/
 
             # Copy Microsoft.Extensions assemblies with checks
-            [ -f "Lidarr/Microsoft.Extensions.Caching.Memory.dll" ] && cp Lidarr/Microsoft.Extensions.Caching.Memory.dll ext/Lidarr-docker/_output/net6.0/
-            [ -f "Lidarr/Microsoft.Extensions.Caching.Abstractions.dll" ] && cp Lidarr/Microsoft.Extensions.Caching.Abstractions.dll ext/Lidarr-docker/_output/net6.0/
-            [ -f "Lidarr/Microsoft.Extensions.DependencyInjection.Abstractions.dll" ] && cp Lidarr/Microsoft.Extensions.DependencyInjection.Abstractions.dll ext/Lidarr-docker/_output/net6.0/
-            [ -f "Lidarr/Microsoft.Extensions.Logging.Abstractions.dll" ] && cp Lidarr/Microsoft.Extensions.Logging.Abstractions.dll ext/Lidarr-docker/_output/net6.0/
-            [ -f "Lidarr/Microsoft.Extensions.Options.dll" ] && cp Lidarr/Microsoft.Extensions.Options.dll ext/Lidarr-docker/_output/net6.0/
-            [ -f "Lidarr/Microsoft.Extensions.Primitives.dll" ] && cp Lidarr/Microsoft.Extensions.Primitives.dll ext/Lidarr-docker/_output/net6.0/
+            [ -f "Lidarr/Microsoft.Extensions.Caching.Memory.dll" ] && cp Lidarr/Microsoft.Extensions.Caching.Memory.dll ext/Lidarr-docker/_output/net8.0/
+            [ -f "Lidarr/Microsoft.Extensions.Caching.Abstractions.dll" ] && cp Lidarr/Microsoft.Extensions.Caching.Abstractions.dll ext/Lidarr-docker/_output/net8.0/
+            [ -f "Lidarr/Microsoft.Extensions.DependencyInjection.Abstractions.dll" ] && cp Lidarr/Microsoft.Extensions.DependencyInjection.Abstractions.dll ext/Lidarr-docker/_output/net8.0/
+            [ -f "Lidarr/Microsoft.Extensions.Logging.Abstractions.dll" ] && cp Lidarr/Microsoft.Extensions.Logging.Abstractions.dll ext/Lidarr-docker/_output/net8.0/
+            [ -f "Lidarr/Microsoft.Extensions.Options.dll" ] && cp Lidarr/Microsoft.Extensions.Options.dll ext/Lidarr-docker/_output/net8.0/
+            [ -f "Lidarr/Microsoft.Extensions.Primitives.dll" ] && cp Lidarr/Microsoft.Extensions.Primitives.dll ext/Lidarr-docker/_output/net8.0/
 
             echo "✅ Tar.gz assembly extraction completed"
             echo "📁 Final assemblies in target directory:"
-            ls -la ext/Lidarr-docker/_output/net6.0/
+            ls -la ext/Lidarr-docker/_output/net8.0/
           else
             echo "Extraction failed - Lidarr directory not found"
             exit 1
@@ -338,12 +338,12 @@ jobs:
       shell: bash
       run: |
         set -e
-        if [ -f ext/Lidarr-docker/_output/net6.0/Lidarr.Core.dll ]; then
+        if [ -f ext/Lidarr-docker/_output/net8.0/Lidarr.Core.dll ]; then
           echo "Lidarr assemblies already present; skipping fallback."
           exit 0
         fi
         echo "Fallback: downloading Lidarr linux-core package and extracting assemblies..."
-        mkdir -p ext/Lidarr-docker/_output/net6.0
+        mkdir -p ext/Lidarr-docker/_output/net8.0
         LIDARR_URL="https://github.com/Lidarr/Lidarr/releases/download/v2.13.3.4711/Lidarr.master.2.13.3.4711.linux-core-x64.tar.gz"
         echo "URL: $LIDARR_URL"
         curl -L --retry 3 "$LIDARR_URL" -o lidarr.tar.gz
@@ -357,10 +357,10 @@ jobs:
           Lidarr.Http.dll \
           Lidarr.Api.V1.dll \
           Lidarr.Host.dll ; do
-          [ -f "Lidarr/$f" ] && cp "Lidarr/$f" ext/Lidarr-docker/_output/net6.0/ || echo "Missing $f (optional)"
+          [ -f "Lidarr/$f" ] && cp "Lidarr/$f" ext/Lidarr-docker/_output/net8.0/ || echo "Missing $f (optional)"
         done
         echo "Assemblies in target directory:"
-        ls -la ext/Lidarr-docker/_output/net6.0/
+        ls -la ext/Lidarr-docker/_output/net8.0/
         rm -f lidarr.tar.gz
 
     - name: Create CI project file (TypNull approach)
@@ -369,7 +369,7 @@ jobs:
         cat > Brainarr.CI.csproj << 'EOF'
         <Project Sdk="Microsoft.NET.Sdk">
           <PropertyGroup>
-            <TargetFramework>net6.0</TargetFramework>
+            <TargetFramework>net8.0</TargetFramework>
             <AssemblyName>Lidarr.Plugin.Brainarr</AssemblyName>
             <OutputPath>Brainarr.Plugin/bin/</OutputPath>
             <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -395,19 +395,19 @@ jobs:
           <!-- Docker-extracted Lidarr assemblies -->
           <ItemGroup>
             <Reference Include="Lidarr.Core">
-              <HintPath>ext/Lidarr-docker/_output/net6.0/Lidarr.Core.dll</HintPath>
+              <HintPath>ext/Lidarr-docker/_output/net8.0/Lidarr.Core.dll</HintPath>
               <Private>false</Private>
             </Reference>
             <Reference Include="Lidarr.Common">
-              <HintPath>ext/Lidarr-docker/_output/net6.0/Lidarr.Common.dll</HintPath>
+              <HintPath>ext/Lidarr-docker/_output/net8.0/Lidarr.Common.dll</HintPath>
               <Private>false</Private>
             </Reference>
             <Reference Include="Lidarr.Http">
-              <HintPath>ext/Lidarr-docker/_output/net6.0/Lidarr.Http.dll</HintPath>
+              <HintPath>ext/Lidarr-docker/_output/net8.0/Lidarr.Http.dll</HintPath>
               <Private>false</Private>
             </Reference>
             <Reference Include="Lidarr.Api.V1">
-              <HintPath>ext/Lidarr-docker/_output/net6.0/Lidarr.Api.V1.dll</HintPath>
+              <HintPath>ext/Lidarr-docker/_output/net8.0/Lidarr.Api.V1.dll</HintPath>
               <Private>false</Private>
             </Reference>
           </ItemGroup>
@@ -417,7 +417,7 @@ jobs:
       shell: bash
 
     - name: Set Lidarr Path
-      run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" >> $GITHUB_ENV
+      run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" >> $GITHUB_ENV
       shell: bash
 
     - name: Install .NET SDKs
@@ -436,7 +436,7 @@ jobs:
     - name: Build (with fallback to CI project)
       run: |
         echo "🔨 Attempting build with main solution..."
-          if ! dotnet build Brainarr.sln --no-restore --configuration Release -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" -m:1; then
+          if ! dotnet build Brainarr.sln --no-restore --configuration Release -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" -m:1; then
           echo "⚠️ Main build failed, trying with CI-optimized project..."
           dotnet restore Brainarr.CI.csproj
           dotnet build Brainarr.CI.csproj --configuration Release -m:1
@@ -498,7 +498,7 @@ jobs:
         mkdir -p artifacts
 
         # Copy built plugin files
-        cp -r Brainarr.Plugin/bin/Release/net6.0/* artifacts/ 2>/dev/null || true
+        cp -r Brainarr.Plugin/bin/Release/net8.0/* artifacts/ 2>/dev/null || true
 
         # Copy plugin manifest
         cp plugin.json artifacts/
@@ -595,19 +595,19 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: lidarr-assemblies
-        path: ext/Lidarr-docker/_output/net6.0/
+        path: ext/Lidarr-docker/_output/net8.0/
 
     - name: Verify assemblies present (security scan)
       shell: bash
       run: |
         set -euo pipefail
-        test -f ext/Lidarr-docker/_output/net6.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll in assemblies artifact"; exit 1; }
-        ls -la ext/Lidarr-docker/_output/net6.0/
+        test -f ext/Lidarr-docker/_output/net8.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll in assemblies artifact"; exit 1; }
+        ls -la ext/Lidarr-docker/_output/net8.0/
 
     - name: Sanity check assemblies manifest (security scan)
       uses: ./.github/actions/verify-assemblies-manifest
       with:
-        path: ext/Lidarr-docker/_output/net6.0/MANIFEST.txt
+        path: ext/Lidarr-docker/_output/net8.0/MANIFEST.txt
         strict: ${{ github.event_name != 'pull_request' }}
 
     # Rely on repo NuGet.config so Taglib source mapping is preserved during security scan restore.
@@ -619,7 +619,7 @@ jobs:
         cat > Brainarr.CI.csproj << 'EOF'
         <Project Sdk="Microsoft.NET.Sdk">
           <PropertyGroup>
-            <TargetFramework>net6.0</TargetFramework>
+            <TargetFramework>net8.0</TargetFramework>
             <AssemblyName>Lidarr.Plugin.Brainarr</AssemblyName>
             <OutputPath>Brainarr.Plugin/bin/</OutputPath>
             <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -645,19 +645,19 @@ jobs:
           <!-- Docker-extracted Lidarr assemblies -->
           <ItemGroup>
             <Reference Include="Lidarr.Core">
-              <HintPath>ext/Lidarr-docker/_output/net6.0/Lidarr.Core.dll</HintPath>
+              <HintPath>ext/Lidarr-docker/_output/net8.0/Lidarr.Core.dll</HintPath>
               <Private>false</Private>
             </Reference>
             <Reference Include="Lidarr.Common">
-              <HintPath>ext/Lidarr-docker/_output/net6.0/Lidarr.Common.dll</HintPath>
+              <HintPath>ext/Lidarr-docker/_output/net8.0/Lidarr.Common.dll</HintPath>
               <Private>false</Private>
             </Reference>
             <Reference Include="Lidarr.Http">
-              <HintPath>ext/Lidarr-docker/_output/net6.0/Lidarr.Http.dll</HintPath>
+              <HintPath>ext/Lidarr-docker/_output/net8.0/Lidarr.Http.dll</HintPath>
               <Private>false</Private>
             </Reference>
             <Reference Include="Lidarr.Api.V1">
-              <HintPath>ext/Lidarr-docker/_output/net6.0/Lidarr.Api.V1.dll</HintPath>
+              <HintPath>ext/Lidarr-docker/_output/net8.0/Lidarr.Api.V1.dll</HintPath>
               <Private>false</Private>
             </Reference>
           </ItemGroup>
@@ -666,7 +666,7 @@ jobs:
         echo "✅ CI project file created for security scan"
 
     - name: Set Lidarr Path
-      run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" >> $GITHUB_ENV
+      run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" >> $GITHUB_ENV
 
     - name: Build for Analysis (with fallback to CI project)
       shell: bash
@@ -676,7 +676,7 @@ jobs:
           echo "⚠️ Main solution restore failed, trying with CI-optimized project..."
           dotnet restore Brainarr.CI.csproj
           dotnet build Brainarr.CI.csproj --configuration Release
-        elif ! dotnet build Brainarr.sln --configuration Release -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" -p:TreatWarningsAsErrors=false -m:1; then
+        elif ! dotnet build Brainarr.sln --configuration Release -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" -p:TreatWarningsAsErrors=false -m:1; then
           echo "⚠️ Main solution build failed, trying with CI-optimized project..."
           dotnet restore Brainarr.CI.csproj
           dotnet build Brainarr.CI.csproj --configuration Release -m:1
@@ -792,25 +792,25 @@ jobs:
         docker create --name temp-lidarr ghcr.io/hotio/lidarr:$LIDARR_DOCKER_VERSION
 
         # Create output directory
-        mkdir -p ext/Lidarr-docker/_output/net6.0
+        mkdir -p ext/Lidarr-docker/_output/net8.0
 
         # Extract required assemblies
-        docker cp temp-lidarr:/app/bin/Lidarr.dll ext/Lidarr-docker/_output/net6.0/
-        docker cp temp-lidarr:/app/bin/Lidarr.Common.dll ext/Lidarr-docker/_output/net6.0/
-        docker cp temp-lidarr:/app/bin/Lidarr.Core.dll ext/Lidarr-docker/_output/net6.0/
-        docker cp temp-lidarr:/app/bin/Lidarr.Http.dll ext/Lidarr-docker/_output/net6.0/
-        docker cp temp-lidarr:/app/bin/Lidarr.Api.V1.dll ext/Lidarr-docker/_output/net6.0/
+        docker cp temp-lidarr:/app/bin/Lidarr.dll ext/Lidarr-docker/_output/net8.0/
+        docker cp temp-lidarr:/app/bin/Lidarr.Common.dll ext/Lidarr-docker/_output/net8.0/
+        docker cp temp-lidarr:/app/bin/Lidarr.Core.dll ext/Lidarr-docker/_output/net8.0/
+        docker cp temp-lidarr:/app/bin/Lidarr.Http.dll ext/Lidarr-docker/_output/net8.0/
+        docker cp temp-lidarr:/app/bin/Lidarr.Api.V1.dll ext/Lidarr-docker/_output/net8.0/
 
         # Extract Microsoft.Extensions assemblies (conditional)
-        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Caching.Memory.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || true
-        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Caching.Abstractions.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || true
-        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.DependencyInjection.Abstractions.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || true
-        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Logging.Abstractions.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || true
-        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Options.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || true
-        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Primitives.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || true
+        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Caching.Memory.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || true
+        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Caching.Abstractions.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || true
+        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.DependencyInjection.Abstractions.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || true
+        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Logging.Abstractions.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || true
+        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Options.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || true
+        docker cp temp-lidarr:/app/bin/Microsoft.Extensions.Primitives.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || true
 
         # Extract optional assemblies
-        docker cp temp-lidarr:/app/bin/Lidarr.Host.dll ext/Lidarr-docker/_output/net6.0/ 2>/dev/null || true
+        docker cp temp-lidarr:/app/bin/Lidarr.Host.dll ext/Lidarr-docker/_output/net8.0/ 2>/dev/null || true
 
         # Cleanup Docker container
         docker rm temp-lidarr
@@ -820,7 +820,7 @@ jobs:
     - name: Build Plugin
       shell: bash
       run: |
-        export LIDARR_PATH="${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0"
+        export LIDARR_PATH="${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0"
         dotnet restore Brainarr.sln
         dotnet build Brainarr.sln --configuration Release -p:LidarrPath="$LIDARR_PATH" -m:1
 
@@ -838,9 +838,9 @@ jobs:
         if [ -f "Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll" ]; then
           cp "Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll" release/
           echo "✅ Found DLL at Brainarr.Plugin/bin/"
-        elif [ -f "Brainarr.Plugin/bin/Release/net6.0/Lidarr.Plugin.Brainarr.dll" ]; then
-          cp "Brainarr.Plugin/bin/Release/net6.0/Lidarr.Plugin.Brainarr.dll" release/
-          echo "✅ Found DLL at Brainarr.Plugin/bin/Release/net6.0/"
+        elif [ -f "Brainarr.Plugin/bin/Release/net8.0/Lidarr.Plugin.Brainarr.dll" ]; then
+          cp "Brainarr.Plugin/bin/Release/net8.0/Lidarr.Plugin.Brainarr.dll" release/
+          echo "✅ Found DLL at Brainarr.Plugin/bin/Release/net8.0/"
         else
           echo "❌ Could not find Lidarr.Plugin.Brainarr.dll"
           echo "Available files in Brainarr.Plugin/bin/:"
@@ -869,18 +869,18 @@ jobs:
           --clobber
 
         # Upload .NET 6.0 specific package for compatibility
-        cp "Brainarr-${{ github.event.release.tag_name }}.zip" "Brainarr-${{ github.event.release.tag_name }}.net6.0.zip"
+        cp "Brainarr-${{ github.event.release.tag_name }}.zip" "Brainarr-${{ github.event.release.tag_name }}.net8.0.zip"
         gh release upload ${{ github.event.release.tag_name }} \
-          "Brainarr-${{ github.event.release.tag_name }}.net6.0.zip" \
+          "Brainarr-${{ github.event.release.tag_name }}.net8.0.zip" \
           --clobber
 
         # Create and upload SHA256 checksums for verification
         sha256sum "Brainarr-${{ github.event.release.tag_name }}.zip" > "Brainarr-${{ github.event.release.tag_name }}.zip.sha256"
-        sha256sum "Brainarr-${{ github.event.release.tag_name }}.net6.0.zip" > "Brainarr-${{ github.event.release.tag_name }}.net6.0.zip.sha256"
+        sha256sum "Brainarr-${{ github.event.release.tag_name }}.net8.0.zip" > "Brainarr-${{ github.event.release.tag_name }}.net8.0.zip.sha256"
 
         gh release upload ${{ github.event.release.tag_name }} \
           "Brainarr-${{ github.event.release.tag_name }}.zip.sha256" \
-          "Brainarr-${{ github.event.release.tag_name }}.net6.0.zip.sha256" \
+          "Brainarr-${{ github.event.release.tag_name }}.net8.0.zip.sha256" \
           --clobber
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,15 +68,15 @@ jobs:
           build-mode: manual
 
       - name: Extract Lidarr assemblies (shared script)
-        run: timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode minimal --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net6.0
+        run: timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode minimal --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
         shell: bash
 
       - name: Verify assemblies and export LIDARR_PATH
         shell: bash
         run: |
           set -euo pipefail
-          bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net6.0
-          echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" >> "$GITHUB_ENV"
+          bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net8.0
+          echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" >> "$GITHUB_ENV"
 
       - name: Restore
         run: timeout 10m dotnet restore Brainarr.sln

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -91,20 +91,20 @@ jobs:
       shell: bash
       run: |
         set -euo pipefail
-        timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net6.0
-        echo "LIDARR_PATH=${GITHUB_WORKSPACE}/ext/Lidarr-docker/_output/net6.0" >> "$GITHUB_ENV"
+        timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
+        echo "LIDARR_PATH=${GITHUB_WORKSPACE}/ext/Lidarr-docker/_output/net8.0" >> "$GITHUB_ENV"
 
     - name: Assemblies sanity check (script)
       shell: bash
       run: |
-        bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net6.0 --expect-tag "ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}"
+        bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net8.0 --expect-tag "ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}"
 
     - name: Verify assemblies present
       shell: bash
       run: |
         set -euo pipefail
-        test -f ext/Lidarr-docker/_output/net6.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll"; exit 1; }
-        test -f ext/Lidarr-docker/_output/net6.0/Lidarr.Http.dll || { echo "Missing Lidarr.Http.dll"; exit 1; }
+        test -f ext/Lidarr-docker/_output/net8.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll"; exit 1; }
+        test -f ext/Lidarr-docker/_output/net8.0/Lidarr.Http.dll || { echo "Missing Lidarr.Http.dll"; exit 1; }
 
     - name: Build & Test (with LidarrPath)
       shell: bash

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -34,11 +34,11 @@ jobs:
           LIDARR_DOCKER_VERSION: pr-plugins-2.14.2.4786
         run: |
           set -euo pipefail
-          timeout 10m bash scripts/extract-lidarr-assemblies.sh --mode minimal --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net6.0
+          timeout 10m bash scripts/extract-lidarr-assemblies.sh --mode minimal --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
 
       - name: Verify assemblies and export LIDARR_PATH
         shell: bash
-        run: bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net6.0
+        run: bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net8.0
 
       - name: Install Stryker.NET tool
         run: |

--- a/.github/workflows/nightly-perf-stress.yml
+++ b/.github/workflows/nightly-perf-stress.yml
@@ -29,26 +29,26 @@ jobs:
           LIDARR_DOCKER_DIGEST: sha256:83b3095113b70a7d013819ed2f6d56d047f28e1f67aa11b7820e280560446b62
         run: |
           set -euo pipefail
-          mkdir -p ext/Lidarr/_output/net6.0
+          mkdir -p ext/Lidarr/_output/net8.0
           IMAGE="ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}"
           if [ -n "${LIDARR_DOCKER_DIGEST:-}" ]; then IMAGE="ghcr.io/hotio/lidarr@${LIDARR_DOCKER_DIGEST}"; fi
           echo "Using Docker image: ${IMAGE}"
           docker pull "${IMAGE}"
           docker create --name temp-lidarr "${IMAGE}" >/dev/null
           # Copy all runtime dependencies; avoids missing assemblies in perf/stress runs
-          docker cp temp-lidarr:/app/bin/. ext/Lidarr/_output/net6.0/
+          docker cp temp-lidarr:/app/bin/. ext/Lidarr/_output/net8.0/
           docker rm -f temp-lidarr >/dev/null
-          ls -la ext/Lidarr/_output/net6.0/
+          ls -la ext/Lidarr/_output/net8.0/
 
       - name: Verify assemblies present
         shell: bash
         run: |
           set -euo pipefail
-          test -f ext/Lidarr/_output/net6.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll in assemblies"; exit 1; }
-          ls -la ext/Lidarr/_output/net6.0/
+          test -f ext/Lidarr/_output/net8.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll in assemblies"; exit 1; }
+          ls -la ext/Lidarr/_output/net8.0/
 
       - name: Set LIDARR_PATH
-        run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr/_output/net6.0" >> $GITHUB_ENV
+        run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr/_output/net8.0" >> $GITHUB_ENV
 
       - name: Restore
         run: dotnet restore Brainarr.sln

--- a/.github/workflows/plugin-package.yml
+++ b/.github/workflows/plugin-package.yml
@@ -72,10 +72,10 @@ jobs:
     - name: Extract Lidarr Assemblies
       shell: bash
       run: |
-        timeout 15m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net6.0
+        timeout 15m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
         echo "Extracted assemblies (sample):"
-        ls -1 ext/Lidarr-docker/_output/net6.0 | sed -n '1,40p'
-        if [ ! -f ext/Lidarr-docker/_output/net6.0/NLog.dll ]; then
+        ls -1 ext/Lidarr-docker/_output/net8.0 | sed -n '1,40p'
+        if [ ! -f ext/Lidarr-docker/_output/net8.0/NLog.dll ]; then
           echo "ERROR: NLog.dll missing from extracted assemblies; plugin may bind to wrong NLog version." >&2
           exit 1
         fi
@@ -83,13 +83,13 @@ jobs:
     - name: Assemblies sanity check (script)
       shell: bash
       run: |
-        bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net6.0 --expect-tag "ghcr.io/hotio/lidarr:pr-plugins-2.14.2.4786"
+        bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net8.0 --expect-tag "ghcr.io/hotio/lidarr:pr-plugins-2.14.2.4786"
 
     - name: Sanity check assemblies manifest
       shell: bash
       run: |
         set -euo pipefail
-        MAN=ext/Lidarr-docker/_output/net6.0/MANIFEST.txt
+        MAN=ext/Lidarr-docker/_output/net8.0/MANIFEST.txt
         test -f "$MAN" || { echo "Missing MANIFEST.txt" >&2; exit 1; }
         echo "=== Assemblies MANIFEST (package) ==="; sed -n '1,80p' "$MAN"
         if grep -q '^Fallback:\s*tarball' "$MAN"; then
@@ -105,7 +105,7 @@ jobs:
         dotnet build Brainarr.Plugin/Brainarr.Plugin.csproj \
           --configuration Release \
           --no-restore \
-          -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" \
+          -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" \
           -m:1
 
     - name: Create Plugin Package

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -42,7 +42,7 @@ jobs:
       run:
         shell: bash
     env:
-      LIDARR_OUTPUT: ${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0
+      LIDARR_OUTPUT: ${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,14 +87,14 @@ jobs:
       shell: bash
       run: |
         set -euo pipefail
-        bash scripts/extract-lidarr-assemblies.sh --mode minimal --output-dir ext/Lidarr-docker/_output/net6.0
+        bash scripts/extract-lidarr-assemblies.sh --mode minimal --output-dir ext/Lidarr-docker/_output/net8.0
 
     - name: Verify assemblies and export LIDARR_PATH (allow tarball)
       shell: bash
       run: |
         set -euo pipefail
-        bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net6.0
-        echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" >> $GITHUB_ENV
+        bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net8.0
+        echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" >> $GITHUB_ENV
 
     - name: 🏷️ Determine Version & Metadata
       id: version
@@ -175,14 +175,14 @@ jobs:
 
         # Check what assemblies we actually extracted
         echo "📋 Available Lidarr assemblies:"
-        ls -la ext/Lidarr-docker/_output/net6.0/
+        ls -la ext/Lidarr-docker/_output/net8.0/
 
         # Restore packages first
         dotnet restore Brainarr.sln
 
         # Build with Docker assemblies + NuGet packages (Microsoft.Extensions now via Central Package Management)
         echo "🎯 Building with Docker assemblies + NuGet packages..."
-        dotnet build Brainarr.sln --configuration Release --no-restore -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0"
+        dotnet build Brainarr.sln --configuration Release --no-restore -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0"
 
         echo "✅ Plugin build completed"
 
@@ -213,9 +213,9 @@ jobs:
           cp Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll release/
           BUILD_PATH="Brainarr.Plugin/bin/"
           echo "✅ Found plugin DLL at $BUILD_PATH"
-        elif [ -f "Brainarr.Plugin/bin/Release/net6.0/Lidarr.Plugin.Brainarr.dll" ]; then
-          cp Brainarr.Plugin/bin/Release/net6.0/Lidarr.Plugin.Brainarr.dll release/
-          BUILD_PATH="Brainarr.Plugin/bin/Release/net6.0/"
+        elif [ -f "Brainarr.Plugin/bin/Release/net8.0/Lidarr.Plugin.Brainarr.dll" ]; then
+          cp Brainarr.Plugin/bin/Release/net8.0/Lidarr.Plugin.Brainarr.dll release/
+          BUILD_PATH="Brainarr.Plugin/bin/Release/net8.0/"
           echo "✅ Found plugin DLL at $BUILD_PATH"
         else
           echo "❌ Could not find Lidarr.Plugin.Brainarr.dll"

--- a/.github/workflows/sanity-build.yml
+++ b/.github/workflows/sanity-build.yml
@@ -59,14 +59,14 @@ jobs:
           LIDARR_DOCKER_VERSION: pr-plugins-2.14.2.4786
         run: |
           set -euo pipefail
-          timeout 10m bash scripts/extract-lidarr-assemblies.sh --mode minimal --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net6.0
+          timeout 10m bash scripts/extract-lidarr-assemblies.sh --mode minimal --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
 
       - name: Verify assemblies and export LIDARR_PATH
         shell: bash
         run: |
           set -euo pipefail
-          bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net6.0
-          echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" >> $GITHUB_ENV
+          bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net8.0
+          echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" >> $GITHUB_ENV
 
       - name: Restore plugin
         shell: bash

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: Extract Lidarr Assemblies
         run: |
-          timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net6.0
-          ls -1 ext/Lidarr-docker/_output/net6.0 | sed -n '1,60p'
+          timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
+          ls -1 ext/Lidarr-docker/_output/net8.0 | sed -n '1,60p'
 
       - name: Build Plugin
         run: |
@@ -67,7 +67,7 @@ jobs:
           dotnet build Brainarr.Plugin/Brainarr.Plugin.csproj \
             --configuration Release \
             --no-restore \
-            -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" \
+            -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" \
             -m:1
 
       - name: Stage Plugin Files (dist)
@@ -77,8 +77,8 @@ jobs:
           mkdir -p plugin-dist
           if [ -f Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll ]; then
             SRC="Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll"
-          elif [ -f Brainarr.Plugin/bin/Release/net6.0/Lidarr.Plugin.Brainarr.dll ]; then
-            SRC="Brainarr.Plugin/bin/Release/net6.0/Lidarr.Plugin.Brainarr.dll"
+          elif [ -f Brainarr.Plugin/bin/Release/net8.0/Lidarr.Plugin.Brainarr.dll ]; then
+            SRC="Brainarr.Plugin/bin/Release/net8.0/Lidarr.Plugin.Brainarr.dll"
           else
             echo "Could not find built Brainarr DLL in expected locations" >&2
             find Brainarr.Plugin -name 'Lidarr.Plugin.Brainarr.dll' -path '*/bin/*' | sed -n '1,10p' || true

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -61,18 +61,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net6.0
+          timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
 
       - name: Assemblies sanity check (script)
         shell: bash
         run: |
-          bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net6.0 --expect-tag "ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}"
+          bash scripts/ci/check-assemblies.sh ext/Lidarr-docker/_output/net8.0 --expect-tag "ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}"
 
       - name: Sanity check assemblies manifest
         shell: bash
         run: |
           set -euo pipefail
-          MAN=ext/Lidarr-docker/_output/net6.0/MANIFEST.txt
+          MAN=ext/Lidarr-docker/_output/net8.0/MANIFEST.txt
           test -f "$MAN" || { echo "Missing MANIFEST.txt" >&2; exit 1; }
           echo "=== Assemblies MANIFEST (test-and-coverage) ==="; sed -n '1,80p' "$MAN"
           EXPECT_TAG="ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}"
@@ -94,16 +94,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test -f ext/Lidarr-docker/_output/net6.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll in assemblies"; exit 1; }
-          if ! compgen -G "ext/Lidarr-docker/_output/net6.0/Lidarr.*.dll" > /dev/null; then
+          test -f ext/Lidarr-docker/_output/net8.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll in assemblies"; exit 1; }
+          if ! compgen -G "ext/Lidarr-docker/_output/net8.0/Lidarr.*.dll" > /dev/null; then
             echo "Missing Lidarr.*.dll assemblies; ensure full /app/bin is extracted from the plugins Docker image"
             exit 1
           fi
-          ls -la ext/Lidarr-docker/_output/net6.0/
+          ls -la ext/Lidarr-docker/_output/net8.0/
 
       - name: Set LIDARR_PATH
         shell: bash
-        run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" >> $GITHUB_ENV
+        run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" >> $GITHUB_ENV
 
       - name: Restore
         shell: bash
@@ -237,7 +237,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bash scripts/extract-lidarr-assemblies.sh --mode full --output-dir ext/Lidarr-docker/_output/net6.0
+          bash scripts/extract-lidarr-assemblies.sh --mode full --output-dir ext/Lidarr-docker/_output/net8.0
 
       - name: Patch submodule NuGet mapping (TagLibSharp-Lidarr)
         shell: pwsh
@@ -257,7 +257,7 @@ jobs:
       - name: Set LIDARR_PATH
         shell: pwsh
         run: |
-          echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net6.0" >> $env:GITHUB_ENV
+          echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" >> $env:GITHUB_ENV
 
       - name: Build plugin (Release)
         shell: pwsh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ This file tracks persistent technical decisions and context for the Brainarr Lid
 ## Local Setup & Build
 - One-command bootstrap: run `./setup.ps1` (Windows/PowerShell) or `./setup.sh` (POSIX) from repo root; they clone or update Lidarr, build it, cache `LIDARR_PATH`, restore the Brainarr solution, and build the plugin. On POSIX run `chmod +x setup.sh` once before invoking it.
 - `setup-lidarr.ps1` remains available for advanced scenarios (alternate branches, `-SkipBuild`); it also records the resolved Lidarr path in `ext/lidarr-path.txt` for reuse.
-- Always build against real Lidarr assemblies; never introduce stubs. The setup scripts ensure `ext/Lidarr/_output/net6.0` exists and set `LIDARR_PATH` automatically.
-- Only set `LIDARR_PATH` manually when Lidarr lives outside `ext/Lidarr/_output/net6.0`; otherwise let the setup tooling manage it.
+- Always build against real Lidarr assemblies; never introduce stubs. The setup scripts ensure `ext/Lidarr/_output/net8.0` exists and set `LIDARR_PATH` automatically.
+- Only set `LIDARR_PATH` manually when Lidarr lives outside `ext/Lidarr/_output/net8.0`; otherwise let the setup tooling manage it.
 - Primary entry points: `build.ps1` / `build.sh` (flags: `-Setup/--setup`, `-Test/--test`, `-Package/--package`, `-Deploy/--deploy`) once Lidarr is prepared.
 - Manual builds happen inside `Brainarr.Plugin/`; run `dotnet build -c Release` only after Lidarr assemblies are present.
 
@@ -46,7 +46,7 @@ This file tracks persistent technical decisions and context for the Brainarr Lid
 - Update provider verification notes in README/docs when changing supported services.
 
 ## CI/CD Essentials
-- CI always compiles against Lidarr's `plugins` branch via Docker image `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}`; extracted assemblies live in `ext/Lidarr-docker/_output/net6.0/` and feed matrix jobs.
+- CI always compiles against Lidarr's `plugins` branch via Docker image `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}`; extracted assemblies live in `ext/Lidarr-docker/_output/net8.0/` and feed matrix jobs.
 - Keep `LIDARR_DOCKER_VERSION` current for the plugins branch; note bumps here when they occur.
 - Current default: `pr-plugins-2.14.2.4786` (updated 2025-09-24).
 - Prefer Docker-based extraction everywhere; fall back to tarballs only when Docker is unavailable and versions are pinned.

--- a/BUILD.md
+++ b/BUILD.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. **.NET SDK 6.0+ (8.0 recommended)** — the plugin targets `net6.0`, and the repo pins SDK `8.0.x` via `global.json` for tooling consistency.
+1. **.NET SDK 6.0+ (8.0 recommended)** — the plugin targets `net8.0`, and the repo pins SDK `8.0.x` via `global.json` for tooling consistency.
 1. **Real Lidarr assemblies** — the build targets real Lidarr binaries (no stubs). The setup scripts fetch them for you.
 1. **Git** — to clone/update this repository.
 
@@ -21,7 +21,7 @@ chmod +x ./setup.sh
 ./setup.sh
 ```
 
-This prepares `ext/Lidarr-docker/_output/net6.0/` (or `ext/Lidarr/_output/net6.0/` when Docker is unavailable) and sets `LIDARR_PATH` for subsequent builds. After setup:
+This prepares `ext/Lidarr-docker/_output/net8.0/` (or `ext/Lidarr/_output/net8.0/` when Docker is unavailable) and sets `LIDARR_PATH` for subsequent builds. After setup:
 
 ```bash
 cd Brainarr.Plugin
@@ -72,7 +72,7 @@ dotnet build -c Release
 
 ### Docker
 
-- **Bootstrap output (default)**: `ext/Lidarr-docker/_output/net6.0/`
+- **Bootstrap output (default)**: `ext/Lidarr-docker/_output/net8.0/`
 - **Inside running container**: `/app/bin` (extracted by scripts into the path above)
 
 ## Build Output
@@ -151,7 +151,7 @@ For development with full test suite:
 
 ## CI/CD Notes
 
-CI compiles against the Lidarr plugins branch by extracting assemblies from Docker image `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` into `ext/Lidarr-docker/_output/net6.0/`. Jobs fail fast if assemblies are missing. See `.github/workflows/` for `sanity-build`, `plugin-package`, and test jobs.
+CI compiles against the Lidarr plugins branch by extracting assemblies from Docker image `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` into `ext/Lidarr-docker/_output/net8.0/`. Jobs fail fast if assemblies are missing. See `.github/workflows/` for `sanity-build`, `plugin-package`, and test jobs.
 
 ## Tests and Coverage
 
@@ -161,7 +161,7 @@ Run the full suite locally with the helper script:
 ./test-local-ci.ps1
 ```
 
-Skip downloading Lidarr assemblies if you already have `ext/Lidarr/_output/net6.0`:
+Skip downloading Lidarr assemblies if you already have `ext/Lidarr/_output/net8.0`:
 
 ```powershell
 ./test-local-ci.ps1 -SkipDownload

--- a/BUILD_REQUIREMENTS.md
+++ b/BUILD_REQUIREMENTS.md
@@ -31,7 +31,7 @@ chmod +x ./setup.sh
 
 ```bash
 bash ./scripts/extract-lidarr-assemblies.sh
-# Assemblies land in ext/Lidarr-docker/_output/net6.0/
+# Assemblies land in ext/Lidarr-docker/_output/net8.0/
 ```
 
 2. Alternatively, clone Lidarr's plugins branch (advanced):
@@ -52,8 +52,8 @@ cd ../..
 4. Set environment variable:
 
 ```bash
-# Prefer Docker output: ext/Lidarr-docker/_output/net6.0
-export LIDARR_PATH="$(pwd)/ext/Lidarr-docker/_output/net6.0"
+# Prefer Docker output: ext/Lidarr-docker/_output/net8.0
+export LIDARR_PATH="$(pwd)/ext/Lidarr-docker/_output/net8.0"
 ```
 
 5. Now build Brainarr:
@@ -75,7 +75,7 @@ This is intentional! We want compilation to fail fast rather than runtime failur
 
 ## CI/CD Integration
 
-Our GitHub Actions workflows extract real Lidarr assemblies from Docker image `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` into `ext/Lidarr-docker/_output/net6.0/`, then build Brainarr against those binaries and run tests. Jobs fail fast if assemblies are missing.
+Our GitHub Actions workflows extract real Lidarr assemblies from Docker image `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` into `ext/Lidarr-docker/_output/net8.0/`, then build Brainarr against those binaries and run tests. Jobs fail fast if assemblies are missing.
 
 See `.github/workflows/` (`plugin-package.yml`, `test-and-coverage.yml`, `sanity-build.yml`) for the pipelines.
 

--- a/Brainarr.Plugin/Brainarr.Plugin.csproj
+++ b/Brainarr.Plugin/Brainarr.Plugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -86,19 +86,19 @@
   <!-- Priority order:
        1. Command line property: -p:LidarrPath=...
        2. Environment variable: LIDARR_PATH
-       3. Docker extraction: ../ext/Lidarr-docker/_output/net6.0
-       4. Local checkout: ../ext/Lidarr/_output/net6.0
-       5. Local source build: ../ext/Lidarr/src/Lidarr/bin/Release/net6.0
-       6. GitHub Actions cache: ../lidarr/_output/net6.0
+       3. Docker extraction: ../ext/Lidarr-docker/_output/net8.0
+       4. Local checkout: ../ext/Lidarr/_output/net8.0
+       5. Local source build: ../ext/Lidarr/src/Lidarr/bin/Release/net8.0
+       6. GitHub Actions cache: ../lidarr/_output/net8.0
        7. System installation paths
   -->
   <PropertyGroup>
     <LidarrPath Condition="'$(LidarrPath)' == ''">$(LIDARR_PATH)</LidarrPath>
     <!-- Prefer docker-extracted assemblies (kept in sync with plugins branch) -->
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr-docker\_output\net6.0')">..\ext\Lidarr-docker\_output\net6.0</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr\_output\net6.0')">..\ext\Lidarr\_output\net6.0</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr\src\Lidarr\bin\Release\net6.0')">..\ext\Lidarr\src\Lidarr\bin\Release\net6.0</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\..\lidarr\_output\net6.0')">..\..\lidarr\_output\net6.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr-docker\_output\net8.0')">..\ext\Lidarr-docker\_output\net8.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr\_output\net8.0')">..\ext\Lidarr\_output\net8.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr\src\Lidarr\bin\Release\net8.0')">..\ext\Lidarr\src\Lidarr\bin\Release\net8.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\..\lidarr\_output\net8.0')">..\..\lidarr\_output\net8.0</LidarrPath>
     <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('C:\ProgramData\Lidarr\bin')">C:\ProgramData\Lidarr\bin</LidarrPath>
     <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('/opt/Lidarr')">/opt/Lidarr</LidarrPath>
     <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('/usr/lib/lidarr/bin')">/usr/lib/lidarr/bin</LidarrPath>
@@ -106,7 +106,7 @@
 
   <!-- CI fallback path when the docker extraction is intentionally missing -->
   <PropertyGroup Condition="'$(CI)' == 'true' and '$(LidarrPath)' == ''">
-    <LidarrPath>$(MSBuildThisFileDirectory)..\ext\Lidarr-docker\_output\net6.0</LidarrPath>
+    <LidarrPath>$(MSBuildThisFileDirectory)..\ext\Lidarr-docker\_output\net8.0</LidarrPath>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(LidarrPath)' != ''">

--- a/Brainarr.Tests/Brainarr.Tests.csproj
+++ b/Brainarr.Tests/Brainarr.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>
@@ -56,10 +56,10 @@
   <!-- Lidarr assemblies reference for testing -->
   <PropertyGroup>
     <LidarrPath Condition="'$(LidarrPath)' == ''">$(LIDARR_PATH)</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr\_output\net6.0')">..\ext\Lidarr\_output\net6.0</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr-docker\_output\net6.0')">..\ext\Lidarr-docker\_output\net6.0</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr\src\Lidarr\bin\Release\net6.0')">..\ext\Lidarr\src\Lidarr\bin\Release\net6.0</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\..\lidarr\_output\net6.0')">..\..\lidarr\_output\net6.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr\_output\net8.0')">..\ext\Lidarr\_output\net8.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr-docker\_output\net8.0')">..\ext\Lidarr-docker\_output\net8.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\ext\Lidarr\src\Lidarr\bin\Release\net8.0')">..\ext\Lidarr\src\Lidarr\bin\Release\net8.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\..\lidarr\_output\net8.0')">..\..\lidarr\_output\net8.0</LidarrPath>
     <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('C:\ProgramData\Lidarr\bin')">C:\ProgramData\Lidarr\bin</LidarrPath>
     <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('/opt/Lidarr')">/opt/Lidarr</LidarrPath>
     <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('/usr/lib/lidarr/bin')">/usr/lib/lidarr/bin</LidarrPath>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - CI: Added scripts/ci/check-assemblies.sh and wired it into core workflows to fail fast when required Lidarr assemblies are missing or from the wrong source/tag.
 - CI: Bumped LIDARR_DOCKER_VERSION to pr-plugins-2.14.2.4786 everywhere (including nightly perf and dependency update jobs) to keep in sync with the plugins branch.
-- CI: Dependency update job now uses Docker-based assembly extraction (ext/Lidarr-docker/_output/net6.0), adds a concurrency group to avoid overlapping runs, and verifies assemblies via the new sanity script.
+- CI: Dependency update job now uses Docker-based assembly extraction (ext/Lidarr-docker/_output/net8.0), adds a concurrency group to avoid overlapping runs, and verifies assemblies via the new sanity script.
 
 ### Documentation
 
@@ -96,7 +96,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
-- Ensured the build resolves Lidarr assemblies from `ext/Lidarr-docker/_output/net6.0` first so Brainarr compiles against 2.14.2+ and no longer triggers `ReflectionTypeLoadException` during Lidarr startup.
+- Ensured the build resolves Lidarr assemblies from `ext/Lidarr-docker/_output/net8.0` first so Brainarr compiles against 2.14.2+ and no longer triggers `ReflectionTypeLoadException` during Lidarr startup.
 - Updated plugin metadata and docs to advertise v1.2.5 compatibility with the current Lidarr nightly baseline.
 
 ### Testing / CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ The CI workflow now uses pre-built Lidarr assemblies instead of trying to build 
 - name: Download Lidarr Assemblies
   run: |
     echo "Downloading Lidarr assemblies from latest release..."
-    mkdir -p ext/Lidarr/_output/net6.0
+    mkdir -p ext/Lidarr/_output/net8.0
 
     # Get latest release URL dynamically
     LIDARR_URL=$(curl -s https://api.github.com/repos/Lidarr/Lidarr/releases/latest | grep "browser_download_url.*linux-core-x64.tar.gz" | cut -d '"' -f 4 | head -1)
@@ -147,10 +147,10 @@ The CI workflow now uses pre-built Lidarr assemblies instead of trying to build 
     tar -xzf lidarr.tar.gz
 
     # Copy required assemblies
-    cp Lidarr/Lidarr.Core.dll ext/Lidarr/_output/net6.0/
-    cp Lidarr/Lidarr.Common.dll ext/Lidarr/_output/net6.0/
-    cp Lidarr/Lidarr.Http.dll ext/Lidarr/_output/net6.0/
-    cp Lidarr/Lidarr.Api.V1.dll ext/Lidarr/_output/net6.0/
+    cp Lidarr/Lidarr.Core.dll ext/Lidarr/_output/net8.0/
+    cp Lidarr/Lidarr.Common.dll ext/Lidarr/_output/net8.0/
+    cp Lidarr/Lidarr.Http.dll ext/Lidarr/_output/net8.0/
+    cp Lidarr/Lidarr.Api.V1.dll ext/Lidarr/_output/net8.0/
 ```
 
 ### Why This Works
@@ -174,10 +174,10 @@ The CI workflow now uses pre-built Lidarr assemblies instead of trying to build 
 The project's `.csproj` file has sophisticated Lidarr path resolution that automatically finds assemblies in:
 1. Command line: `-p:LidarrPath=...`
 2. Environment: `LIDARR_PATH`
-3. Local submodule: `ext/Lidarr/_output/net6.0`
+3. Local submodule: `ext/Lidarr/_output/net8.0`
 4. System installations: `/opt/Lidarr`, `C:\ProgramData\Lidarr\bin`, etc.
 
-For local development, ensure Lidarr assemblies are present in `ext/Lidarr/_output/net6.0/` or set the `LIDARR_PATH` environment variable.
+For local development, ensure Lidarr assemblies are present in `ext/Lidarr/_output/net8.0/` or set the `LIDARR_PATH` environment variable.
 
 ### CI Status: ✅ WORKING
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -117,7 +117,7 @@ The build scripts handle all dependencies automatically:
 1. **Preferred:** Extract Lidarr plugins/nightly assemblies from Docker (no source clone required)
 ```bash
 bash ./scripts/extract-lidarr-assemblies.sh
-export LIDARR_PATH="$(pwd)/ext/Lidarr-docker/_output/net6.0"
+export LIDARR_PATH="$(pwd)/ext/Lidarr-docker/_output/net8.0"
 ```
 
 2. **Alternative (advanced): Clone Lidarr source:**
@@ -131,10 +131,10 @@ cd ../..
 3. **Set LIDARR_PATH environment variable:**
 ```bash
 # Linux/macOS
-export LIDARR_PATH="$(pwd)/ext/Lidarr/_output/net6.0"
+export LIDARR_PATH="$(pwd)/ext/Lidarr/_output/net8.0"
 
 # Windows PowerShell
-$env:LIDARR_PATH = "$(Get-Location)\ext\Lidarr\_output\net6.0"
+$env:LIDARR_PATH = "$(Get-Location)\ext\Lidarr\_output\net8.0"
 ```
 
 4. **Build the plugin:**
@@ -215,7 +215,7 @@ The plugin tracks:
 
 ## CI/CD Pipeline
 
-GitHub Actions jobs extract Lidarr assemblies from Docker image `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` into `ext/Lidarr-docker/_output/net6.0/`, build Brainarr against those binaries, run tests, and publish release artifacts.
+GitHub Actions jobs extract Lidarr assemblies from Docker image `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` into `ext/Lidarr-docker/_output/net8.0/`, build Brainarr against those binaries, run tests, and publish release artifacts.
 
 ## Troubleshooting
 

--- a/build.ps1
+++ b/build.ps1
@@ -72,9 +72,9 @@ if ($Setup) {
 
 # Check if we have Lidarr available
 $lidarrPaths = @(
-    ".\ext\Lidarr-docker\_output\net6.0",
-    ".\ext\Lidarr\_output\net6.0",
-    ".\ext\Lidarr\src\Lidarr\bin\Release\net6.0",
+    ".\ext\Lidarr-docker\_output\net8.0",
+    ".\ext\Lidarr\_output\net8.0",
+    ".\ext\Lidarr\src\Lidarr\bin\Release\net8.0",
     $env:LIDARR_PATH,
     "C:\ProgramData\Lidarr\bin"
 )
@@ -210,7 +210,7 @@ if ($Package) {
         Write-Host "Version missing from plugin.json" -ForegroundColor Red
         exit 1
     }
-    $packageName = "Brainarr-$version.net6.0.zip"
+    $packageName = "Brainarr-$version.net8.0.zip"
 
     Push-Location $outputPath
     try {

--- a/build.sh
+++ b/build.sh
@@ -85,9 +85,9 @@ fi
 # Find Lidarr
 LIDARR_FOUND=false
 LIDARR_PATHS=(
-    "./ext/Lidarr-docker/_output/net6.0"
-    "./ext/Lidarr/_output/net6.0"
-    "./ext/Lidarr/src/Lidarr/bin/Release/net6.0"
+    "./ext/Lidarr-docker/_output/net8.0"
+    "./ext/Lidarr/_output/net8.0"
+    "./ext/Lidarr/src/Lidarr/bin/Release/net8.0"
     "$LIDARR_PATH"
     "/opt/Lidarr"
     "/usr/lib/lidarr/bin"
@@ -193,7 +193,7 @@ if [ "$PACKAGE" = true ]; then
         echo -e "${RED}Failed to parse version from plugin.json${NC}"
         exit 1
     fi
-    PACKAGE_NAME="Brainarr-$VERSION.net6.0.zip"
+    PACKAGE_NAME="Brainarr-$VERSION.net8.0.zip"
 
     # Remove existing package
     [ -f "$PACKAGE_NAME" ] && rm "$PACKAGE_NAME"

--- a/docs/CI_CD_IMPROVEMENTS.md
+++ b/docs/CI_CD_IMPROVEMENTS.md
@@ -79,7 +79,7 @@ Critical version alignments for Lidarr plugins:
 
 | Component | Version | Notes |
 |-----------|---------|-------|
-| Target Framework | net6.0 | Must match Lidarr host |
+| Target Framework | net8.0 | Must match Lidarr host |
 | Microsoft.Extensions.* | 8.0.x | Required by modern NLog |
 | FluentValidation | 9.5.4 | Matches Lidarr's version |
 | NLog | 5.4.0 | Compatible with Lidarr |

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -28,7 +28,7 @@ Use this list to confirm the release is ready **before** running `./.github/scri
 
 ## 5. Packaging Snapshot (optional if tag script succeeds locally)
 
-- [ ] `pwsh ./build.ps1 --package` (or `./build.sh --package`) produces `Brainarr-<version>.net6.0.zip` + checksums.
+- [ ] `pwsh ./build.ps1 --package` (or `./build.sh --package`) produces `Brainarr-<version>.net8.0.zip` + checksums.
 - [ ] Inspect ZIP contents: `Lidarr.Plugin.Brainarr.dll` + `plugin.json` only.
 
 ## 6. Tag & Publish

--- a/docs/USER_SETUP_GUIDE.md
+++ b/docs/USER_SETUP_GUIDE.md
@@ -12,7 +12,7 @@
 
 - Run `./setup.ps1` (Windows) or `./setup.sh` (macOS/Linux) from the repository root to fetch Lidarr assemblies and restore the Brainarr solution.
 - Optional: `pwsh ./build.ps1 --test` to run the full validation suite before deploying to production.
-- Keep `ext/Lidarr/_output/net6.0` intact—this is where the setup scripts place the assemblies Lidarr expects.
+- Keep `ext/Lidarr/_output/net8.0` intact—this is where the setup scripts place the assemblies Lidarr expects.
 
 ## Step 2 — Choose and configure a provider
 

--- a/docs/archive/DOCUMENTATION_AUDIT_COMPLETE.md
+++ b/docs/archive/DOCUMENTATION_AUDIT_COMPLETE.md
@@ -96,7 +96,7 @@ Files lacking comprehensive documentation:
 
 ### 3.3 Build Commands
 **Issue**: Build instructions don't mention required Lidarr assemblies
-- Missing step: Setting up ext/Lidarr/_output/net6.0/
+- Missing step: Setting up ext/Lidarr/_output/net8.0/
 - No mention of LIDARR_PATH environment variable
 - Should reference BUILD.md for detailed instructions
 

--- a/docs/ci-stability-guide.md
+++ b/docs/ci-stability-guide.md
@@ -88,7 +88,7 @@ matrix:
 ```bash
 # Preferred: Extract from plugins Docker image
 LIDARR_DOCKER_VERSION=${LIDARR_DOCKER_VERSION:-pr-plugins-2.14.2.4786}
-mkdir -p ext/Lidarr/_output/net6.0
+mkdir -p ext/Lidarr/_output/net8.0
 docker pull ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}
 cid=$(docker create ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION})
 for f in \
@@ -98,7 +98,7 @@ for f in \
   Lidarr.Http.dll \
   Lidarr.Api.V1.dll \
   Lidarr.Host.dll; do
-  docker cp "$cid:/app/bin/$f" ext/Lidarr/_output/net6.0/ 2>/dev/null || echo "Optional: $f missing"
+  docker cp "$cid:/app/bin/$f" ext/Lidarr/_output/net8.0/ 2>/dev/null || echo "Optional: $f missing"
 done
 docker rm -f "$cid" >/dev/null
 ```
@@ -136,7 +136,7 @@ Fallback to release tarballs is allowed only when Docker is unavailable or when 
 dotnet test --blame-hang-timeout 30s --logger:"console;verbosity=detailed"
 
 # Assembly verification
-ls -la ext/Lidarr/_output/net6.0/
+ls -la ext/Lidarr/_output/net8.0/
 
 # Build verification
 dotnet build --verbosity normal

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
   "issues": "https://github.com/RicherTunes/Brainarr/issues",
   "changelog": "https://github.com/RicherTunes/Brainarr/blob/main/CHANGELOG.md",
   "entryPoint": "Lidarr.Plugin.Brainarr.dll",
-  "targetFramework": "net6.0",
+  "targetFramework": "net8.0",
   "runtime": "linux-x64;win-x64;osx-x64",
   "files": [
     {
@@ -136,6 +136,6 @@
       "sha256": "ad4dfe6fd52e0fad594016696b971f16929b9f8108255d5b0991a69ff2666120"
     }
   ],
-  "downloadUrl": "https://github.com/RicherTunes/Brainarr/releases/latest/download/Brainarr-{version}.net6.0.zip",
+  "downloadUrl": "https://github.com/RicherTunes/Brainarr/releases/latest/download/Brainarr-{version}.net8.0.zip",
   "updateUrl": "https://api.github.com/repos/RicherTunes/Brainarr/releases/latest"
 }

--- a/scripts/branch-audit.sh
+++ b/scripts/branch-audit.sh
@@ -45,4 +45,4 @@ while read -r ref; do
 done <<<"$list"
 
 echo
-echo "Tip: to test a branch locally without committing, try:\n  git checkout -B audit/<name> $BASE_REF && git merge --no-ff $REMOTE/<name> --no-edit || true\n  LIDARR_DOCKER_VERSION=pr-plugins-2.13.3.4692 ./setup-lidarr.sh --mode docker\n  dotnet build Brainarr.sln -c Release -p:LidarrPath=\"$PWD/ext/Lidarr/_output/net6.0\"\n  ~/.dotnet/dotnet test Brainarr.sln -c Release --no-build --filter \"TestCategory=Unit|Category=Unit\""
+echo "Tip: to test a branch locally without committing, try:\n  git checkout -B audit/<name> $BASE_REF && git merge --no-ff $REMOTE/<name> --no-edit || true\n  LIDARR_DOCKER_VERSION=pr-plugins-2.13.3.4692 ./setup-lidarr.sh --mode docker\n  dotnet build Brainarr.sln -c Release -p:LidarrPath=\"$PWD/ext/Lidarr/_output/net8.0\"\n  ~/.dotnet/dotnet test Brainarr.sln -c Release --no-build --filter \"TestCategory=Unit|Category=Unit\""

--- a/scripts/ci/check-assemblies.sh
+++ b/scripts/ci/check-assemblies.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Brainarr CI sanity: verify Lidarr assemblies are present and consistent
 # Usage: check-assemblies.sh [assemblies_dir] [--expect-tag ghcr.io/hotio/lidarr:TAG]
 
-DIR=${1:-"ext/Lidarr-docker/_output/net6.0"}
+DIR=${1:-"ext/Lidarr-docker/_output/net8.0"}
 EXPECT_TAG=""
 
 if [[ ${2:-} == "--expect-tag" ]]; then

--- a/scripts/extract-lidarr-assemblies.sh
+++ b/scripts/extract-lidarr-assemblies.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Brainarr CI helper: Extract Lidarr assemblies from the plugins image
 # Fallback order: digest (if provided) -> tag -> pinned tar.gz
 
-OUT_DIR="ext/Lidarr-docker/_output/net6.0"
+OUT_DIR="ext/Lidarr-docker/_output/net8.0"
 NO_TAR_FALLBACK="false"
 MODE="minimal" # minimal|full
 

--- a/scripts/seed-initial-issues.ps1
+++ b/scripts/seed-initial-issues.ps1
@@ -104,8 +104,8 @@ Acceptance
 AGENTS decision: extract required Lidarr assemblies from the Hotio `plugins` branch Docker image and publish as an artifact for matrix jobs.
 
 Tasks
-- [ ] Create a dedicated job that pulls `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` and exports `/app/bin` assemblies to `ext/Lidarr-docker/_output/net6.0/`
-- [ ] Upload artifact `lidarr-assemblies-net6.0`
+- [ ] Create a dedicated job that pulls `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` and exports `/app/bin` assemblies to `ext/Lidarr-docker/_output/net8.0/`
+- [ ] Upload artifact `lidarr-assemblies-net8.0`
 - [ ] Replace re-extraction in dependent jobs with artifact download
 
 Acceptance
@@ -114,7 +114,7 @@ Acceptance
 '@ },
 
   @{ title = "CI: Fail-fast if Lidarr assemblies missing"; labels = @("ci","task","needs-triage"); body = @'
-Add an early sanity check in build/test jobs to fail if `ext/Lidarr-docker/_output/net6.0/` is absent or empty.
+Add an early sanity check in build/test jobs to fail if `ext/Lidarr-docker/_output/net8.0/` is absent or empty.
 
 Tasks
 - [ ] Add pre-build step to assert required assemblies exist

--- a/scripts/seed-initial-issues.sh
+++ b/scripts/seed-initial-issues.sh
@@ -153,8 +153,8 @@ BODY2=$(cat <<'EOF'
 AGENTS decision: extract required Lidarr assemblies from the Hotio `plugins` branch Docker image and publish as an artifact for matrix jobs.
 
 Tasks
-- [ ] Create a dedicated job that pulls `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` and exports `/app/bin` assemblies to `ext/Lidarr-docker/_output/net6.0/`
-- [ ] Upload artifact `lidarr-assemblies-net6.0`
+- [ ] Create a dedicated job that pulls `ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}` and exports `/app/bin` assemblies to `ext/Lidarr-docker/_output/net8.0/`
+- [ ] Upload artifact `lidarr-assemblies-net8.0`
 - [ ] Replace re-extraction in dependent jobs with artifact download
 
 Acceptance
@@ -164,7 +164,7 @@ EOF
 )
 
 BODY3=$(cat <<'EOF'
-Add an early sanity check in build/test jobs to fail if `ext/Lidarr-docker/_output/net6.0/` is absent or empty.
+Add an early sanity check in build/test jobs to fail if `ext/Lidarr-docker/_output/net8.0/` is absent or empty.
 
 Tasks
 - [ ] Add pre-build step to assert required assemblies exist

--- a/scripts/snapshots/run-local.ps1
+++ b/scripts/snapshots/run-local.ps1
@@ -20,18 +20,18 @@ Need node
 $root = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
 Set-Location $root
 
-if (-not (Test-Path 'ext/Lidarr/_output/net6.0/Lidarr.Core.dll')) {
+if (-not (Test-Path 'ext/Lidarr/_output/net8.0/Lidarr.Core.dll')) {
   Write-Host 'Lidarr assemblies missing; running setup.ps1' -ForegroundColor Yellow
   ./setup.ps1
 }
 
 if (-not $SkipBuild) {
   dotnet restore ./Brainarr.Plugin/Brainarr.Plugin.csproj
-  dotnet build ./Brainarr.Plugin/Brainarr.Plugin.csproj -c Release -p:LidarrPath="$(Resolve-Path 'ext/Lidarr/_output/net6.0')" -m:1
+  dotnet build ./Brainarr.Plugin/Brainarr.Plugin.csproj -c Release -p:LidarrPath="$(Resolve-Path 'ext/Lidarr/_output/net8.0')" -m:1
 }
 
 New-Item -ItemType Directory -Force -Path plugin-dist | Out-Null
-$dll = Join-Path $root 'Brainarr.Plugin/bin/Release/net6.0/Lidarr.Plugin.Brainarr.dll'
+$dll = Join-Path $root 'Brainarr.Plugin/bin/Release/net8.0/Lidarr.Plugin.Brainarr.dll'
 if (-not (Test-Path $dll)) {
   $dll = Join-Path $root 'Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll'
 }

--- a/scripts/snapshots/run-local.sh
+++ b/scripts/snapshots/run-local.sh
@@ -43,8 +43,8 @@ ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT_DIR"
 
 # Ensure Lidarr assemblies exist; recommend setup if missing
-if [[ ! -f ext/Lidarr/_output/net6.0/Lidarr.Core.dll ]]; then
-  echo "Lidarr assemblies not found at ext/Lidarr/_output/net6.0; running ./setup.sh --setup" >&2
+if [[ ! -f ext/Lidarr/_output/net8.0/Lidarr.Core.dll ]]; then
+  echo "Lidarr assemblies not found at ext/Lidarr/_output/net8.0; running ./setup.sh --setup" >&2
   chmod +x ./setup.sh 2>/dev/null || true
   ./setup.sh --setup || { echo "setup.sh failed" >&2; exit 1; }
 fi
@@ -52,14 +52,14 @@ fi
 # Build Brainarr plugin (unless skipped)
 if [[ "$SKIP_BUILD" != "true" ]]; then
   dotnet restore Brainarr.Plugin/Brainarr.Plugin.csproj
-  dotnet build Brainarr.Plugin/Brainarr.Plugin.csproj -c Release -p:LidarrPath="$(pwd)/ext/Lidarr/_output/net6.0" -m:1
+  dotnet build Brainarr.Plugin/Brainarr.Plugin.csproj -c Release -p:LidarrPath="$(pwd)/ext/Lidarr/_output/net8.0" -m:1
 fi
 
 # Stage plugin files for Lidarr plugin mount
 mkdir -p plugin-dist
 DLL_SRC=""
-if [[ -f Brainarr.Plugin/bin/Release/net6.0/Lidarr.Plugin.Brainarr.dll ]]; then
-  DLL_SRC="Brainarr.Plugin/bin/Release/net6.0/Lidarr.Plugin.Brainarr.dll"
+if [[ -f Brainarr.Plugin/bin/Release/net8.0/Lidarr.Plugin.Brainarr.dll ]]; then
+  DLL_SRC="Brainarr.Plugin/bin/Release/net8.0/Lidarr.Plugin.Brainarr.dll"
 elif [[ -f Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll ]]; then
   DLL_SRC="Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll"
 fi

--- a/setup-lidarr.ps1
+++ b/setup-lidarr.ps1
@@ -93,8 +93,8 @@ try {
     }
 
     $lidarrCandidates = @(
-        Join-Path $extFullPath "_output/net6.0",
-        Join-Path $extFullPath "src/Lidarr/bin/Release/net6.0"
+        Join-Path $extFullPath "_output/net8.0",
+        Join-Path $extFullPath "src/Lidarr/bin/Release/net8.0"
     )
 
     foreach ($candidate in $lidarrCandidates) {

--- a/setup-lidarr.sh
+++ b/setup-lidarr.sh
@@ -8,18 +8,18 @@ set -euo pipefail
 MODE="docker"        # docker | source
 BRANCH="plugins"     # used when MODE=source
 EXT_PATH="ext/Lidarr"
-OUT_PATH="$EXT_PATH/_output/net6.0"
+OUT_PATH="$EXT_PATH/_output/net8.0"
 DOCKER_TAG="${LIDARR_DOCKER_VERSION:-pr-plugins-2.13.3.4692}"
 
 usage() {
   cat <<EOF
-Usage: $0 [--mode docker|source] [--branch plugins] [--ext-path ext/Lidarr] [--out-path ext/Lidarr/_output/net6.0] [--docker-tag <tag>]
+Usage: $0 [--mode docker|source] [--branch plugins] [--ext-path ext/Lidarr] [--out-path ext/Lidarr/_output/net8.0] [--docker-tag <tag>]
 
 Options:
   --mode        docker (default) to extract from ghcr.io/hotio/lidarr:<tag>, or source to clone/build Lidarr.
   --branch      Lidarr branch for MODE=source (default: plugins)
   --ext-path    Path to ext/Lidarr working directory (default: ext/Lidarr)
-  --out-path    Destination for assemblies (default: ext/Lidarr/_output/net6.0)
+  --out-path    Destination for assemblies (default: ext/Lidarr/_output/net8.0)
   --docker-tag  Docker tag for plugins image (default: env LIDARR_DOCKER_VERSION or pr-plugins-2.13.3.4692)
 
 Environment:
@@ -72,7 +72,7 @@ elif [[ "$MODE" == "source" ]]; then
   popd >/dev/null
   # Prefer standard _output
   if [[ ! -d "$OUT_PATH" ]]; then
-    alt="$EXT_PATH/src/NzbDrone.Core/bin/Release/net6.0"
+    alt="$EXT_PATH/src/NzbDrone.Core/bin/Release/net8.0"
     if [[ -d "$alt" ]]; then
       OUT_PATH="$alt"
     fi

--- a/setup.ps1
+++ b/setup.ps1
@@ -35,8 +35,8 @@ function Resolve-LidarrPath {
     }
 
     $candidates += @(
-        Join-Path $Root "ext/Lidarr/_output/net6.0",
-        Join-Path $Root "ext/Lidarr/src/Lidarr/bin/Release/net6.0"
+        Join-Path $Root "ext/Lidarr/_output/net8.0",
+        Join-Path $Root "ext/Lidarr/src/Lidarr/bin/Release/net8.0"
     )
 
     foreach ($candidate in $candidates) {

--- a/setup.sh
+++ b/setup.sh
@@ -53,8 +53,8 @@ resolve_lidarr_path() {
     candidates+=("$recorded")
   fi
   candidates+=(
-    "$ext_full_path/_output/net6.0"
-    "$ext_full_path/src/Lidarr/bin/Release/net6.0"
+    "$ext_full_path/_output/net8.0"
+    "$ext_full_path/src/Lidarr/bin/Release/net8.0"
   )
 
   for candidate in "${candidates[@]}"; do

--- a/tasks/seed.json
+++ b/tasks/seed.json
@@ -17,7 +17,7 @@
     },
     {
       "title": "CI: Add fast-fail guard for missing Lidarr assemblies",
-      "body": "Before restore/build, verify required assemblies exist under ext/Lidarr-docker/_output/net6.0 and fail with a clear message if missing.",
+      "body": "Before restore/build, verify required assemblies exist under ext/Lidarr-docker/_output/net8.0 and fail with a clear message if missing.",
       "labels": ["ci"]
     },
     {

--- a/test-local-ci.ps1
+++ b/test-local-ci.ps1
@@ -20,9 +20,9 @@ if (Test-Path "Lidarr") { Remove-Item "Lidarr" -Recurse -Force }
 if (Test-Path "TestResults") { Remove-Item "TestResults" -Recurse -Force }
 try { Get-Process testhost -ErrorAction SilentlyContinue | Stop-Process -Force } catch {}
 
-# Step 2: Ensure ext/Lidarr/_output/net6.0 directory exists
+# Step 2: Ensure ext/Lidarr/_output/net8.0 directory exists
 Write-Host "`n📁 Setting up Lidarr assemblies directory..." -ForegroundColor Yellow
-$lidarrPath = "ext/Lidarr/_output/net6.0"
+$lidarrPath = "ext/Lidarr/_output/net8.0"
 if (-not (Test-Path $lidarrPath)) {
     New-Item -ItemType Directory -Path $lidarrPath -Force | Out-Null
 }

--- a/test-local-ci.sh
+++ b/test-local-ci.sh
@@ -18,10 +18,10 @@ rm -f lidarr.tar.gz
 rm -rf Lidarr/
 rm -rf TestResults/
 
-# Step 2: Ensure ext/Lidarr/_output/net6.0 directory exists
+# Step 2: Ensure ext/Lidarr/_output/net8.0 directory exists
 echo ""
 echo "?? Setting up Lidarr assemblies directory..."
-mkdir -p ext/Lidarr/_output/net6.0
+mkdir -p ext/Lidarr/_output/net8.0
 
 # Step 3: Obtain Lidarr assemblies (prefer plugins Docker, fallback to tar.gz)
 if [ "$SKIP_DOWNLOAD" != "true" ]; then
@@ -32,9 +32,9 @@ if [ "$SKIP_DOWNLOAD" != "true" ]; then
         docker pull ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION}
         cid=$(docker create ghcr.io/hotio/lidarr:${LIDARR_DOCKER_VERSION})
         # Copy entire /app/bin to ensure all runtime dependencies are present (e.g., Equ.dll)
-        docker cp "$cid:/app/bin/." ext/Lidarr/_output/net6.0/
+        docker cp "$cid:/app/bin/." ext/Lidarr/_output/net8.0/
         docker rm -f "$cid" >/dev/null
-        echo "? Assemblies ready (Docker)"; ls -la ext/Lidarr/_output/net6.0/ || true
+        echo "? Assemblies ready (Docker)"; ls -la ext/Lidarr/_output/net8.0/ || true
     else
         echo "Docker not found; falling back to release tarball"
         LIDARR_URL=$(curl -s https://api.github.com/repos/Lidarr/Lidarr/releases/latest | grep "browser_download_url.*linux-core-x64.tar.gz" | cut -d '"' -f 4 | head -1)
@@ -47,9 +47,9 @@ if [ "$SKIP_DOWNLOAD" != "true" ]; then
         tar -xzf lidarr.tar.gz
         if [ -d "Lidarr" ]; then
             for f in Lidarr.Core.dll Lidarr.Common.dll Lidarr.Http.dll Lidarr.Api.V1.dll; do
-                cp "Lidarr/$f" ext/Lidarr/_output/net6.0/ 2>/dev/null || echo "$f not found"
+                cp "Lidarr/$f" ext/Lidarr/_output/net8.0/ 2>/dev/null || echo "$f not found"
             done
-            echo "? Assemblies ready (tar.gz)"; ls -la ext/Lidarr/_output/net6.0/ || true
+            echo "? Assemblies ready (tar.gz)"; ls -la ext/Lidarr/_output/net8.0/ || true
         else
             echo "? Failed to extract Lidarr archive"; exit 1
         fi
@@ -59,7 +59,7 @@ else
 fi
 
 # Step 4: Set environment variable (same as CI)
-export LIDARR_PATH="$(pwd)/ext/Lidarr/_output/net6.0"
+export LIDARR_PATH="$(pwd)/ext/Lidarr/_output/net8.0"
 echo ""; echo "?? Set LIDARR_PATH=$LIDARR_PATH"
 
 # Step 5: Restore dependencies

--- a/tests/Brainarr.Providers.OpenAI.Tests/Brainarr.Providers.OpenAI.Tests.csproj
+++ b/tests/Brainarr.Providers.OpenAI.Tests/Brainarr.Providers.OpenAI.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <!-- Prefer default testhost dependency resolution; Lidarr assemblies resolved via ModuleInitializer resolver -->
@@ -26,8 +26,8 @@
   <!-- Ensure Lidarr assemblies are present at test runtime -->
   <PropertyGroup>
     <LidarrPath Condition="'$(LidarrPath)' == ''">$(LIDARR_PATH)</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr-docker\\_output\\net6.0')">..\\..\\ext\\Lidarr-docker\\_output\\net6.0</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr\\_output\\net6.0')">..\\..\\ext\\Lidarr\\_output\\net6.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr-docker\\_output\\net8.0')">..\\..\\ext\\Lidarr-docker\\_output\\net8.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr\\_output\\net8.0')">..\\..\\ext\\Lidarr\\_output\\net8.0</LidarrPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(LidarrPath)' != ''">
     <Reference Include="Lidarr.Common">

--- a/tests/Brainarr.Providers.OpenAI.Tests/Directory.Build.props
+++ b/tests/Brainarr.Providers.OpenAI.Tests/Directory.Build.props
@@ -2,8 +2,8 @@
   <!-- Ensure Lidarr assemblies are present at test runtime for this test project -->
   <PropertyGroup>
     <LidarrPath Condition="'$(LidarrPath)' == ''">$(LIDARR_PATH)</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr-docker\\_output\\net6.0')">..\\..\\ext\\Lidarr-docker\\_output\\net6.0</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr\\_output\\net6.0')">..\\..\\ext\\Lidarr\\_output\\net6.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr-docker\\_output\\net8.0')">..\\..\\ext\\Lidarr-docker\\_output\\net8.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr\\_output\\net8.0')">..\\..\\ext\\Lidarr\\_output\\net8.0</LidarrPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(LidarrPath)' != ''">
     <Reference Include="Lidarr.Core">

--- a/tests/Brainarr.TestKit.Providers/Brainarr.TestKit.Providers.csproj
+++ b/tests/Brainarr.TestKit.Providers/Brainarr.TestKit.Providers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <IsTestProject>false</IsTestProject>
@@ -11,8 +11,8 @@
   <!-- Resolve LidarrPath from env and common extraction locations -->
   <PropertyGroup>
     <LidarrPath Condition="'$(LidarrPath)' == ''">$(LIDARR_PATH)</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr-docker\\_output\\net6.0')">..\\..\\ext\\Lidarr-docker\\_output\\net6.0</LidarrPath>
-    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr\\_output\\net6.0')">..\\..\\ext\\Lidarr\\_output\\net6.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr-docker\\_output\\net8.0')">..\\..\\ext\\Lidarr-docker\\_output\\net8.0</LidarrPath>
+    <LidarrPath Condition="'$(LidarrPath)' == '' AND Exists('..\\..\\ext\\Lidarr\\_output\\net8.0')">..\\..\\ext\\Lidarr\\_output\\net8.0</LidarrPath>
   </PropertyGroup>
   <ItemGroup>
     <!-- Compile-time reference to Lidarr Http abstractions used by TestKit -->


### PR DESCRIPTION
## Summary

Lidarr's plugins branch has migrated to .NET 8.0 ([commit 5313298](https://github.com/Lidarr/Lidarr/commit/5313298)). Plugins compiled for .NET 6.0 fail to load with `TypeLoadException` when running on .NET 8.0 runtime due to assembly binding issues.

**Error from issue #268:**
```
System.TypeLoadException: Method 'Test' in type 'NzbDrone.Core.ImportLists.Brainarr.Brainarr' does not have an implementation.
```

## Changes

This commit updates:
- Target framework from `net6.0` to `net8.0` in all project files
- All assembly path references in csproj files, scripts, and workflows  
- CI workflows to extract and use net8.0 assemblies
- Build scripts and documentation references

## Files Modified

- **Project files:** `Brainarr.Plugin.csproj`, `Brainarr.Tests.csproj`, test project files
- **CI workflows:** All workflow files updated
- **Scripts:** `build.sh`, `build.ps1`, `extract-lidarr-assemblies.sh`, setup scripts
- **Documentation:** BUILD.md, AGENTS.md, and other docs updated

## Test Plan

- [ ] CI builds pass with .NET 8.0 target
- [ ] Plugin loads successfully on Lidarr running .NET 8.0 runtime
- [ ] Existing functionality works as expected

Fixes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)