### PR TITLE
Adopt Guard utility from lidarr.plugin.common

### DIFF
--- a/Brainarr.Plugin/Services/Core/AIService.cs
+++ b/Brainarr.Plugin/Services/Core/AIService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Lidarr.Plugin.Common.Utilities;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.ImportLists.Brainarr.Services;
@@ -34,12 +35,12 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
             IRecommendationSanitizer sanitizer,
             IRecommendationValidator validator)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _healthMonitor = healthMonitor ?? throw new ArgumentNullException(nameof(healthMonitor));
-            _retryPolicy = retryPolicy ?? throw new ArgumentNullException(nameof(retryPolicy));
-            _rateLimiter = rateLimiter ?? throw new ArgumentNullException(nameof(rateLimiter));
-            _sanitizer = sanitizer ?? throw new ArgumentNullException(nameof(sanitizer));
-            _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+            _logger = Guard.NotNull(logger);
+            _healthMonitor = Guard.NotNull(healthMonitor);
+            _retryPolicy = Guard.NotNull(retryPolicy);
+            _rateLimiter = Guard.NotNull(rateLimiter);
+            _sanitizer = Guard.NotNull(sanitizer);
+            _validator = Guard.NotNull(validator);
             _providerChain = new SortedDictionary<int, List<IAIProvider>>();
             _metrics = new AIServiceMetrics();
         }
@@ -235,8 +236,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
         /// </summary>
         public void RegisterProvider(IAIProvider provider, int priority = 100)
         {
-            if (provider == null)
-                throw new ArgumentNullException(nameof(provider));
+            Guard.NotNull(provider);
 
             lock (_lockObject)
             {

--- a/Brainarr.Plugin/Services/Core/BrainarrOrchestrator.cs
+++ b/Brainarr.Plugin/Services/Core/BrainarrOrchestrator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Threading;
+using Lidarr.Plugin.Common.Utilities;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.ImportLists.Brainarr;
@@ -98,14 +99,14 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
             NzbDrone.Core.ImportLists.Brainarr.Services.ILibraryAwarePromptBuilder promptBuilder = null,
             IStyleCatalogService styleCatalog = null)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _providerFactory = providerFactory ?? throw new ArgumentNullException(nameof(providerFactory));
-            _libraryAnalyzer = libraryAnalyzer ?? throw new ArgumentNullException(nameof(libraryAnalyzer));
-            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
-            _providerHealth = providerHealth ?? throw new ArgumentNullException(nameof(providerHealth));
-            _validator = validator ?? throw new ArgumentNullException(nameof(validator));
-            _modelDetection = modelDetection ?? throw new ArgumentNullException(nameof(modelDetection));
-            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _logger = Guard.NotNull(logger);
+            _providerFactory = Guard.NotNull(providerFactory);
+            _libraryAnalyzer = Guard.NotNull(libraryAnalyzer);
+            _cache = Guard.NotNull(cache);
+            _providerHealth = Guard.NotNull(providerHealth);
+            _validator = Guard.NotNull(validator);
+            _modelDetection = Guard.NotNull(modelDetection);
+            _httpClient = Guard.NotNull(httpClient);
             _duplicationPrevention = duplicationPrevention ?? new DuplicationPreventionService(logger);
             _mbidResolver = mbidResolver ?? new NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.MusicBrainzResolver(logger);
             _artistResolver = artistResolver ?? new NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.ArtistMbidResolver(logger, httpClient: null);

--- a/Brainarr.Plugin/Services/Core/RecommendationCoordinator.cs
+++ b/Brainarr.Plugin/Services/Core/RecommendationCoordinator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Lidarr.Plugin.Common.Utilities;
 using NLog;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.Parser.Model;
@@ -33,14 +34,14 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
             ILibraryProfileService profileService,
             IRecommendationCacheKeyBuilder keyBuilder)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
-            _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
-            _sanitizer = sanitizer ?? throw new ArgumentNullException(nameof(sanitizer));
-            _schemaValidator = schemaValidator ?? throw new ArgumentNullException(nameof(schemaValidator));
-            _history = history ?? throw new ArgumentNullException(nameof(history));
-            _profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
-            _keyBuilder = keyBuilder ?? throw new ArgumentNullException(nameof(keyBuilder));
+            _logger = Guard.NotNull(logger);
+            _cache = Guard.NotNull(cache);
+            _pipeline = Guard.NotNull(pipeline);
+            _sanitizer = Guard.NotNull(sanitizer);
+            _schemaValidator = Guard.NotNull(schemaValidator);
+            _history = Guard.NotNull(history);
+            _profileService = Guard.NotNull(profileService);
+            _keyBuilder = Guard.NotNull(keyBuilder);
         }
 
         public async Task<List<ImportListItemInfo>> RunAsync(

--- a/Brainarr.Plugin/Services/Core/RecommendationPipeline.cs
+++ b/Brainarr.Plugin/Services/Core/RecommendationPipeline.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Lidarr.Plugin.Common.Utilities;
 using NLog;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using NzbDrone.Core.Parser.Model;
@@ -39,16 +40,16 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
             RecommendationHistory history,
             IStyleCatalogService styleCatalog = null)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _libraryAnalyzer = libraryAnalyzer ?? throw new ArgumentNullException(nameof(libraryAnalyzer));
-            _validator = validator ?? throw new ArgumentNullException(nameof(validator));
-            _safetyGates = safetyGates ?? throw new ArgumentNullException(nameof(safetyGates));
-            _topUpPlanner = topUpPlanner ?? throw new ArgumentNullException(nameof(topUpPlanner));
-            _mbidResolver = mbidResolver ?? throw new ArgumentNullException(nameof(mbidResolver));
-            _artistResolver = artistResolver ?? throw new ArgumentNullException(nameof(artistResolver));
-            _duplicationPrevention = duplicationPrevention ?? throw new ArgumentNullException(nameof(duplicationPrevention));
-            _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
-            _history = history ?? throw new ArgumentNullException(nameof(history));
+            _logger = Guard.NotNull(logger);
+            _libraryAnalyzer = Guard.NotNull(libraryAnalyzer);
+            _validator = Guard.NotNull(validator);
+            _safetyGates = Guard.NotNull(safetyGates);
+            _topUpPlanner = Guard.NotNull(topUpPlanner);
+            _mbidResolver = Guard.NotNull(mbidResolver);
+            _artistResolver = Guard.NotNull(artistResolver);
+            _duplicationPrevention = Guard.NotNull(duplicationPrevention);
+            _metrics = Guard.NotNull(metrics);
+            _history = Guard.NotNull(history);
             _styleCatalog = styleCatalog; // Optional for backwards compatibility
         }
 


### PR DESCRIPTION
## Summary

- Replace manual `?? throw new ArgumentNullException(nameof(...))` patterns with `Guard.NotNull` from lidarr.plugin.common
- Demonstrates the pattern for adopting shared utilities from the common library

## Changes

### Files Updated (33 validations converted)
- `AIService.cs` - 7 validations
- `BrainarrOrchestrator.cs` - 8 validations  
- `RecommendationCoordinator.cs` - 8 validations
- `RecommendationPipeline.cs` - 10 validations

### Before
```csharp
_logger = logger ?? throw new ArgumentNullException(nameof(logger));
```

### After
```csharp
_logger = Guard.NotNull(logger);
```

## Benefits

- **Automatic parameter name capture** via `CallerArgumentExpression`
- **Consistent validation behavior** across codebase
- **Reduced boilerplate** - cleaner, more readable code
- **Better alignment** with lidarr.plugin.common patterns

## Test plan

- [ ] CI pipeline passes all tests
- [ ] Build compiles without errors
- [ ] No functional changes to validation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)