### PR TITLE
fix(screenshots): use flat plugin path structure

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -97,9 +97,11 @@ jobs:
       - name: Start Lidarr with plugin mounted
         run: |
           docker pull ghcr.io/hotio/lidarr:${{ env.LIDARR_DOCKER_VERSION }}
+          # NOTE: Lidarr plugins branch expects flat structure: /config/plugins/PluginName/
+          # NOT nested: /config/plugins/Owner/PluginName/
           docker run -d --name lidarr-ss \
             -p 8686:8686 \
-            -v "${{ github.workspace }}/plugin-dist:/config/plugins/RicherTunes/Brainarr:ro" \
+            -v "${{ github.workspace }}/plugin-dist:/config/plugins/Brainarr:ro" \
             -e PUID=1000 -e PGID=1000 \
             ghcr.io/hotio/lidarr:${{ env.LIDARR_DOCKER_VERSION }}
           # Wait for config.xml to be created


### PR DESCRIPTION
## Summary
- Fix plugin mount path in CI screenshot workflow
- Use `/config/plugins/Brainarr` instead of `/config/plugins/RicherTunes/Brainarr`
- Add explanatory comment documenting the expected structure

## Root Cause
The Lidarr plugins branch expects a **flat plugin directory structure**:
```
/config/plugins/PluginName/
```
NOT nested:
```
/config/plugins/Owner/PluginName/
```

This was discovered from the multi-plugin-smoke-test.yml in Lidarr.Plugin.Common which documents this requirement.

## Impact
Screenshots were showing "Couldn't find any results for 'Brainarr'" because the plugin wasn't being detected by Lidarr when mounted to the wrong path.

## Test Plan
- [ ] Trigger screenshot workflow manually
- [ ] Verify plugin is detected via API (step should pass)
- [ ] Verify screenshots show actual config dialogs