### PR TITLE
test(packaging): enforce ecosystem packaging policy

### DIFF
--- a/.github/workflows/plugin-package.yml
+++ b/.github/workflows/plugin-package.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Patch submodule NuGet mapping (TagLibSharp-Lidarr)
       shell: bash
@@ -115,7 +115,28 @@ jobs:
         mkdir -p package
 
         # Copy plugin files into the package root so Lidarr sees them without an extra subfolder
-        cp Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll package/
+        cp Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll package/        
+
+        # Type identity assemblies (must ship as separate DLLs)
+        host_out="ext/Lidarr-docker/_output/net8.0"
+        for dep in \
+          "Lidarr.Plugin.Abstractions.dll" \
+          "Microsoft.Extensions.DependencyInjection.Abstractions.dll" \
+          "Microsoft.Extensions.Logging.Abstractions.dll" \
+          "FluentValidation.dll"; do
+          if [ ! -f "$host_out/$dep" ]; then
+            echo "ERROR: Required runtime dependency missing from extracted host assemblies: $dep" >&2
+            echo "Build output sample:"
+            ls -1 "$host_out" | sed -n '1,120p'
+            exit 1
+          fi
+          cp "$host_out/$dep" package/
+        done
+
+        # Optional (allowed if present; can be internalized later)
+        if [ -f "Brainarr.Plugin/bin/Lidarr.Plugin.Common.dll" ]; then
+          cp "Brainarr.Plugin/bin/Lidarr.Plugin.Common.dll" package/
+        fi
         cp plugin.json package/
         cp manifest.json package/
         cp .lidarr.plugin package/
@@ -132,12 +153,31 @@ jobs:
         zipfile="Brainarr-latest.zip"
         unzip -l "$zipfile" | awk '{print $4}' | sed '/^$/d' | sort -u > ziplist.txt
         echo "ZIP contents:"; cat ziplist.txt
-        for f in "Lidarr.Plugin.Brainarr.dll" "plugin.json" "manifest.json" ".lidarr.plugin"; do
+        for f in \
+          "Lidarr.Plugin.Brainarr.dll" \
+          "Lidarr.Plugin.Abstractions.dll" \
+          "Microsoft.Extensions.DependencyInjection.Abstractions.dll" \
+          "Microsoft.Extensions.Logging.Abstractions.dll" \
+          "FluentValidation.dll" \
+          "plugin.json" \
+          "manifest.json" \
+          ".lidarr.plugin"; do
           if ! grep -Fxq "$f" ziplist.txt; then
             echo "Missing expected file in ZIP: $f" >&2
             exit 1
           fi
         done
+
+    - name: Validate packaging policy (unit tests)
+      shell: bash
+      env:
+        REQUIRE_PACKAGE_TESTS: "true"
+        PLUGIN_PACKAGE_PATH: "${{ github.workspace }}/Brainarr-latest.zip"
+      run: |
+        dotnet test Brainarr.Tests/Brainarr.Tests.csproj \
+          --configuration Release \
+          --filter "Category=Packaging" \
+          --nologo
 
     - name: Upload Package Artifact
       uses: actions/upload-artifact@v4

--- a/Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests.cs
+++ b/Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Brainarr.Tests.Packaging
+{
+    public sealed class BrainarrPackagingPolicyTests
+    {
+        private static readonly string[] RequiredFiles =
+        {
+            "Lidarr.Plugin.Brainarr.dll",
+            "plugin.json",
+            "manifest.json"
+        };
+
+        private static readonly string[] RequiredTypeIdentityAssemblies =
+        {
+            "Lidarr.Plugin.Abstractions.dll",
+            "Microsoft.Extensions.DependencyInjection.Abstractions.dll",
+            "Microsoft.Extensions.Logging.Abstractions.dll",
+            "FluentValidation.dll"
+        };
+
+        private static readonly string[] ForbiddenAssemblies =
+        {
+            "System.Text.Json.dll",
+            "Lidarr.Core.dll",
+            "Lidarr.Common.dll",
+            "Lidarr.Host.dll",
+            "Lidarr.Http.dll",
+            "NzbDrone.Core.dll",
+            "NzbDrone.Common.dll"
+        };
+
+        [PackagingFact]
+        [Trait("Category", "Packaging")]
+        public void Package_Should_Contain_Required_Files()
+        {
+            var zipPath = GetPackagePathOrThrow();
+            var entries = ReadZipEntries(zipPath);
+
+            entries.Should().Contain(RequiredFiles);
+            entries.Should().Contain(RequiredTypeIdentityAssemblies);
+        }
+
+        [PackagingFact]
+        [Trait("Category", "Packaging")]
+        public void Package_Should_Not_Contain_Forbidden_Assemblies()
+        {
+            var zipPath = GetPackagePathOrThrow();
+            var entries = ReadZipEntries(zipPath);
+
+            entries.Should().NotContain(ForbiddenAssemblies);
+
+            var hostAssemblies = entries
+                .Where(e => e.StartsWith("Lidarr.", StringComparison.OrdinalIgnoreCase))
+                .Where(e => !e.StartsWith("Lidarr.Plugin.", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            hostAssemblies.Should().BeEmpty("plugin packages must not ship Lidarr host assemblies");
+        }
+
+        private static string GetPackagePathOrThrow()
+        {
+            var zipPath = PackagingTestPaths.TryFindPackagePath();
+            if (zipPath != null)
+            {
+                return zipPath;
+            }
+
+            if (PackagingTestPaths.IsStrictMode())
+            {
+                throw new InvalidOperationException("No plugin package found. Set PLUGIN_PACKAGE_PATH or run `./build.ps1 -Package`.");
+            }
+
+            throw new InvalidOperationException("PackagingFact should have skipped when package is missing.");
+        }
+
+        private static HashSet<string> ReadZipEntries(string zipPath)
+        {
+            using var archive = ZipFile.OpenRead(zipPath);
+            return archive.Entries
+                .Select(e => e.FullName.Replace('\\', '/').Trim('/'))
+                .Where(e => !string.IsNullOrWhiteSpace(e))
+                .Select(Path.GetFileName)
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}
+

--- a/Brainarr.Tests/Packaging/PackagingFactAttribute.cs
+++ b/Brainarr.Tests/Packaging/PackagingFactAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+using Xunit;
+
+namespace Brainarr.Tests.Packaging
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class PackagingFactAttribute : FactAttribute
+    {
+        public PackagingFactAttribute()
+        {
+            if (PackagingTestPaths.IsStrictMode())
+            {
+                return;
+            }
+
+            if (PackagingTestPaths.TryFindPackagePath() == null)
+            {
+                Skip = "No plugin package found. Run `./build.ps1 -Package` (or set REQUIRE_PACKAGE_TESTS=true in CI).";
+            }
+        }
+    }
+}
+

--- a/Brainarr.Tests/Packaging/PackagingTestPaths.cs
+++ b/Brainarr.Tests/Packaging/PackagingTestPaths.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Brainarr.Tests.Packaging
+{
+    public static class PackagingTestPaths
+    {
+        public static bool IsStrictMode()
+        {
+            return IsTruthy(Environment.GetEnvironmentVariable("REQUIRE_PACKAGE_TESTS"));
+        }
+
+        public static string? TryFindPackagePath()
+        {
+            var explicitPath =
+                Environment.GetEnvironmentVariable("PLUGIN_PACKAGE_PATH") ??
+                Environment.GetEnvironmentVariable("BRAINARR_PACKAGE_PATH");
+
+            if (!string.IsNullOrWhiteSpace(explicitPath) && File.Exists(explicitPath))
+            {
+                return Path.GetFullPath(explicitPath);
+            }
+
+            var repoRoot = FindRepoRoot();
+            if (repoRoot == null)
+            {
+                return null;
+            }
+
+            var candidates = Directory.GetFiles(repoRoot, "Brainarr-*.zip")
+                .Concat(Directory.GetFiles(repoRoot, "Brainarr-*.net8.0.zip"))
+                .Concat(Directory.GetFiles(repoRoot, "Brainarr-latest.zip"))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(p => new FileInfo(p))
+                .OrderByDescending(f => f.LastWriteTimeUtc)
+                .ToList();
+
+            return candidates.FirstOrDefault()?.FullName;
+        }
+
+        public static string FindRepoRootOrThrow()
+        {
+            return FindRepoRoot() ?? throw new InvalidOperationException("Failed to locate Brainarr repo root (expected Brainarr.sln).");
+        }
+
+        private static string? FindRepoRoot()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "Brainarr.sln")))
+                {
+                    return dir.FullName;
+                }
+
+                dir = dir.Parent;
+            }
+
+            return null;
+        }
+
+        private static bool IsTruthy(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            return value.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+                   value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+                   value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+                   value.Equals("on", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+

--- a/docs/PACKAGING_POLICY_BASELINE.md
+++ b/docs/PACKAGING_POLICY_BASELINE.md
@@ -1,0 +1,30 @@
+# Brainarr Packaging Policy Baseline
+
+This repo follows the Lidarr plugin ecosystem packaging rules:
+
+## Ship (type identity)
+These assemblies must be shipped as separate files alongside the plugin DLL.
+
+- `Lidarr.Plugin.Abstractions.dll`
+- `Microsoft.Extensions.DependencyInjection.Abstractions.dll`
+- `Microsoft.Extensions.Logging.Abstractions.dll`
+- `FluentValidation.dll`
+
+## Merge (internalize)
+These should be merged/internalized into `Lidarr.Plugin.Brainarr.dll` (or otherwise not shipped as separate files).
+
+- `Lidarr.Plugin.Common.dll`
+- `Polly*`, `TagLibSharp*`, and other non-type-identity dependencies
+
+## Do Not Ship (host provides)
+These must never be included in the plugin package.
+
+- `Lidarr.Core.dll`, `Lidarr.Common.dll`, `Lidarr.Host.dll`, `Lidarr.Http.dll`, etc.
+- `NzbDrone.*.dll`
+- `System.Text.Json.dll` (cross-boundary type identity risk)
+
+## How it is enforced
+- Unit tests: `Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests.cs`
+  - Local: tests skip if no package exists.
+  - CI/strict: set `REQUIRE_PACKAGE_TESTS=true` and provide `PLUGIN_PACKAGE_PATH` to require the package.
+


### PR DESCRIPTION
Adds Brainarr packaging policy tests (required/forbidden DLLs) and aligns packaging to the ecosystem rules.\n\nKey points\n- Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests.cs validates required type-identity DLLs are present and forbidden host/runtime DLLs are absent.\n- Tests skip locally when no package exists; CI can enforce by setting REQUIRE_PACKAGE_TESTS=true and PLUGIN_PACKAGE_PATH.\n- uild.ps1 packaging now pulls type-identity DLLs from host assemblies (ext/Lidarr.../net8.0) if not in build output, and no longer includes System.Text.Json or broad Microsoft.Extensions.* scans.\n- plugin-package.yml now packages the required type-identity DLLs from extracted host assemblies and runs the packaging tests against Brainarr-latest.zip.\n\nDocs\n- docs/PACKAGING_POLICY_BASELINE.md captures the baseline.