### PR TITLE
fix: make MBID enrichment best-effort (don\u0027t drop recs)

### DIFF
--- a/Brainarr.Tests/Services/Enrichment/ArtistMbidResolverBestEffortTests.cs
+++ b/Brainarr.Tests/Services/Enrichment/ArtistMbidResolverBestEffortTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Brainarr.Tests.Helpers;
+using FluentAssertions;
+using NzbDrone.Core.ImportLists.Brainarr.Models;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment;
+using Xunit;
+
+namespace Brainarr.Tests.Services.Enrichment
+{
+    public class ArtistMbidResolverBestEffortTests
+    {
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("{}")
+                };
+                return Task.FromResult(response);
+            }
+        }
+
+        [Fact]
+        public async Task EnrichArtistsAsync_PreservesOriginalRecommendation_WhenLookupFails()
+        {
+            // Arrange
+            var httpClient = new HttpClient(new StubHandler());
+            var resolver = new ArtistMbidResolver(TestLogger.CreateNullLogger(), httpClient);
+            var rec = new Recommendation { Artist = "Radiohead", Confidence = 0.9 };
+
+            // Act
+            var result = await resolver.EnrichArtistsAsync(new List<Recommendation> { rec }, CancellationToken.None);
+
+            // Assert
+            result.Should().HaveCount(1);
+            result[0].Artist.Should().Be("Radiohead");
+            result[0].ArtistMusicBrainzId.Should().BeNull();
+        }
+    }
+}
+


### PR DESCRIPTION
$## Why\nRequireMbids=false should not silently drop recommendations when MusicBrainz lookups fail. This was causing top-up underfill (expected 2, got 1) in BrainarrOrchestratorTopUpTests.\n\n## What\n- Preserve the original Recommendation when album/artist MBID resolution fails (best-effort); downstream safety gates still enforce MBIDs when configured.\n- Add regression tests for both resolvers.\n\n## Tests\n- dotnet test Brainarr.Tests/Brainarr.Tests.csproj -c Release -m:1 --no-build (2037 passed, 29 skipped).\n- Focused filter for TopUp + resolver tests (4 passed).\n