### PR TITLE
refactor(services): delegate RetryPolicy to Lidarr.Plugin.Common

### DIFF
--- a/Brainarr.Plugin/Services/Logging/NLogToILoggerAdapter.cs
+++ b/Brainarr.Plugin/Services/Logging/NLogToILoggerAdapter.cs
@@ -1,0 +1,96 @@
+using System;
+using Microsoft.Extensions.Logging;
+using NLog;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Services.Logging
+{
+    /// <summary>
+    /// Adapter that wraps NLog Logger to implement Microsoft.Extensions.Logging.ILogger.
+    /// Enables Brainarr to use Lidarr.Plugin.Common services that depend on ILogger.
+    /// </summary>
+    public class NLogToILoggerAdapter : Microsoft.Extensions.Logging.ILogger
+    {
+        private readonly Logger _nlogLogger;
+
+        public NLogToILoggerAdapter(Logger nlogLogger)
+        {
+            _nlogLogger = nlogLogger ?? throw new ArgumentNullException(nameof(nlogLogger));
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
+        {
+            // NLog doesn't have a direct equivalent, return a no-op disposable
+            return new NoOpDisposable();
+        }
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
+        {
+            return _nlogLogger.IsEnabled(MapToNLogLevel(logLevel));
+        }
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+
+            var message = formatter(state, exception);
+            var nlogLevel = MapToNLogLevel(logLevel);
+
+            if (exception != null)
+            {
+                _nlogLogger.Log(nlogLevel, exception, message);
+            }
+            else
+            {
+                _nlogLogger.Log(nlogLevel, message);
+            }
+        }
+
+        private static NLog.LogLevel MapToNLogLevel(Microsoft.Extensions.Logging.LogLevel level)
+        {
+            return level switch
+            {
+                Microsoft.Extensions.Logging.LogLevel.Trace => NLog.LogLevel.Trace,
+                Microsoft.Extensions.Logging.LogLevel.Debug => NLog.LogLevel.Debug,
+                Microsoft.Extensions.Logging.LogLevel.Information => NLog.LogLevel.Info,
+                Microsoft.Extensions.Logging.LogLevel.Warning => NLog.LogLevel.Warn,
+                Microsoft.Extensions.Logging.LogLevel.Error => NLog.LogLevel.Error,
+                Microsoft.Extensions.Logging.LogLevel.Critical => NLog.LogLevel.Fatal,
+                Microsoft.Extensions.Logging.LogLevel.None => NLog.LogLevel.Off,
+                _ => NLog.LogLevel.Info
+            };
+        }
+
+        private sealed class NoOpDisposable : IDisposable
+        {
+            public void Dispose() { }
+        }
+    }
+
+    /// <summary>
+    /// Factory for creating NLog to ILogger adapters.
+    /// </summary>
+    public static class NLogAdapterFactory
+    {
+        /// <summary>
+        /// Creates an ILogger adapter from an NLog Logger.
+        /// </summary>
+        public static Microsoft.Extensions.Logging.ILogger CreateILogger(Logger nlogLogger)
+        {
+            return new NLogToILoggerAdapter(nlogLogger);
+        }
+
+        /// <summary>
+        /// Creates an ILogger adapter for the current class using NLog.
+        /// </summary>
+        public static Microsoft.Extensions.Logging.ILogger CreateILogger()
+        {
+            return new NLogToILoggerAdapter(LogManager.GetCurrentClassLogger());
+        }
+    }
+}

--- a/Brainarr.Plugin/Services/RetryPolicy.cs
+++ b/Brainarr.Plugin/Services/RetryPolicy.cs
@@ -2,7 +2,11 @@ using System;
 using System.Threading.Tasks;
 using NLog;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Logging;
 using Lidarr.Plugin.Common.Utilities;
+using CommonRetryPolicy = Lidarr.Plugin.Common.Services.Resilience.ExponentialBackoffRetryPolicy;
+using CommonRetryPolicyOptions = Lidarr.Plugin.Common.Services.Resilience.RetryPolicyOptions;
+using CommonRetryExhaustedException = Lidarr.Plugin.Common.Services.Resilience.RetryExhaustedException;
 
 namespace NzbDrone.Core.ImportLists.Brainarr.Services
 {
@@ -10,6 +14,10 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
     /// Interface for implementing retry policies with exponential backoff.
     /// Provides resilient execution of operations that may fail due to transient errors.
     /// </summary>
+    /// <remarks>
+    /// This interface is maintained for backwards compatibility within Brainarr.
+    /// The implementation delegates to Lidarr.Plugin.Common's retry policy.
+    /// </remarks>
     public interface IRetryPolicy
     {
         Task<T> ExecuteAsync<T>(Func<Task<T>> action, string operationName);
@@ -17,15 +25,15 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
 
     /// <summary>
     /// Implementation of exponential backoff retry policy for resilient operation execution.
-    /// Uses exponential delay increases between retry attempts to avoid overwhelming failing services.
+    /// Delegates to Lidarr.Plugin.Common's ExponentialBackoffRetryPolicy.
     /// </summary>
     /// <remarks>
     /// Exponential Backoff Algorithm:
     /// - Attempt 1: No delay
-    /// - Attempt 2: initialDelay (default 500ms)
-    /// - Attempt 3: initialDelay * 2 (1000ms)
-    /// - Attempt 4: initialDelay * 4 (2000ms)
-    /// - Attempt 5: initialDelay * 8 (4000ms)
+    /// - Attempt 2: initialDelay (default 1000ms)
+    /// - Attempt 3: initialDelay * 2 (2000ms)
+    /// - Attempt 4: initialDelay * 4 (4000ms)
+    /// - etc.
     ///
     /// Benefits:
     /// - Prevents thundering herd problems when multiple instances retry simultaneously
@@ -51,21 +59,29 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
     /// </remarks>
     public class ExponentialBackoffRetryPolicy : IRetryPolicy
     {
-        private readonly Logger _logger;
-        private readonly int _maxRetries;
-        private readonly TimeSpan _initialDelay;
+        private readonly CommonRetryPolicy _innerPolicy;
 
         /// <summary>
         /// Initializes a new instance of the ExponentialBackoffRetryPolicy.
         /// </summary>
-        /// <param name="logger">Logger for diagnostic information</param>
+        /// <param name="logger">NLog Logger for diagnostic information</param>
         /// <param name="maxRetries">Maximum number of retry attempts (default: from BrainarrConstants)</param>
         /// <param name="initialDelay">Initial delay between retries (default: from BrainarrConstants)</param>
         public ExponentialBackoffRetryPolicy(Logger logger, int? maxRetries = null, TimeSpan? initialDelay = null)
         {
-            _logger = logger;
-            _maxRetries = maxRetries ?? BrainarrConstants.MaxRetryAttempts;
-            _initialDelay = initialDelay ?? TimeSpan.FromMilliseconds(BrainarrConstants.InitialRetryDelayMs);
+            var options = new CommonRetryPolicyOptions
+            {
+                MaxRetries = maxRetries ?? BrainarrConstants.MaxRetryAttempts,
+                InitialDelay = initialDelay ?? TimeSpan.FromMilliseconds(BrainarrConstants.InitialRetryDelayMs),
+                MaxDelay = TimeSpan.FromMilliseconds(BrainarrConstants.MaxRetryDelayMs),
+                UseJitter = true,
+                // Use RetryUtilities from common library to determine retryable exceptions
+                ShouldRetry = RetryUtilities.IsRetryableException
+            };
+
+            // Adapt NLog Logger to ILogger for the common library
+            var ilogger = logger != null ? NLogAdapterFactory.CreateILogger(logger) : null;
+            _innerPolicy = new CommonRetryPolicy(ilogger, options);
         }
 
         /// <summary>
@@ -77,75 +93,17 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
         /// <returns>Result of the operation if successful</returns>
         /// <exception cref="RetryExhaustedException">Thrown when all retry attempts are exhausted</exception>
         /// <exception cref="TaskCanceledException">Thrown when operation is cancelled (not retried)</exception>
-        /// <remarks>
-        /// Execution flow:
-        /// 1. Try operation immediately (attempt 1)
-        /// 2. On failure, wait with exponential backoff
-        /// 3. Retry up to maxRetries times
-        /// 4. If all attempts fail, throw RetryExhaustedException with original exception
-        ///
-        /// The delay calculation ensures each retry waits longer than the previous:
-        /// delay = initialDelay * 2^(attempt-1)
-        ///
-        /// Example with 500ms initial delay:
-        /// - Retry 1: 500ms delay
-        /// - Retry 2: 1000ms delay
-        /// - Retry 3: 2000ms delay
-        /// - Retry 4: 4000ms delay
-        /// </remarks>
         public async Task<T> ExecuteAsync<T>(Func<Task<T>> action, string operationName)
         {
-            Exception lastException = null;
-
-            for (int attempt = 0; attempt < _maxRetries; attempt++)
+            try
             {
-                try
-                {
-                    if (attempt > 0)
-                    {
-                        // SECURITY FIX: Prevent integer overflow in exponential backoff
-                        var multiplier = Math.Min(Math.Pow(2, attempt - 1), 1024); // Cap at 2^10
-                        var baseDelayMs = Math.Min(_initialDelay.TotalMilliseconds * multiplier, 60000); // Cap at 60 seconds
-                        // Full jitter to reduce synchronized retry storms
-                        var rnd = new Random(unchecked(Environment.TickCount + attempt * 397));
-                        var jitterMs = rnd.Next(0, (int)Math.Max(1, baseDelayMs));
-                        var delay = TimeSpan.FromMilliseconds(jitterMs);
-                        _logger.Info($"Retry {attempt}/{_maxRetries} for {operationName} after {delay.TotalSeconds:F2}s jittered delay");
-                        await Task.Delay(delay);
-                    }
-
-                    return await action();
-                }
-                catch (TaskCanceledException)
-                {
-                    // Don't retry on cancellation
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    lastException = ex;
-
-                    // Use RetryUtilities from lidarr.plugin.common to determine if exception is retryable
-                    // This prevents wasteful retries on permanent failures (auth errors, 400/404, etc.)
-                    var isRetryable = RetryUtilities.IsRetryableException(ex);
-
-                    if (!isRetryable)
-                    {
-                        _logger.Warn($"Non-retryable error for {operationName}: {ex.Message}");
-                        throw;
-                    }
-
-                    _logger.Warn($"Attempt {attempt + 1}/{_maxRetries} failed for {operationName}: {ex.Message}");
-
-                    if (attempt == _maxRetries - 1)
-                    {
-                        _logger.Error(ex, $"All {_maxRetries} attempts failed for {operationName}");
-                        throw new RetryExhaustedException($"Operation '{operationName}' failed after {_maxRetries} attempts", ex);
-                    }
-                }
+                return await _innerPolicy.ExecuteAsync(action, operationName);
             }
-
-            throw new RetryExhaustedException($"Operation '{operationName}' failed after {_maxRetries} attempts", lastException);
+            catch (CommonRetryExhaustedException ex)
+            {
+                // Re-throw as Brainarr's RetryExhaustedException for backwards compatibility
+                throw new RetryExhaustedException(ex.Message, ex.InnerException);
+            }
         }
     }
 
@@ -153,11 +111,51 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
     /// Exception thrown when all retry attempts have been exhausted.
     /// Contains the original exception that caused the failures.
     /// </summary>
+    /// <remarks>
+    /// This exception type is maintained for backwards compatibility within Brainarr.
+    /// It wraps Lidarr.Plugin.Common's RetryExhaustedException.
+    /// </remarks>
     public class RetryExhaustedException : Exception
     {
         public RetryExhaustedException(string message, Exception innerException)
             : base(message, innerException)
         {
+        }
+    }
+
+    /// <summary>
+    /// Factory for creating Brainarr-specific retry policies.
+    /// </summary>
+    public static class BrainarrRetryPolicyFactory
+    {
+        /// <summary>
+        /// Creates a default retry policy with Brainarr's standard settings.
+        /// </summary>
+        public static IRetryPolicy CreateDefault(Logger logger = null)
+        {
+            return new ExponentialBackoffRetryPolicy(logger);
+        }
+
+        /// <summary>
+        /// Creates an aggressive retry policy for critical operations.
+        /// </summary>
+        public static IRetryPolicy CreateAggressive(Logger logger = null)
+        {
+            return new ExponentialBackoffRetryPolicy(
+                logger,
+                maxRetries: 5,
+                initialDelay: TimeSpan.FromMilliseconds(500));
+        }
+
+        /// <summary>
+        /// Creates a conservative retry policy to minimize provider load.
+        /// </summary>
+        public static IRetryPolicy CreateConservative(Logger logger = null)
+        {
+            return new ExponentialBackoffRetryPolicy(
+                logger,
+                maxRetries: 2,
+                initialDelay: TimeSpan.FromSeconds(2));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Migrate Brainarr's RetryPolicy implementation to use the shared ExponentialBackoffRetryPolicy from Lidarr.Plugin.Common
- Add NLogToILoggerAdapter to bridge NLog Logger to Microsoft.Extensions.Logging.ILogger
- Eliminates code duplication and ensures consistent retry behavior across plugins

## Changes
- **New**: `NLogToILoggerAdapter.cs` - Bridges NLog Logger to ILogger interface
- **Refactored**: `RetryPolicy.cs` - Delegates to common library's implementation

## Test plan
- [ ] CI passes (build, tests, CodeQL, lint)
- [ ] Existing RetryPolicyTests still pass (validated via CI)
- [ ] Plugin loads correctly in Lidarr

🤖 Generated with [Claude Code](https://claude.com/claude-code)