### PR TITLE
fix(tests): use dynamic dates to avoid date-dependent test failures

### DIFF
--- a/Brainarr.Tests/Services/Core/LibraryAnalyzerTests.cs
+++ b/Brainarr.Tests/Services/Core/LibraryAnalyzerTests.cs
@@ -74,6 +74,8 @@ namespace Brainarr.Tests.Services.Core
         {
             // Arrange
             var artists = CreateTestArtists(5);
+            // Use dynamic dates relative to current year to avoid date-dependent test failures
+            var currentYear = DateTime.UtcNow.Year;
             var albums = new List<Album>
             {
                 CreateAlbumWithDate("Album1", new DateTime(1975, 1, 1)),
@@ -81,8 +83,8 @@ namespace Brainarr.Tests.Services.Core
                 CreateAlbumWithDate("Album3", new DateTime(1985, 1, 1)),
                 CreateAlbumWithDate("Album4", new DateTime(1995, 1, 1)),
                 CreateAlbumWithDate("Album5", new DateTime(2010, 1, 1)),
-                CreateAlbumWithDate("Album6", new DateTime(2023, 1, 1)),
-                CreateAlbumWithDate("Album7", new DateTime(2024, 1, 1))
+                CreateAlbumWithDate("Album6", new DateTime(currentYear - 1, 6, 1)),  // Last year
+                CreateAlbumWithDate("Album7", new DateTime(currentYear, 1, 1))        // This year
             };
 
             _artistService.Setup(s => s.GetAllArtists()).Returns(artists);

--- a/Brainarr.Tests/Services/RecommendationValidatorTests.cs
+++ b/Brainarr.Tests/Services/RecommendationValidatorTests.cs
@@ -125,11 +125,14 @@ namespace Brainarr.Tests.Services
         public void ValidateRecommendation_AllowsLegitimateAlbums(string artist, string album, bool expected)
         {
             // Arrange
+            // Use dynamic year for anniversary tests to avoid date-dependent failures
+            // For 50th anniversary to be within 5-year tolerance, original year + 50 must be near current year
+            var anniversaryBaseYear = DateTime.UtcNow.Year - 50; // e.g., 2026 - 50 = 1976
             var recommendation = new Recommendation
             {
                 Artist = artist,
                 Album = album,
-                Year = album.Contains("50th") ? 1970 : 1975 // Set appropriate year for anniversary validation
+                Year = album.Contains("50th") ? anniversaryBaseYear : 1975
             };
 
             // Act


### PR DESCRIPTION
## Summary
Two unit tests were failing because they used hardcoded dates that became invalid as time passed:

1. **AnalyzeLibrary_CalculatesTemporalPatterns**: Albums from 2023-2024 are no longer "recent" (last 2 years) now that it's 2026. Updated to use `DateTime.UtcNow.Year` for recent album dates.

2. **ValidateRecommendation_AllowsLegitimateAlbums**: "50th Anniversary" with year 1970 means 1970+50=2020, which is now 6 years ago and fails the 5-year tolerance check. Updated to use dynamic anniversary base year (`currentYear - 50`).

## Test plan
- [ ] Both previously failing tests now pass
- [ ] Tests remain meaningful and correctly validate the underlying logic
- [ ] No other tests affected by these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)