### PR TITLE
refactor: migrate RateLimiter to use Lidarr.Plugin.Common

### DIFF
--- a/Brainarr.Plugin/Services/RateLimiter.cs
+++ b/Brainarr.Plugin/Services/RateLimiter.cs
@@ -1,178 +1,134 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NLog;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Logging;
+using CommonRateLimiter = Lidarr.Plugin.Common.Services.Resilience.TokenBucketRateLimiter;
+using CommonRateLimitPresets = Lidarr.Plugin.Common.Services.Resilience.RateLimitPresets;
 
 namespace NzbDrone.Core.ImportLists.Brainarr.Services
 {
+    /// <summary>
+    /// Interface for rate limiting resource access.
+    /// Provides token bucket rate limiting for API calls and other throttled resources.
+    /// </summary>
+    /// <remarks>
+    /// This interface is maintained for backwards compatibility within Brainarr.
+    /// The implementation delegates to Lidarr.Plugin.Common's TokenBucketRateLimiter.
+    /// </remarks>
     public interface IRateLimiter
     {
         Task<T> ExecuteAsync<T>(string resource, Func<Task<T>> action);
-        Task<T> ExecuteAsync<T>(string resource, Func<System.Threading.CancellationToken, Task<T>> action, System.Threading.CancellationToken cancellationToken);
+        Task<T> ExecuteAsync<T>(string resource, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken);
         void Configure(string resource, int maxRequests, TimeSpan period);
     }
 
+    /// <summary>
+    /// Token bucket rate limiter implementation for Brainarr.
+    /// Delegates to Lidarr.Plugin.Common's TokenBucketRateLimiter.
+    /// </summary>
+    /// <remarks>
+    /// Token Bucket Algorithm:
+    /// - Tokens are added at a fixed rate (refill rate = capacity / period)
+    /// - Each request consumes one token
+    /// - If no tokens available, request waits until tokens refill
+    /// - Maximum tokens capped at capacity
+    ///
+    /// Example: 10 requests per minute
+    /// - Capacity: 10 tokens
+    /// - Refill rate: 10/60 = 0.167 tokens per second
+    /// - Burst: Can handle 10 requests immediately
+    /// - Sustained: ~0.167 requests per second
+    ///
+    /// Use cases in Brainarr:
+    /// - AI provider API calls (OpenAI, Anthropic, etc.)
+    /// - Local provider requests (Ollama, LM Studio)
+    /// - MusicBrainz validation (strict 1 req/sec)
+    /// </remarks>
     public class RateLimiter : IRateLimiter
     {
-        private readonly ConcurrentDictionary<string, ResourceRateLimiter> _limiters;
-        private readonly Logger _logger;
+        private readonly CommonRateLimiter _innerLimiter;
 
+        /// <summary>
+        /// Initializes a new instance of the RateLimiter.
+        /// </summary>
+        /// <param name="logger">NLog Logger for diagnostic information</param>
         public RateLimiter(Logger logger)
         {
-            _logger = logger;
-            _limiters = new ConcurrentDictionary<string, ResourceRateLimiter>();
+            // Adapt NLog Logger to ILogger for the common library
+            var ilogger = logger != null ? NLogAdapterFactory.CreateILogger(logger) : null;
+            _innerLimiter = new CommonRateLimiter(ilogger);
         }
 
+        /// <summary>
+        /// Configures rate limiting for a specific resource.
+        /// </summary>
+        /// <param name="resource">Resource identifier (e.g., "openai", "musicbrainz")</param>
+        /// <param name="maxRequests">Maximum requests allowed in the period</param>
+        /// <param name="period">Time period for the rate limit</param>
         public void Configure(string resource, int maxRequests, TimeSpan period)
         {
-            // Validate and sanitize parameters
-            if (string.IsNullOrWhiteSpace(resource))
-            {
-                _logger.Warn("Rate limiter resource name cannot be null or empty, using 'default'");
-                resource = "default";
-            }
-
-            if (maxRequests <= 0)
-            {
-                _logger.Warn($"Invalid maxRequests ({maxRequests}), using default value of 10");
-                maxRequests = 10;
-            }
-
-            if (period <= TimeSpan.Zero)
-            {
-                _logger.Warn($"Invalid period ({period}), using default value of 1 minute");
-                period = TimeSpan.FromMinutes(1);
-            }
-
-            _limiters[resource] = new ResourceRateLimiter(maxRequests, period, _logger);
-            _logger.Debug($"Rate limiter configured for {resource}: {maxRequests} requests per {period.TotalSeconds}s");
+            _innerLimiter.Configure(resource, maxRequests, period);
         }
 
+        /// <summary>
+        /// Executes an operation with rate limiting, waiting if necessary.
+        /// </summary>
+        /// <typeparam name="T">Return type of the operation</typeparam>
+        /// <param name="resource">Resource identifier for rate limiting</param>
+        /// <param name="action">The async operation to execute</param>
+        /// <returns>Result of the operation</returns>
         public async Task<T> ExecuteAsync<T>(string resource, Func<Task<T>> action)
         {
-            // Get configured limiter or create default if not configured
-            if (!_limiters.TryGetValue(resource, out var limiter))
-            {
-                // By default, do not throttle unless explicitly configured
-                return await action().ConfigureAwait(false);
-            }
-
-            return await limiter.ExecuteAsync(action).ConfigureAwait(false);
+            return await _innerLimiter.ExecuteAsync(resource, action).ConfigureAwait(false);
         }
 
-        public async Task<T> ExecuteAsync<T>(string resource, Func<System.Threading.CancellationToken, Task<T>> action, System.Threading.CancellationToken cancellationToken)
+        /// <summary>
+        /// Executes an operation with rate limiting and cancellation support.
+        /// </summary>
+        /// <typeparam name="T">Return type of the operation</typeparam>
+        /// <param name="resource">Resource identifier for rate limiting</param>
+        /// <param name="action">The async operation to execute</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Result of the operation</returns>
+        public async Task<T> ExecuteAsync<T>(string resource, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken)
         {
-            if (!_limiters.TryGetValue(resource, out var limiter))
-            {
-                return await action(cancellationToken).ConfigureAwait(false);
-            }
-            return await limiter.ExecuteAsync(action, cancellationToken).ConfigureAwait(false);
+            return await _innerLimiter.ExecuteAsync(resource, action, cancellationToken).ConfigureAwait(false);
         }
 
-        private class ResourceRateLimiter
+        /// <summary>
+        /// Gets the current available tokens for a resource.
+        /// </summary>
+        /// <param name="resource">Resource identifier</param>
+        /// <returns>Number of available tokens, or null if resource not configured</returns>
+        public int? GetAvailableTokens(string resource)
         {
-            private readonly object _lock = new object();
-            private readonly Logger _logger;
-            private readonly double _maxTokens;
-            private readonly double _refillRatePerSecond;
-            private double _availableTokens;
-            private DateTime _lastRefill;
+            return _innerLimiter.GetAvailableTokens(resource);
+        }
 
-            public ResourceRateLimiter(int maxRequests, TimeSpan period, Logger logger)
-            {
-                _logger = logger;
-                _maxTokens = Math.Max(1, maxRequests);
-                var seconds = Math.Max(0.001, period.TotalSeconds);
-                _refillRatePerSecond = _maxTokens / seconds;
-                _availableTokens = _maxTokens;
-                _lastRefill = DateTime.UtcNow;
-            }
-
-            private TimeSpan ReserveSlot()
-            {
-                var now = DateTime.UtcNow;
-
-                RefillTokens(now);
-
-                if (_availableTokens >= 1d)
-                {
-                    _availableTokens -= 1d;
-                    return TimeSpan.Zero;
-                }
-
-                var tokensNeeded = 1d - _availableTokens;
-                var secondsToWait = tokensNeeded / _refillRatePerSecond;
-                if (secondsToWait < 0d)
-                {
-                    secondsToWait = 0d;
-                }
-                _availableTokens -= 1d;
-                return TimeSpan.FromSeconds(secondsToWait);
-            }
-
-            private void RefillTokens(DateTime now)
-            {
-                if (now <= _lastRefill)
-                {
-                    return;
-                }
-
-                var elapsedSeconds = (now - _lastRefill).TotalSeconds;
-                if (elapsedSeconds <= 0d)
-                {
-                    return;
-                }
-
-                _availableTokens = Math.Min(_maxTokens, _availableTokens + elapsedSeconds * _refillRatePerSecond);
-                _lastRefill = now;
-            }
-
-            public async Task<T> ExecuteAsync<T>(Func<Task<T>> action)
-            {
-                TimeSpan wait;
-                lock (_lock)
-                {
-                    wait = ReserveSlot();
-                }
-
-                if (wait > TimeSpan.Zero)
-                {
-                    _logger.Debug($"Rate limit waiting {wait.TotalMilliseconds:F0}ms");
-                    await Task.Delay(wait).ConfigureAwait(false);
-                }
-
-                return await action().ConfigureAwait(false);
-            }
-
-            public async Task<T> ExecuteAsync<T>(Func<System.Threading.CancellationToken, Task<T>> action, System.Threading.CancellationToken cancellationToken)
-            {
-                TimeSpan wait;
-                lock (_lock)
-                {
-                    wait = ReserveSlot();
-                }
-
-                if (wait > TimeSpan.Zero)
-                {
-                    _logger.Debug($"Rate limit waiting {wait.TotalMilliseconds:F0}ms");
-                    await Task.Delay(wait, cancellationToken).ConfigureAwait(false);
-                }
-
-                cancellationToken.ThrowIfCancellationRequested();
-                return await action(cancellationToken).ConfigureAwait(false);
-            }
+        /// <summary>
+        /// Resets the rate limiter for a specific resource or all resources.
+        /// </summary>
+        /// <param name="resource">Resource to reset, or null to reset all</param>
+        public void Reset(string resource = null)
+        {
+            _innerLimiter.Reset(resource);
         }
     }
 
-    // Provider-specific rate limiters
+    /// <summary>
+    /// Provider-specific rate limiter configurations for Brainarr.
+    /// </summary>
     public static class RateLimiterConfiguration
     {
         private static readonly HashSet<IRateLimiter> _configuredLimiters = new HashSet<IRateLimiter>();
         private static readonly object _lock = new object();
 
+        /// <summary>
+        /// Configures default rate limits for all Brainarr providers.
+        /// Only configures each rate limiter instance once to prevent log spam.
+        /// </summary>
         public static void ConfigureDefaults(IRateLimiter rateLimiter)
         {
             // Only configure each rate limiter instance once to prevent log spam


### PR DESCRIPTION
## Summary
- Refactors RateLimiter to delegate to Lidarr.Plugin.Common's TokenBucketRateLimiter
- Uses NLogAdapterFactory to bridge NLog Logger to ILogger (same pattern as RetryPolicy PR #330)
- Maintains backwards compatibility by keeping `IRateLimiter` interface and `RateLimiterConfiguration` class
- Exposes additional utility methods: `GetAvailableTokens()`, `Reset()`

## Why
This migration reduces code duplication and ensures consistent behavior across all Lidarr plugins using the shared common library.

## Test plan
- [x] Comprehensive existing test suite (14 test methods in RateLimiterTests.cs)
- [ ] CI build and test verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)