### PR TITLE
Fix CS1998 async warnings in test methods

### DIFF
--- a/Brainarr.Tests/EdgeCases/ResourceAndTimeTests.cs
+++ b/Brainarr.Tests/EdgeCases/ResourceAndTimeTests.cs
@@ -168,7 +168,7 @@ namespace Brainarr.Tests.EdgeCases
         }
 
         [Fact]
-        public async Task HealthMonitor_WithSystemTimeGoingBackwards_HandlesGracefully()
+        public void HealthMonitor_WithSystemTimeGoingBackwards_HandlesGracefully()
         {
             // Arrange
             var healthMonitor = new ProviderHealthMonitor(_logger);

--- a/Brainarr.Tests/Integration/EndToEndTests.cs
+++ b/Brainarr.Tests/Integration/EndToEndTests.cs
@@ -166,7 +166,7 @@ namespace Brainarr.Tests.Integration
         }
 
         [Fact]
-        public async Task RecommendationFlow_WithHealthMonitoring_TracksHealth()
+        public void RecommendationFlow_WithHealthMonitoring_TracksHealth()
         {
             // Arrange
             var healthMonitor = new ProviderHealthMonitor(_logger);

--- a/Brainarr.Tests/RateLimiterTests.cs
+++ b/Brainarr.Tests/RateLimiterTests.cs
@@ -22,7 +22,7 @@ namespace Brainarr.Tests
 
             var sw = Stopwatch.StartNew();
             var tasks = Enumerable.Range(0, 10)
-                .Select(_ => limiter.ExecuteAsync("test", async () => DateTime.UtcNow))
+                .Select(_ => limiter.ExecuteAsync("test", () => Task.FromResult(DateTime.UtcNow)))
                 .ToArray();
 
             var times = await Task.WhenAll(tasks);
@@ -48,13 +48,13 @@ namespace Brainarr.Tests
             limiter.Configure("cancel", 1, TimeSpan.FromSeconds(5));
 
             // Consume the first slot
-            await limiter.ExecuteAsync("cancel", async ct => 1, CancellationToken.None);
+            await limiter.ExecuteAsync("cancel", ct => Task.FromResult(1), CancellationToken.None);
 
             using var cts = new CancellationTokenSource(100);
 
             Func<Task> act = async () =>
             {
-                await limiter.ExecuteAsync("cancel", async ct => 2, cts.Token);
+                await limiter.ExecuteAsync("cancel", ct => Task.FromResult(2), cts.Token);
             };
 
             await act.Should().ThrowAsync<OperationCanceledException>();

--- a/Brainarr.Tests/RateLimiting/EnhancedRateLimiterTests.cs
+++ b/Brainarr.Tests/RateLimiting/EnhancedRateLimiterTests.cs
@@ -58,7 +58,7 @@ namespace Brainarr.Tests.RateLimiting
 
             // Consume and then check again
 
-            await limiter.ExecuteAsync(req, async () => 1);
+            await limiter.ExecuteAsync(req, () => Task.FromResult(1));
 
 
             var second = await limiter.CheckRateLimitAsync(req);

--- a/Brainarr.Tests/Services/Core/RecommendationCoordinatorTests.cs
+++ b/Brainarr.Tests/Services/Core/RecommendationCoordinatorTests.cs
@@ -58,10 +58,10 @@ namespace Brainarr.Tests.Services.Core
                 cache.Setup(c => c.TryGet(It.IsAny<string>(), out cachedItems)).Returns(true);
 
                 var fetchCalled = 0;
-                async Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct)
+                Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct)
                 {
                     fetchCalled++;
-                    return new List<Recommendation>();
+                    return Task.FromResult(new List<Recommendation>());
                 }
 
                 var usedKeys = new List<string>();
@@ -116,10 +116,10 @@ namespace Brainarr.Tests.Services.Core
                     .ReturnsAsync(pipelineResult);
 
                 var fetchCalled = 0;
-                async Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct)
+                Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct)
                 {
                     fetchCalled++;
-                    return new List<Recommendation> { new Recommendation { Artist = "X", Album = "Y" } };
+                    return Task.FromResult(new List<Recommendation> { new Recommendation { Artist = "X", Album = "Y" } });
                 }
 
                 var result = await coord.RunAsync(
@@ -168,9 +168,9 @@ namespace Brainarr.Tests.Services.Core
 
                 profiles.Setup(p => p.GetLibraryProfile()).Returns(new LibraryProfile());
 
-                async Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct)
+                Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct)
                 {
-                    return new List<Recommendation>();
+                    return Task.FromResult(new List<Recommendation>());
                 }
 
                 var settings = new BrainarrSettings();
@@ -322,7 +322,7 @@ namespace Brainarr.Tests.Services.Core
                 cache.Setup(c => c.Set(It.IsAny<string>(), It.IsAny<List<ImportListItemInfo>>(), It.IsAny<System.TimeSpan?>()))
                      .Callback<string, List<ImportListItemInfo>, System.TimeSpan?>((k, _, __) => keys.Add(k));
 
-                async Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => new List<Recommendation>();
+                Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => Task.FromResult(new List<Recommendation>());
 
                 var s1 = new BrainarrSettings { Provider = AIProvider.OpenAI, ModelSelection = "m" };
                 var s2 = new BrainarrSettings { Provider = AIProvider.Anthropic, ModelSelection = "m" };
@@ -355,7 +355,7 @@ namespace Brainarr.Tests.Services.Core
                 cache.Setup(c => c.Set(It.IsAny<string>(), It.IsAny<List<ImportListItemInfo>>(), It.IsAny<System.TimeSpan?>()))
                      .Callback<string, List<ImportListItemInfo>, System.TimeSpan?>((k, _, __) => keys.Add(k));
 
-                async Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => new List<Recommendation>();
+                Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => Task.FromResult(new List<Recommendation>());
 
                 var s1 = new BrainarrSettings { MaxRecommendations = 10, ModelSelection = "m" };
                 var s2 = new BrainarrSettings { MaxRecommendations = 20, ModelSelection = "m" };
@@ -404,7 +404,7 @@ namespace Brainarr.Tests.Services.Core
                     .Returns(lp1)
                     .Returns(lp2);
 
-                async Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => new List<Recommendation>();
+                Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => Task.FromResult(new List<Recommendation>());
                 var settings = new BrainarrSettings { ModelSelection = "m" };
                 await coord.RunAsync(settings, Fetch, new ReviewQueueService(logger, tmp), Mock.Of<IAIProvider>(), Mock.Of<ILibraryAwarePromptBuilder>(), CancellationToken.None);
                 // Force re-analysis by expiring cache
@@ -437,7 +437,7 @@ namespace Brainarr.Tests.Services.Core
                 cache.Setup(c => c.Set(It.IsAny<string>(), It.IsAny<List<ImportListItemInfo>>(), It.IsAny<System.TimeSpan?>()))
                      .Callback<string, List<ImportListItemInfo>, System.TimeSpan?>((k, _, __) => keys.Add(k));
 
-                async Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => new List<Recommendation>();
+                Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => Task.FromResult(new List<Recommendation>());
 
                 var s1 = new BrainarrSettings { SamplingStrategy = SamplingStrategy.Balanced, RecommendationMode = RecommendationMode.SpecificAlbums, ModelSelection = "m" };
                 var s2 = new BrainarrSettings { SamplingStrategy = SamplingStrategy.Comprehensive, RecommendationMode = RecommendationMode.SpecificAlbums, ModelSelection = "m" };
@@ -591,7 +591,7 @@ namespace Brainarr.Tests.Services.Core
                 var coord1 = new RecommendationCoordinator(logger, cache1.Object, pipeline1.Object, sanitizer1.Object, schema1.Object, history, profiles1.Object, keyBuilder);
                 var coord2 = new RecommendationCoordinator(logger, cache2.Object, pipeline2.Object, sanitizer2.Object, schema2.Object, history, profiles2.Object, keyBuilder);
 
-                async Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => new List<Recommendation>();
+                Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => Task.FromResult(new List<Recommendation>());
                 var settings = new BrainarrSettings { ModelSelection = "m", RecommendationMode = RecommendationMode.SpecificAlbums };
 
                 await coord1.RunAsync(settings, Fetch, new ReviewQueueService(logger, tmp), Mock.Of<IAIProvider>(), Mock.Of<ILibraryAwarePromptBuilder>(), CancellationToken.None);
@@ -620,7 +620,7 @@ namespace Brainarr.Tests.Services.Core
 
                 profiles.Setup(p => p.GetLibraryProfile()).Returns(new LibraryProfile());
 
-                async Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => new List<Recommendation>();
+                Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => Task.FromResult(new List<Recommendation>());
                 var settings = new BrainarrSettings();
 
                 // First run populates cache

--- a/Brainarr.Tests/Services/DuplicationPreventionServiceTests.cs
+++ b/Brainarr.Tests/Services/DuplicationPreventionServiceTests.cs
@@ -487,15 +487,15 @@ namespace Brainarr.Tests.Services
 
             // Act
             var results = await Task.WhenAll(
-                _service.PreventConcurrentFetch(operationKey, async () =>
+                _service.PreventConcurrentFetch(operationKey, () =>
                 {
                     executionTimes.Add(DateTime.UtcNow);
-                    return "first";
+                    return Task.FromResult("first");
                 }),
-                Task.Delay(10).ContinueWith(_ => _service.PreventConcurrentFetch(operationKey, async () =>
+                Task.Delay(10).ContinueWith(_ => _service.PreventConcurrentFetch(operationKey, () =>
                 {
                     executionTimes.Add(DateTime.UtcNow);
-                    return "second";
+                    return Task.FromResult("second");
                 })).Unwrap()
             );
 

--- a/Brainarr.Tests/Services/ProviderHealthTests.cs
+++ b/Brainarr.Tests/Services/ProviderHealthTests.cs
@@ -22,7 +22,7 @@ namespace Brainarr.Tests.Services
         }
 
         [Fact]
-        public async Task CheckHealthAsync_NewProvider_ReturnsHealthy()
+        public void CheckHealthAsync_NewProvider_ReturnsHealthy()
         {
             // Arrange - Add enough success metrics to avoid HTTP check
             var provider = "new-provider";
@@ -39,7 +39,7 @@ namespace Brainarr.Tests.Services
         }
 
         [Fact]
-        public async Task RecordSuccess_UpdatesMetrics()
+        public void RecordSuccess_UpdatesMetrics()
         {
             // Arrange
             var provider = "test-provider";
@@ -57,7 +57,7 @@ namespace Brainarr.Tests.Services
         }
 
         [Fact]
-        public async Task RecordFailure_UpdatesMetrics()
+        public void RecordFailure_UpdatesMetrics()
         {
             // Arrange
             var provider = "test-provider";
@@ -75,7 +75,7 @@ namespace Brainarr.Tests.Services
         }
 
         [Fact]
-        public async Task CheckHealthAsync_MixedResults_CalculatesCorrectly()
+        public void CheckHealthAsync_MixedResults_CalculatesCorrectly()
         {
             // Arrange
             var provider = "test-provider";
@@ -99,7 +99,7 @@ namespace Brainarr.Tests.Services
         }
 
         [Fact]
-        public async Task CheckHealthAsync_MostlyFailures_ReturnsUnhealthy()
+        public void CheckHealthAsync_MostlyFailures_ReturnsUnhealthy()
         {
             // Arrange
             var provider = "test-provider";
@@ -123,7 +123,7 @@ namespace Brainarr.Tests.Services
         }
 
         [Fact]
-        public async Task CheckHealthAsync_ExactlyHalfFailures_ReturnsDegraded()
+        public void CheckHealthAsync_ExactlyHalfFailures_ReturnsDegraded()
         {
             // Arrange
             var provider = "test-provider";
@@ -154,7 +154,7 @@ namespace Brainarr.Tests.Services
         [InlineData(500, HealthStatus.Healthy)]
         [InlineData(1000, HealthStatus.Healthy)]
         [InlineData(5000, HealthStatus.Healthy)]
-        public async Task RecordSuccess_WithVariousResponseTimes_AcceptsAll(double responseTime, HealthStatus expectedStatus)
+        public void RecordSuccess_WithVariousResponseTimes_AcceptsAll(double responseTime, HealthStatus expectedStatus)
         {
             // Arrange
             var provider = "test-provider";
@@ -175,7 +175,7 @@ namespace Brainarr.Tests.Services
         [InlineData("")]
         [InlineData("Error message")]
         [InlineData("Very long error message that contains a lot of detail about what went wrong")]
-        public async Task RecordFailure_WithVariousErrors_AcceptsAll(string? errorMessage)
+        public void RecordFailure_WithVariousErrors_AcceptsAll(string? errorMessage)
         {
             // Arrange
             var provider = "test-provider";
@@ -222,7 +222,7 @@ namespace Brainarr.Tests.Services
         }
 
         [Fact]
-        public async Task RecordMetrics_MultipleProviders_IndependentTracking()
+        public void RecordMetrics_MultipleProviders_IndependentTracking()
         {
             // Arrange
             var provider1 = "provider1";
@@ -315,7 +315,7 @@ namespace Brainarr.Tests.Services
         }
 
         [Fact]
-        public async Task CheckHealthAsync_RapidStatusChanges_TracksCorrectly()
+        public void CheckHealthAsync_RapidStatusChanges_TracksCorrectly()
         {
             // Arrange
             var provider = "test-provider";


### PR DESCRIPTION
## Summary

- Fix CS1998 compiler warnings by converting async methods that don't use await to synchronous methods
- Replace async lambdas without await with `Task.FromResult` patterns
- Affects 7 test files with ~17 method/lambda fixes

## Changes

### Files Modified
- `ProviderHealthTests.cs` - 10 methods converted from `async Task` to `void`
- `RateLimiterTests.cs` - Async lambdas converted to use `Task.FromResult`
- `EnhancedRateLimiterTests.cs` - Async lambda fixed
- `DuplicationPreventionServiceTests.cs` - Async lambdas fixed
- `RecommendationCoordinatorTests.cs` - Fetch delegate functions converted
- `ResourceAndTimeTests.cs` - Health monitor test made synchronous
- `EndToEndTests.cs` - Health monitoring test made synchronous

## Test plan

- [x] Verify build compiles without CS1998 warnings in changed files
- [ ] CI pipeline passes all tests
- [ ] No functional changes to test behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)