### PR TITLE
Fix CS0168 unused variable warning

### DIFF
--- a/Brainarr.Plugin/Services/RateLimiting/EnhancedRateLimiter.cs
+++ b/Brainarr.Plugin/Services/RateLimiting/EnhancedRateLimiter.cs
@@ -126,7 +126,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.RateLimiting
                 _metrics.RecordSuccess(request.Resource, duration);
                 return response;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 _metrics.RecordFailure(request.Resource);
                 throw;


### PR DESCRIPTION
## Summary

- Fix CS0168 compiler warning by removing unused exception variable

## Changes

- `EnhancedRateLimiter.cs:129` - Changed `catch (Exception ex)` to `catch (Exception)` since the exception is only rethrown and not logged or used

## Test plan

- [ ] CI pipeline passes all tests
- [ ] No warnings from CS0168 in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)