### PR TITLE
fix(ci): configure git auth for tag push in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,8 +346,11 @@ jobs:
       shell: bash
       env:
         VERSION_TAG: ${{ steps.version.outputs.version }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
+        # Configure git to use GITHUB_TOKEN for authentication
+        git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         git fetch --tags --force
         git tag -f latest "$VERSION_TAG"
         # Delete remote 'latest' if exists, then push the new one


### PR DESCRIPTION
## Summary

- Add `GITHUB_TOKEN` env to "Move 'latest' tag" step
- Configure git URL to use token authentication for push operations
- The workflow has `contents: write` permission but git push needs explicit token config

## Test plan

- [ ] Next release will verify the 'latest' tag is properly moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)