### PR TITLE
fix: isolate ResiliencePolicy tests from static state pollution

### DIFF
--- a/Brainarr.Plugin/Resilience/ResiliencePolicy.cs
+++ b/Brainarr.Plugin/Resilience/ResiliencePolicy.cs
@@ -22,6 +22,19 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Resilience
     {
         private static IUniversalAdaptiveRateLimiter? _adaptiveLimiter;
 
+        /// <summary>
+        /// <b>TEST-ONLY:</b> Resets static state for test isolation. Call from test fixtures to
+        /// prevent cross-test pollution via the shared <see cref="_adaptiveLimiter"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method is <c>internal</c> and only accessible from <c>Brainarr.Tests</c>
+        /// via <c>InternalsVisibleTo</c>. It must not be called from production code.
+        /// </remarks>
+        internal static void ResetForTesting()
+        {
+            _adaptiveLimiter = null;
+        }
+
         public static void ConfigureAdaptiveLimiter(IUniversalAdaptiveRateLimiter limiter)
         {
             _adaptiveLimiter = limiter ?? throw new ArgumentNullException(nameof(limiter));

--- a/Brainarr.Tests/Resilience/ResiliencePolicyTests.cs
+++ b/Brainarr.Tests/Resilience/ResiliencePolicyTests.cs
@@ -10,9 +10,26 @@ using Xunit;
 
 namespace Brainarr.Tests.Resilience
 {
-    public class ResiliencePolicyTests
+    /// <summary>
+    /// Tests for <see cref="ResiliencePolicy"/>. Uses <see cref="IClassFixture{T}"/>
+    /// to reset static state before each test class run, preventing cross-test pollution.
+    /// </summary>
+    public class ResiliencePolicyTests : IDisposable
     {
         private static Logger L => LogManager.GetCurrentClassLogger();
+
+        public ResiliencePolicyTests()
+        {
+            // Reset static state before each test to prevent pollution from other tests
+            // that may have configured the adaptive rate limiter.
+            ResiliencePolicy.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            // Clean up after tests
+            ResiliencePolicy.ResetForTesting();
+        }
 
         [Fact]
         public async Task RunWithRetriesAsync_succeeds_on_second_attempt()


### PR DESCRIPTION
## Summary
- Fixes intermittent failure of `ResiliencePolicyTests.WithHttpResilienceAsync_returns_last_response_after_exhausting_retries`
- Root cause: static `_adaptiveLimiter` field configured by other tests wasn't being reset
- The configured limiter's `WaitIfNeededAsync` call was adding delays/affecting test behavior

## Changes
- Add `ResetForTesting()` method to `ResiliencePolicy` for test isolation
- Implement `IDisposable` on `ResiliencePolicyTests` to reset state before/after each test

## Test plan
- [x] Run isolated test: passes in 2s
- [x] Run full test suite with `--filter Category!=Performance`: 2028 passed, 0 failed, 29 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)