### PR TITLE
fix(tests): search artifacts/packages for plugin package

### DIFF
--- a/Brainarr.Tests/Packaging/PackagingTestPaths.cs
+++ b/Brainarr.Tests/Packaging/PackagingTestPaths.cs
@@ -28,9 +28,14 @@ namespace Brainarr.Tests.Packaging
                 return null;
             }
 
-            var candidates = Directory.GetFiles(repoRoot, "Brainarr-*.zip")
-                .Concat(Directory.GetFiles(repoRoot, "Brainarr-*.net8.0.zip"))
-                .Concat(Directory.GetFiles(repoRoot, "Brainarr-latest.zip"))
+            // Search in repo root and artifacts/packages/ (build.ps1 output location)
+            var searchPaths = new[] { repoRoot, Path.Combine(repoRoot, "artifacts", "packages") };
+
+            var candidates = searchPaths
+                .Where(Directory.Exists)
+                .SelectMany(dir => Directory.GetFiles(dir, "Brainarr-*.zip")
+                    .Concat(Directory.GetFiles(dir, "Brainarr-*.net8.0.zip"))
+                    .Concat(Directory.GetFiles(dir, "Brainarr-latest.zip")))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .Select(p => new FileInfo(p))
                 .OrderByDescending(f => f.LastWriteTimeUtc)


### PR DESCRIPTION
## Summary
Fix packaging test to find packages in the correct location.

`PackagingTestPaths.TryFindPackagePath()` now searches both:
- repo root (legacy location)
- `artifacts/packages/` (build.ps1 output location)

This aligns the test with `build.ps1` which creates packages in `artifacts/packages/` as of the recent standardization.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~BrainarrPackagingPolicyTests"` passes (3/3)
- [x] Package found at `artifacts/packages/Brainarr-1.3.2.net8.0.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)