### PR TITLE
feat(ci): add failure notifications and automated submodule bump

### DIFF
--- a/.github/workflows/bump-common.yml
+++ b/.github/workflows/bump-common.yml
@@ -1,0 +1,148 @@
+name: Bump Common Submodule
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Run daily at 2:15 AM UTC (after Common nightly at 5 AM, before our nightly at 6 AM)
+    - cron: '15 2 * * *'
+
+concurrency:
+  group: bump-common
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    name: Bump Common to Latest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.SUBMODULES_TOKEN || github.token }}
+
+      - name: Update Common submodule to latest main
+        id: update
+        run: |
+          set -euo pipefail
+
+          cd ext/lidarr.plugin.common
+          git fetch origin main
+          NEW_SHA=$(git rev-parse origin/main)
+          CURRENT_SHA=$(git rev-parse HEAD)
+
+          if [ "$NEW_SHA" = "$CURRENT_SHA" ]; then
+            echo "No changes in submodule; skipping."
+            echo "changed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Updating from $CURRENT_SHA to $NEW_SHA"
+          git checkout $NEW_SHA
+          cd ../..
+
+          # Update the SHA tracking file if it exists
+          if [ -f .github/lidarr_digest.txt ]; then
+            # Keep the digest file as-is for now
+            :
+          fi
+
+          git add ext/lidarr.plugin.common
+
+          echo "changed=true" >> $GITHUB_OUTPUT
+          echo "new_sha=$NEW_SHA" >> $GITHUB_OUTPUT
+          echo "short_sha=${NEW_SHA:0:7}" >> $GITHUB_OUTPUT
+
+      - name: Setup .NET
+        if: steps.update.outputs.changed == 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Verify build with new submodule
+        if: steps.update.outputs.changed == 'true'
+        id: verify
+        run: |
+          set -euo pipefail
+
+          # Quick sanity build to verify the update doesn't break anything
+          echo "Verifying build with updated Common submodule..."
+
+          # Use the extract script if available, otherwise skip assembly check
+          if [ -f scripts/extract-lidarr-assemblies.sh ]; then
+            timeout 5m bash scripts/extract-lidarr-assemblies.sh --mode minimal --output-dir ext/Lidarr-docker/_output/net8.0 || true
+          fi
+
+          dotnet restore Brainarr.sln || { echo "build_ok=false" >> $GITHUB_OUTPUT; exit 0; }
+
+          LIDARR_PATH="${GITHUB_WORKSPACE}/ext/Lidarr-docker/_output/net8.0"
+          if [ -d "$LIDARR_PATH" ]; then
+            dotnet build Brainarr.Plugin/Brainarr.Plugin.csproj -c Release -p:LidarrPath="$LIDARR_PATH" -m:1 --no-restore || { echo "build_ok=false" >> $GITHUB_OUTPUT; exit 0; }
+          else
+            dotnet build Brainarr.Plugin/Brainarr.Plugin.csproj -c Release -m:1 --no-restore || { echo "build_ok=false" >> $GITHUB_OUTPUT; exit 0; }
+          fi
+
+          echo "build_ok=true" >> $GITHUB_OUTPUT
+
+      - name: Create branch and commit
+        if: steps.update.outputs.changed == 'true' && steps.verify.outputs.build_ok == 'true'
+        run: |
+          BRANCH="chore/bump-common-${{ steps.update.outputs.short_sha }}"
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          git checkout -B "$BRANCH"
+          git commit -m "chore(submodule): bump Common to ${{ steps.update.outputs.short_sha }}
+
+          Updates ext/lidarr.plugin.common to ${{ steps.update.outputs.new_sha }}
+
+          Build verification: ✅ Passed"
+
+          git push -u origin "$BRANCH" --force
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Create or update PR
+        if: steps.update.outputs.changed == 'true' && steps.verify.outputs.build_ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ env.BRANCH }}"
+
+          # Check if PR already exists
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' || echo "")
+
+          if [ -z "$EXISTING_PR" ]; then
+            gh pr create \
+              --title "chore(submodule): bump Common to ${{ steps.update.outputs.short_sha }}" \
+              --body "## Automated Submodule Update
+
+Updates \`ext/lidarr.plugin.common\` to latest main.
+
+**New SHA:** \`${{ steps.update.outputs.new_sha }}\`
+
+### Verification
+- ✅ Build passed with updated submodule
+
+---
+*This PR was automatically created by the bump-common workflow.*" \
+              --head "$BRANCH" \
+              --base main
+          else
+            echo "PR #$EXISTING_PR already exists for branch $BRANCH"
+          fi
+
+      - name: Report build failure
+        if: steps.update.outputs.changed == 'true' && steps.verify.outputs.build_ok == 'false'
+        run: |
+          echo "::warning::Build failed with updated Common submodule. Manual intervention required."
+          echo "## ⚠️ Build Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The build failed after updating Common to \`${{ steps.update.outputs.new_sha }}\`." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "This may indicate breaking changes in Common that need to be addressed." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -1,0 +1,102 @@
+name: Notify on Failure
+
+# Triggers on workflow failures for critical CI workflows
+
+on:
+  workflow_run:
+    workflows:
+      - "CI"
+      - "Nightly Tests"
+      - "Test and Coverage"
+      - "Sanity Build"
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  notify:
+    name: Send Failure Notification
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+
+    steps:
+      - name: Prepare notification data
+        id: data
+        run: |
+          echo "workflow_name=${{ github.event.workflow_run.name }}" >> $GITHUB_OUTPUT
+          echo "run_url=${{ github.event.workflow_run.html_url }}" >> $GITHUB_OUTPUT
+          echo "branch=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+          echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
+          echo "commit=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
+          echo "actor=${{ github.event.workflow_run.actor.login }}" >> $GITHUB_OUTPUT
+
+      - name: Send Discord notification
+        if: ${{ vars.DISCORD_WEBHOOK != '' || secrets.DISCORD_WEBHOOK != '' }}
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          curl -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [{
+                "title": "❌ CI Failure: ${{ steps.data.outputs.workflow_name }}",
+                "description": "Workflow failed on **${{ steps.data.outputs.branch }}**",
+                "color": 15158332,
+                "fields": [
+                  {"name": "Repository", "value": "`${{ steps.data.outputs.repo }}`", "inline": true},
+                  {"name": "Branch", "value": "`${{ steps.data.outputs.branch }}`", "inline": true},
+                  {"name": "Triggered by", "value": "`${{ steps.data.outputs.actor }}`", "inline": true}
+                ],
+                "url": "${{ steps.data.outputs.run_url }}",
+                "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
+              }]
+            }' \
+            "$DISCORD_WEBHOOK" || echo "Discord notification failed (webhook may not be configured)"
+
+      - name: Send Slack notification
+        if: ${{ vars.SLACK_WEBHOOK != '' || secrets.SLACK_WEBHOOK != '' }}
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+            -d '{
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {"type": "plain_text", "text": "❌ CI Failure: Brainarr", "emoji": true}
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {"type": "mrkdwn", "text": "*Workflow:*\n${{ steps.data.outputs.workflow_name }}"},
+                    {"type": "mrkdwn", "text": "*Branch:*\n${{ steps.data.outputs.branch }}"},
+                    {"type": "mrkdwn", "text": "*Triggered by:*\n${{ steps.data.outputs.actor }}"}
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {"type": "plain_text", "text": "View Run"},
+                      "url": "${{ steps.data.outputs.run_url }}"
+                    }
+                  ]
+                }
+              ]
+            }' \
+            "$SLACK_WEBHOOK" || echo "Slack notification failed (webhook may not be configured)"
+
+      - name: Log failure to summary
+        run: |
+          echo "## ❌ Workflow Failure Detected" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Workflow | ${{ steps.data.outputs.workflow_name }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Repository | ${{ steps.data.outputs.repo }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Branch | ${{ steps.data.outputs.branch }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Triggered by | ${{ steps.data.outputs.actor }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Run URL | [${{ steps.data.outputs.run_url }}](${{ steps.data.outputs.run_url }}) |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds two CI/CD robustness improvements:

### 1. Failure Notifications (`notify-failure.yml`)
- Monitors: CI, Nightly Tests, Test and Coverage, Sanity Build
- Sends notifications on failure via:
  - Discord (`DISCORD_WEBHOOK` secret)
  - Slack (`SLACK_WEBHOOK` secret)
- Falls back to GitHub Step Summary if no webhook configured

### 2. Automated Submodule Bump (`bump-common.yml`)
- **Schedule:** Daily at 2:15 AM UTC
- **Process:**
  1. Fetches latest Common main
  2. Verifies build passes with new submodule
  3. Creates PR only if build succeeds
  4. Reports failure if build breaks

## Configuration Required

To enable notifications, add one or both secrets:
- `DISCORD_WEBHOOK` - Discord webhook URL
- `SLACK_WEBHOOK` - Slack incoming webhook URL

## Part of CI/CD Robustness Initiative

This addresses the gap where CI failures go unnoticed and submodule updates are manual-only.