### PR TITLE
docs: align packaging policy with ecosystem canonical policy

### DIFF
--- a/docs/PACKAGING_POLICY_BASELINE.md
+++ b/docs/PACKAGING_POLICY_BASELINE.md
@@ -1,24 +1,25 @@
 # Brainarr Packaging Policy Baseline
 
-This repo follows the Lidarr plugin ecosystem packaging rules:
+This repo follows the Lidarr plugin ecosystem packaging rules as defined in
+`Lidarr.Plugin.Common/tests/PackageValidation/PluginPackageValidator.cs`.
 
-## Ship (type identity)
-These assemblies must be shipped as separate files alongside the plugin DLL.
+## Ship (required assemblies)
+These assemblies must be shipped as separate files alongside the plugin DLL:
 
-- `Lidarr.Plugin.Abstractions.dll`
-- `Microsoft.Extensions.DependencyInjection.Abstractions.dll`
-- `Microsoft.Extensions.Logging.Abstractions.dll`
-- `FluentValidation.dll`
+- `Lidarr.Plugin.Abstractions.dll` (required for plugin discovery; host image does not ship it)
 
 ## Merge (internalize)
-These should be merged/internalized into `Lidarr.Plugin.Brainarr.dll` (or otherwise not shipped as separate files).
+These should be merged/internalized into `Lidarr.Plugin.Brainarr.dll` via ILRepack:
 
 - `Lidarr.Plugin.Common.dll`
-- `Polly*`, `TagLibSharp*`, and other non-type-identity dependencies
+- `Polly*`, `TagLibSharp*`, `Microsoft.Extensions.DependencyInjection.dll` (impl), etc.
 
 ## Do Not Ship (host provides)
-These must never be included in the plugin package.
+These must **never** be included in the plugin package - shipping them causes type-identity conflicts:
 
+- `FluentValidation.dll` (host provides; breaks `DownloadClient.Test(List<ValidationFailure>)`)
+- `Microsoft.Extensions.DependencyInjection.Abstractions.dll` (host provides)
+- `Microsoft.Extensions.Logging.Abstractions.dll` (host provides)
 - `Lidarr.Core.dll`, `Lidarr.Common.dll`, `Lidarr.Host.dll`, `Lidarr.Http.dll`, etc.
 - `NzbDrone.*.dll`
 - `System.Text.Json.dll` (cross-boundary type identity risk)
@@ -27,4 +28,11 @@ These must never be included in the plugin package.
 - Unit tests: `Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests.cs`
   - Local: tests skip if no package exists.
   - CI/strict: set `REQUIRE_PACKAGE_TESTS=true` and provide `PLUGIN_PACKAGE_PATH` to require the package.
+- Canonical source of truth: `Lidarr.Plugin.Common/tests/PackageValidation/PluginPackageValidator.cs`
+
+## Known discrepancies
+
+**TODO**: The `build.ps1` and `manifest.json` currently include FluentValidation.dll and
+MS.Extensions.*Abstractions.dll in the package. These should be removed to align with the
+canonical ecosystem policy. See issue tracking this alignment work.
 


### PR DESCRIPTION
## Summary

Updates `PACKAGING_POLICY_BASELINE.md` to reflect the canonical ecosystem policy from `Lidarr.Plugin.Common/tests/PackageValidation/PluginPackageValidator.cs`:

- **Ship**: Only `Lidarr.Plugin.Abstractions.dll` (host image doesn't ship it)
- **Do Not Ship**: `FluentValidation.dll`, `MS.Extensions.*Abstractions.dll` (host provides, shipping causes type-identity conflicts)
- **Merge**: Everything else via ILRepack

## Known Discrepancies

The current `build.ps1` and `manifest.json` still include FluentValidation.dll and MS.Extensions.*Abstractions.dll in the package. A follow-up PR will address aligning the actual build with this policy.

## Context

This is part of the ecosystem packaging policy investigation following the Common library submodule bump. See:
- Tidalarr PR #103 (test fixes aligning with this policy)
- Common PR #166 (maxConcurrentTracks feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)