### PR TITLE
docs: clarify bridge exemption review cadence

### DIFF
--- a/.bridge-exempt
+++ b/.bridge-exempt
@@ -2,6 +2,7 @@
 # Owner: @RicherTunes
 # Rationale: Brainarr is an LLM-based import list plugin, not a streaming service.
 # Review date: 2026-09-27 (6 months from grant — renew or revoke)
+# Reviewed during quarterly parity audit (next: 2026-06-28) and at exemption review date (2026-09-27), whichever comes first.
 # Granted: 2026-03-27
 #
 # This exemption is renewable, not permanent. At each review date:


### PR DESCRIPTION
## Summary
- Update `.bridge-exempt` to explicitly state the exemption is reviewed at the quarterly parity audit (next: 2026-06-28) or the exemption review date (2026-09-27), whichever comes first

## Test plan
- [ ] Verify `.bridge-exempt` comment is correct and readable
- [ ] Docs-only change — no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)