### PR TITLE
fix: remove analyzer-disabling AdditionalProperties that caused duplicate builds

### DIFF
--- a/Brainarr.Plugin/Brainarr.Plugin.csproj
+++ b/Brainarr.Plugin/Brainarr.Plugin.csproj
@@ -196,8 +196,9 @@
     <ProjectReference Include="..\ext\lidarr.plugin.common\src\Lidarr.Plugin.Common.csproj">
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
       <Private>true</Private>
-      <!-- Disable analyzers for the submodule to avoid PublicAPI duplicate warnings affecting our CI -->
-      <AdditionalProperties>GeneratePackageOnBuild=false;RunAnalyzersDuringBuild=false;RunAnalyzersDuringCompilation=false;EnableNETAnalyzers=false</AdditionalProperties>
+      <!-- Prevent Common from generating NuGet package during plugin build -->
+      <!-- Keep GeneratePackageOnBuild=false; removed analyzer flags that caused duplicate builds -->
+      <AdditionalProperties>GeneratePackageOnBuild=false</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Removes analyzer-disabling properties from the `AdditionalProperties` on the Common ProjectReference that were causing MSBuild to treat Common as a different build configuration, leading to duplicate parallel builds and file locking race conditions on Windows CI:
```
CSC error CS2012: Cannot open 'dll' for writing
```

## Changes

### Brainarr.Plugin/Brainarr.Plugin.csproj
Before:
```xml
<AdditionalProperties>GeneratePackageOnBuild=false;RunAnalyzersDuringBuild=false;RunAnalyzersDuringCompilation=false;EnableNETAnalyzers=false</AdditionalProperties>
```

After:
```xml
<AdditionalProperties>GeneratePackageOnBuild=false</AdditionalProperties>
```

Kept `GeneratePackageOnBuild=false` which is legitimately needed to prevent Common from generating a NuGet package during plugin builds.

## Related
- Lidarr.Plugin.Common PR #137
- Qobuzarr PR #92
- Tidalarr PR #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)