### PR TITLE
fix(tests): remove obsolete reflection access to _cachedAt in CacheKey test

### DIFF
--- a/Brainarr.Tests/Services/Core/RecommendationCoordinatorTests.cs
+++ b/Brainarr.Tests/Services/Core/RecommendationCoordinatorTests.cs
@@ -407,9 +407,7 @@ namespace Brainarr.Tests.Services.Core
                 async Task<List<Recommendation>> Fetch(LibraryProfile p, CancellationToken ct) => new List<Recommendation>();
                 var settings = new BrainarrSettings { ModelSelection = "m" };
                 await coord.RunAsync(settings, Fetch, new ReviewQueueService(logger, tmp), Mock.Of<IAIProvider>(), Mock.Of<ILibraryAwarePromptBuilder>(), CancellationToken.None);
-                // Force re-analysis by expiring cache
-                var cachedAtField = typeof(RecommendationCoordinator).GetField("_cachedAt", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                cachedAtField.SetValue(coord, DateTime.UtcNow - TimeSpan.FromMinutes(20));
+                // Profile caching is now in ILibraryProfileService - the mock's SetupSequence handles returning lp1 then lp2
                 await coord.RunAsync(settings, Fetch, new ReviewQueueService(logger, tmp), Mock.Of<IAIProvider>(), Mock.Of<ILibraryAwarePromptBuilder>(), CancellationToken.None);
 
                 Assert.Equal(2, keys.Count);


### PR DESCRIPTION
## Summary
- Removed obsolete reflection code that tried to access `_cachedAt` field
- The `RecommendationCoordinator` was refactored to use `ILibraryProfileService` for profile caching, which removed the internal `_cachedAt` field
- The test's mock `SetupSequence` already handles returning different profiles on subsequent calls

## Root Cause
The test was failing with `NullReferenceException` because:
```csharp
var cachedAtField = typeof(RecommendationCoordinator).GetField("_cachedAt", ...);
cachedAtField.SetValue(...);  // NullReferenceException - field doesn't exist anymore
```

## Fix
Removed the reflection-based cache expiry since the mock's `SetupSequence` handles returning `lp1` then `lp2` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)