### PR TITLE
chore: add .bridge-exempt marker

### DIFF
--- a/.bridge-exempt
+++ b/.bridge-exempt
@@ -1,0 +1,9 @@
+# Bridge Parity Exemption
+# Brainarr is an LLM-based import list plugin, not a streaming service.
+# It does not wire AddBridgeDefaults() because:
+#   - IIndexerStatusReporter: no indexer (HasIndexer() => false)
+#   - IDownloadStatusReporter: no download client (HasDownloadClient() => false)
+#   - IAuthFailureHandler: LLM auth uses IProviderHealthMonitor, not bridge contracts
+#   - IRateLimitReporter: per-provider rate limiting via LimiterRegistry
+# See: CLAUDE.md "Bridge Wiring (Intentionally Skipped)" section
+# Exempted: 2026-03-27


### PR DESCRIPTION
## Summary
- Adds `.bridge-exempt` marker file to formally codify Brainarr's exclusion from bridge parity enforcement
- Brainarr is an LLM-based import list plugin (not a streaming service) and intentionally does not wire `AddBridgeDefaults()`
- The marker is recognized by Common's `ecosystem-parity-lint.ps1` `Test-BridgeExempt` function

## Test plan
- [ ] Verify `.bridge-exempt` file exists at repo root with correct content
- [ ] Verify no functional changes to plugin code

🤖 Generated with [Claude Code](https://claude.com/claude-code)