### PR TITLE
fix(ci): prevent SIGPIPE errors in assembly listing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         timeout 15m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
         echo "Extracted assemblies (sample):"
-        ls -1 ext/Lidarr-docker/_output/net8.0 | head -20
+        ls -1 ext/Lidarr-docker/_output/net8.0 2>/dev/null | head -20 || true
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/packaging-closure.yml
+++ b/.github/workflows/packaging-closure.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         timeout 15m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
         echo "Extracted assemblies (sample):"
-        ls -1 ext/Lidarr-docker/_output/net8.0 | head -20
+        ls -1 ext/Lidarr-docker/_output/net8.0 2>/dev/null | head -20 || true
 
     - name: Build Plugin
       shell: bash


### PR DESCRIPTION
## Summary

- Add `|| true` and stderr redirection to `ls | head` commands to prevent flaky CI failures
- The broken pipe error occurs when `head` closes the pipe before `ls` finishes writing
- This was causing intermittent failures in the Packaging Closure workflow

## Test plan

- [x] The fix suppresses SIGPIPE errors from `ls | head` commands
- [ ] Verify Packaging Closure workflow passes without flaky failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)