### PR TITLE
fix(ci): resolve nightly workflow failures

### DIFF
--- a/.github/workflows/nightly-perf-stress.yml
+++ b/.github/workflows/nightly-perf-stress.yml
@@ -12,15 +12,45 @@ concurrency:
 jobs:
   perf-stress:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       BRAINARR_HEAVY_TESTS: 'true'
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.SUBMODULES_TOKEN || github.token }}
+
+      - name: Force PAT for submodules
+        shell: bash
+        env:
+          SUBMODULES_TOKEN: ${{ secrets.SUBMODULES_TOKEN }}
+        run: |
+          if [ -n "${SUBMODULES_TOKEN}" ]; then
+            git config --global url."https://x-access-token:${SUBMODULES_TOKEN}@github.com/".insteadOf "https://github.com/"
+          fi
+
+      - name: Patch submodule NuGet mapping (TagLibSharp-Lidarr)
+        shell: bash
+        run: |
+          set -euo pipefail
+          CFG="ext/lidarr.plugin.common/NuGet.config"
+          if [ -f "$CFG" ]; then
+            grep -q 'TagLibSharp-Lidarr' "$CFG" || \
+              sed -i '/<packageSource key="lidarr-taglib">/a \      <package pattern="TagLibSharp-Lidarr*" />' "$CFG"
+          fi
 
       - name: Setup .NET 6
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '6.0.x'
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Download Lidarr assemblies (plugins Docker)
         shell: bash
@@ -54,7 +84,7 @@ jobs:
         run: dotnet restore Brainarr.sln
 
       - name: Build
-        run: dotnet build Brainarr.sln --no-restore --configuration Release -p:LidarrPath="${{ env.LIDARR_PATH }}"
+        run: dotnet build Brainarr.sln --no-restore --configuration Release -p:LidarrPath="${{ env.LIDARR_PATH }}" -p:PluginPackagingDisable=true -m:1
 
       - name: Run Performance/Stress tests
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,6 +45,16 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
 
+    - name: Patch submodule NuGet mapping (TagLibSharp-Lidarr)
+      shell: bash
+      run: |
+        set -euo pipefail
+        CFG="ext/lidarr.plugin.common/NuGet.config"
+        if [ -f "$CFG" ]; then
+          grep -q 'TagLibSharp-Lidarr' "$CFG" || \
+            sed -i '/<packageSource key="lidarr-taglib">/a \      <package pattern="TagLibSharp-Lidarr*" />' "$CFG"
+        fi
+
     - name: Extract Lidarr Assemblies
       shell: bash
       run: |
@@ -58,7 +68,9 @@ jobs:
     - name: Build
       run: |
         dotnet build --configuration Release --no-restore \
-          -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0"
+          -p:LidarrPath="${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" \
+          -p:PluginPackagingDisable=true \
+          -m:1
 
     - name: Run Tests
       run: |

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   screenshots:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -170,6 +170,22 @@ jobs:
           mkdir -p .screenshot-tools
           curl -fsSL https://raw.githubusercontent.com/RicherTunes/Lidarr.Plugin.Common/main/scripts/snapshots/snap.mjs -o .screenshot-tools/snap.mjs
           echo "Downloaded centralized screenshot utility"
+
+      - name: Verify Lidarr is reachable
+        shell: bash
+        run: |
+          set -e
+          echo "Checking Lidarr connectivity..."
+          for i in $(seq 1 15); do
+            if curl -fsS --max-time 5 http://localhost:8686 >/dev/null 2>&1; then
+              echo "Lidarr is responding!"
+              exit 0
+            fi
+            echo "Attempt $i: Lidarr not ready, waiting..."
+            sleep 5
+          done
+          echo "WARNING: Lidarr may not be fully ready, attempting screenshots anyway"
+          docker logs lidarr-ss 2>&1 | tail -50 || true
 
       - name: Capture Screenshots
         env:


### PR DESCRIPTION
## Summary
- Fix nightly-perf-stress.yml: Add missing submodules checkout and .NET 8 setup
- Fix nightly.yml: Add `-m:1` flag to prevent build race conditions
- Fix screenshots.yml: Increase timeout and add Lidarr connectivity verification

## Test plan
- [ ] Trigger nightly-perf-stress workflow manually and verify it passes
- [ ] Trigger nightly workflow manually and verify both 6.0.x and 8.0.x matrix jobs pass
- [ ] Trigger screenshots workflow manually and verify it captures screenshots

## Root Causes Addressed

### nightly-perf-stress (run 19794914190)
**Error:** `The project file ".../ext/lidarr.plugin.common/src/Lidarr.Plugin.Common.csproj" was not found`
**Fix:** Added `submodules: recursive` to checkout step, along with:
- Force PAT for submodules step
- TagLibSharp-Lidarr NuGet patch
- .NET 8 setup (assemblies are net8.0)
- `-m:1` flag to prevent race conditions
- `timeout-minutes: 45`

### nightly (run 19795025874)
**Error (6.0.x):** `System.IO.IOException: The process cannot access the file '...Lidarr.Plugin.Abstractions.deps.json' because it is being used by another process`
**Fix:** Added `-m:1` flag to build step and TagLibSharp-Lidarr NuGet patch

### screenshots (run 19795461498)
**Error:** Timeout after 30 minutes, Playwright failed with `net::ERR_CONNECTION_RESET`
**Fix:** 
- Increased timeout to 45 minutes
- Added explicit Lidarr connectivity verification step before screenshot capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)