### PR TITLE
fix(global.json): prevent rollforward to .NET 10 preview SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "8.0.0",
-    "rollForward": "latestMajor",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Summary
- Changes `rollForward` from `latestMajor` to `latestFeature` in `global.json`

## Problem
GitHub Actions runners now have .NET SDK 10.0.100 (preview) installed. With `rollForward: latestMajor`, the SDK selection rolls forward to 10.x, causing the ILRepack task lookup to fail with:

```
error MSB4036: The "ILRepack" task was not found.
```

## Solution
Using `rollForward: latestFeature` ensures we stay within the 8.x SDK series while still getting the latest patches and features.

## Test plan
- [ ] CI CodeQL build passes with .NET 8.x SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)