### PR TITLE
fix(ci): add GITHUB_TOKEN env to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
     - name: Check if Release exists
       id: check_release
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
         TAG="${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

- Add missing `env:` block to pass `GITHUB_TOKEN` to the "Check if Release exists" step
- The step uses `set -euo pipefail` which treats unbound variables as errors

## Test plan

- [ ] Merge and re-tag v1.3.2 to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)