### PR TITLE
refactor(tests): adopt Common.TestKit Plugin*Contract helpers (-337 LOC)

### DIFF
--- a/Brainarr.Tests/Contracts/VersionContractTests.cs
+++ b/Brainarr.Tests/Contracts/VersionContractTests.cs
@@ -1,89 +1,30 @@
-using System.IO;
-using System.Text.Json;
+using Lidarr.Plugin.Common.TestKit.Compliance;
+using NzbDrone.Core.ImportLists.Brainarr.Hosting;
 using Xunit;
 
 namespace Brainarr.Tests.Contracts;
 
 /// <summary>
-/// Catches version drift between sources of truth: VERSION file, plugin.json,
-/// manifest.json, and assembly metadata.
+/// Catches version drift between AssemblyVersion, plugin.json, manifest.json, and the
+/// top-level VERSION file. The actual assertions live in <see cref="PluginVersionContract"/>
+/// in Common.TestKit — this class is just per-plugin glue.
 ///
-/// Background: Properties/AssemblyInfo.cs once carried a hardcoded
-/// <c>[assembly: AssemblyVersion("1.3.2.0")]</c> literal that stayed put through
-/// the 1.4.0 and 1.4.1 releases (because <c>&lt;GenerateAssemblyInfo&gt;false&lt;/GenerateAssemblyInfo&gt;</c>
-/// made Directory.Build.props' VERSION-file-driven version inert). Result:
-/// <c>/api/v1/system/plugins</c> reported installedVersion=1.3.2 while the actual
-/// release was 1.4.1. The csproj has since been switched to
-/// <c>&lt;GenerateAssemblyInfo&gt;true&lt;/GenerateAssemblyInfo&gt;</c>; this contract test
-/// makes sure the four sources of truth never drift apart again.
+/// See <c>ext/Lidarr.Plugin.Common/testkit/Compliance/PluginVersionContract.cs</c> for
+/// the background incidents this catches (brainarr's AssemblyInfo.cs literal "1.3.2.0"
+/// stayed put through 1.4.x; tidalarr's TidalModule.Version "1.1.0" stayed through 1.1.1;
+/// applemusicarr's manifest.json "0.3.0-beta.2" stayed through 0.4.0).
 /// </summary>
 public class VersionContractTests
 {
     [Fact]
-    public void AssemblyVersion_MatchesPluginJsonVersion()
-    {
-        var pluginJsonPath = LocatePluginJson();
-        Skip.If(pluginJsonPath is null, "plugin.json not found in baseDir or repo root");
-
-        using var doc = JsonDocument.Parse(File.ReadAllText(pluginJsonPath!));
-        var expected = doc.RootElement.GetProperty("version").GetString();
-        Assert.False(string.IsNullOrWhiteSpace(expected), "plugin.json must declare a version");
-
-        var asmVersion = typeof(NzbDrone.Core.ImportLists.Brainarr.Hosting.BrainarrInstalledPlugin)
-            .Assembly.GetName().Version?.ToString(3);
-
-        Assert.Equal(expected, asmVersion);
-    }
+    public void AssemblyVersion_MatchesPluginJsonVersion() =>
+        PluginVersionContract.AssertAssemblyVersionMatchesPluginJson(typeof(BrainarrInstalledPlugin));
 
     [Fact]
-    public void ManifestJson_MatchesPluginJsonVersion()
-    {
-        var pluginJsonPath = LocatePluginJson();
-        var manifestJsonPath = LocateRepoFile("manifest.json");
-        Skip.If(pluginJsonPath is null || manifestJsonPath is null,
-            "plugin.json or manifest.json not found in repo");
-
-        using var pluginDoc = JsonDocument.Parse(File.ReadAllText(pluginJsonPath!));
-        using var manifestDoc = JsonDocument.Parse(File.ReadAllText(manifestJsonPath!));
-
-        var pluginVersion = pluginDoc.RootElement.GetProperty("version").GetString();
-        var manifestVersion = manifestDoc.RootElement.GetProperty("version").GetString();
-
-        Assert.Equal(pluginVersion, manifestVersion);
-    }
+    public void ManifestJson_MatchesPluginJsonVersion() =>
+        PluginVersionContract.AssertManifestMatchesPluginJson(typeof(BrainarrInstalledPlugin));
 
     [Fact]
-    public void VersionFile_MatchesPluginJsonVersion()
-    {
-        var versionPath = LocateRepoFile("VERSION");
-        var pluginJsonPath = LocatePluginJson();
-        Skip.If(versionPath is null || pluginJsonPath is null,
-            "VERSION or plugin.json not found — only enforced for repo-rooted runs");
-
-        var versionFile = File.ReadAllText(versionPath!).Trim();
-        using var doc = JsonDocument.Parse(File.ReadAllText(pluginJsonPath!));
-        var pluginJson = doc.RootElement.GetProperty("version").GetString();
-
-        Assert.Equal(versionFile, pluginJson);
-    }
-
-    private static string? LocatePluginJson()
-    {
-        // AppContext.BaseDirectory — copied here by the SDK at build time
-        var candidate = Path.Combine(AppContext.BaseDirectory, "plugin.json");
-        if (File.Exists(candidate)) return candidate;
-        return LocateRepoFile("plugin.json");
-    }
-
-    private static string? LocateRepoFile(string fileName)
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            var candidate = Path.Combine(dir.FullName, fileName);
-            if (File.Exists(candidate)) return candidate;
-            dir = dir.Parent;
-        }
-        return null;
-    }
+    public void VersionFile_MatchesPluginJsonVersion() =>
+        PluginVersionContract.AssertVersionFileMatchesPluginJson(typeof(BrainarrInstalledPlugin));
 }

--- a/Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests.cs
+++ b/Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests.cs
@@ -1,158 +1,39 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using FluentAssertions;
-using Xunit;
+using Lidarr.Plugin.Common.TestKit.Compliance;
 
 namespace Brainarr.Tests.Packaging
 {
+    /// <summary>
+    /// Validates Brainarr's release zip against the cross-plugin policy. Actual assertion
+    /// logic lives in <see cref="PluginPackagingContract"/> in Common.TestKit — this class
+    /// is just per-plugin glue that supplies the brainarr-specific shape.
+    /// </summary>
     public sealed class BrainarrPackagingPolicyTests
     {
-        private static readonly string[] RequiredFiles =
-        {
-            "Lidarr.Plugin.Brainarr.dll",
-            "plugin.json",
-            "manifest.json"
-        };
-
-        // Previously this list also contained Lidarr.Plugin.Abstractions.dll as a sidecar.
-        // It's now merged + internalized into Lidarr.Plugin.Brainarr.dll via ILRepack
-        // (see ext/Lidarr.Plugin.Common/build/PluginPackaging.targets) so it MUST NOT ship
-        // as a sidecar — doing so reintroduces the COR_E_INVALIDOPERATION cross-ALC conflict
-        // the merge was meant to eliminate. The forbidden list below enforces that.
-        private const long MergedDllMinimumBytes = 2_000_000;
-
-        private static readonly string[] ForbiddenAssemblies =
-        {
-            // Host-provided contract assemblies — shipping them causes type-identity conflicts.
-            "FluentValidation.dll",
-            "Microsoft.Extensions.DependencyInjection.Abstractions.dll",
-            "Microsoft.Extensions.Logging.Abstractions.dll",
-            "Microsoft.Extensions.Caching.Abstractions.dll",
-            "Microsoft.Extensions.Caching.Memory.dll",
-            "Microsoft.Extensions.Options.dll",
-            "Microsoft.Extensions.Primitives.dll",
-            "System.Text.Json.dll",
-            "Newtonsoft.Json.dll",
-            "NLog.dll",
-            // Lidarr host assemblies — host provides them; shipping triggers loader conflicts.
-            "Lidarr.Core.dll",
-            "Lidarr.Common.dll",
-            "Lidarr.Host.dll",
-            "Lidarr.Http.dll",
-            "Lidarr.Api.V1.dll",
-            "NzbDrone.Core.dll",
-            "NzbDrone.Common.dll",
-            // Plugin abstractions — merged + internalized by ILRepack, MUST NOT ship as sidecars.
-            // (Were in RequiredTypeIdentityAssemblies before the May 2026 merge — now they're forbidden.)
-            "Lidarr.Plugin.Abstractions.dll",
-            "Lidarr.Plugin.Common.dll"
-        };
+        private static readonly PluginPackagePolicy Policy = PluginPackagingContract.MergedDllPolicy(
+            mainAssemblyName: "Lidarr.Plugin.Brainarr",
+            extraRequired: new[] { "manifest.json" });
 
         [PackagingFact]
         [Trait("Category", "Packaging")]
-        public void Package_Should_Contain_Required_Files()
+        public void Package_Matches_Brainarr_Policy()
         {
             var zipPath = GetPackagePathOrThrow();
-            var entries = ReadZipEntries(zipPath);
-
-            entries.Should().Contain(RequiredFiles);
-        }
-
-        /// <summary>
-        /// The merged plugin DLL must be at least ~2MB. A smaller DLL means ILRepack's
-        /// RepackPlugin target didn't run and the Common+Abstractions types weren't
-        /// internalized — at runtime Lidarr would then throw
-        /// "Could not load file or assembly 'Lidarr.Plugin.Common, Version=...'" because
-        /// the sidecar was correctly omitted by the packaging policy but the merge
-        /// didn't actually merge anything.
-        /// </summary>
-        [PackagingFact]
-        [Trait("Category", "Packaging")]
-        public void Plugin_Dll_Should_Be_Merged_Size()
-        {
-            var zipPath = GetPackagePathOrThrow();
-            using var archive = ZipFile.OpenRead(zipPath);
-
-            var entry = archive.Entries.FirstOrDefault(e =>
-                Path.GetFileName(e.FullName).Equals("Lidarr.Plugin.Brainarr.dll", StringComparison.OrdinalIgnoreCase));
-
-            entry.Should().NotBeNull("Lidarr.Plugin.Brainarr.dll must be in the package");
-            entry!.Length.Should().BeGreaterOrEqualTo(
-                MergedDllMinimumBytes,
-                "merged DLL should be ~3MB (includes internalized Common + Abstractions); " +
-                "a smaller DLL means ILRepack didn't run and runtime will fail with " +
-                "'Could not load file or assembly Lidarr.Plugin.Abstractions/Common'");
-        }
-
-        [PackagingFact]
-        [Trait("Category", "Packaging")]
-        public void Package_Should_Not_Contain_Forbidden_Assemblies()
-        {
-            var zipPath = GetPackagePathOrThrow();
-            var entries = ReadZipEntries(zipPath);
-
-            entries.Should().NotContain(ForbiddenAssemblies);
-
-            var hostAssemblies = entries
-                .Where(e => e.StartsWith("Lidarr.", StringComparison.OrdinalIgnoreCase))
-                .Where(e => !e.StartsWith("Lidarr.Plugin.", StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
-            hostAssemblies.Should().BeEmpty("plugin packages must not ship Lidarr host assemblies");
-        }
-
-        /// <summary>
-        /// Guard test: FluentValidation.dll must NOT be shipped.
-        ///
-        /// Shipping FluentValidation.dll causes type-identity mismatch across the plugin boundary:
-        /// - Plugin's ValidationResult ≠ Host's ValidationResult (different ALCs)
-        /// - Override signature for Test() method doesn't match
-        /// - Lidarr error: "Method 'Test' in type '...' does not have an implementation"
-        ///
-        /// The plugin must use the host's FluentValidation assembly for type identity to match.
-        /// </summary>
-        [PackagingFact]
-        [Trait("Category", "Packaging")]
-        public void Package_Must_Not_Ship_FluentValidation()
-        {
-            var zipPath = GetPackagePathOrThrow();
-            var entries = ReadZipEntries(zipPath);
-
-            entries.Should().NotContain(
-                "FluentValidation.dll",
-                "FluentValidation.dll causes type-identity mismatch: " +
-                "override signature for Test(List<ValidationFailure>) doesn't match host's signature " +
-                "when ValidationResult resolves from different assembly load contexts");
+            PluginPackagingContract.AssertZipMatchesPolicy(zipPath, Policy);
         }
 
         private static string GetPackagePathOrThrow()
         {
             var zipPath = PackagingTestPaths.TryFindPackagePath();
-            if (zipPath != null)
-            {
-                return zipPath;
-            }
+            if (zipPath != null) return zipPath;
 
             if (PackagingTestPaths.IsStrictMode())
             {
-                throw new InvalidOperationException("No plugin package found. Set PLUGIN_PACKAGE_PATH or run `./build.ps1 -Package`.");
+                throw new InvalidOperationException(
+                    "No plugin package found. Set PLUGIN_PACKAGE_PATH or run `./build.ps1 -Package`.");
             }
 
             throw new InvalidOperationException("PackagingFact should have skipped when package is missing.");
-        }
-
-        private static HashSet<string> ReadZipEntries(string zipPath)
-        {
-            using var archive = ZipFile.OpenRead(zipPath);
-            return archive.Entries
-                .Select(e => e.FullName.Replace('\\', '/').Trim('/'))
-                .Where(e => !string.IsNullOrWhiteSpace(e))
-                .Select(Path.GetFileName)
-                .Where(n => !string.IsNullOrWhiteSpace(n))
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/Brainarr.Tests/ReleaseE2E/PublishedReleaseInstallabilityTests.cs
+++ b/Brainarr.Tests/ReleaseE2E/PublishedReleaseInstallabilityTests.cs
@@ -1,194 +1,35 @@
-using System;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
+using Lidarr.Plugin.Common.TestKit.Compliance;
 using Xunit;
 
 namespace Brainarr.Tests.ReleaseE2E;
 
 /// <summary>
-/// Simulates Lidarr's <c>PluginService.GetRemotePlugin</c> filter against the LIVE
-/// GitHub releases of this repo, then verifies the most-recent installable release's
-/// zip satisfies the packaging policy (required files present, forbidden DLLs absent).
+/// Regression backstop against Lidarr's <c>PluginService.GetRemotePlugin</c> filter applied
+/// to the LIVE GitHub releases of this repo. Actual assertions live in
+/// <see cref="PublishedReleaseInstallabilityContract"/> in Common.TestKit — this class is
+/// just per-plugin glue.
 ///
-/// This is the regression backstop for the May 2026 install-failure class of bugs:
-///   - Asset name didn't contain `net8.0.zip` → Lidarr UI Install spinner hangs forever
-///   - Asset shipped sidecar host DLLs → install completed but plugin crashed with
-///     "Could not load Lidarr.Plugin.Abstractions / Common" / TypeLoadException
-///
-/// Why we exercise this against GitHub instead of the local build artifact:
-/// the local PackagingPolicyTests already cover the build output. This test catches
-/// the case where the *publish* step diverges from the build — e.g. someone hand-uploads
-/// a stale zip, or release.yml's `files:` list points at the wrong artifact.
-///
-/// [Trait("Category", "ReleaseE2E")] so the default test sweep skips it (the GitHub
-/// call is rate-limited and slow). Run via:
-///   dotnet test --filter "Category=ReleaseE2E"
-///
-/// Skips gracefully when there's no network / GitHub is unreachable / no releases yet.
+/// <para>Opt-in via [Trait("Category", "ReleaseE2E")]; skipped in the default test sweep.</para>
 /// </summary>
 public class PublishedReleaseInstallabilityTests
 {
     private const string Owner = "RicherTunes";
     private const string Repo = "Brainarr";
-    private const string Framework = "net8.0";
 
-    private static readonly string[] RequiredFiles =
-    {
-        "Lidarr.Plugin.Brainarr.dll",
-        "plugin.json",
-        "manifest.json"
-    };
-
-    private static readonly string[] ForbiddenAssemblies =
-    {
-        "FluentValidation.dll",
-        "NLog.dll",
-        "System.Text.Json.dll",
-        "Newtonsoft.Json.dll",
-        "Microsoft.Extensions.DependencyInjection.Abstractions.dll",
-        "Microsoft.Extensions.Logging.Abstractions.dll",
-        "Microsoft.Extensions.Caching.Abstractions.dll",
-        "Microsoft.Extensions.Caching.Memory.dll",
-        "Microsoft.Extensions.Options.dll",
-        "Microsoft.Extensions.Primitives.dll",
-        "Lidarr.Core.dll",
-        "Lidarr.Common.dll",
-        "Lidarr.Http.dll",
-        "Lidarr.Api.V1.dll",
-        "NzbDrone.Core.dll",
-        "NzbDrone.Common.dll",
-        // Merged-and-internalized via ILRepack; sidecars regress multi-plugin co-existence.
-        "Lidarr.Plugin.Abstractions.dll",
-        "Lidarr.Plugin.Common.dll",
-    };
+    private static readonly PluginPackagePolicy Policy = PluginPackagingContract.MergedDllPolicy(
+        mainAssemblyName: "Lidarr.Plugin.Brainarr",
+        extraRequired: new[] { "manifest.json" });
 
     [SkippableFact]
     [Trait("Category", "ReleaseE2E")]
-    public async Task LatestPublishedRelease_PassesLidarrInstallFilter()
-    {
-        using HttpClient http = CreateClient();
-
-        var releases = await TryGetReleasesAsync(http);
-        Skip.If(releases is null, "GitHub releases unavailable — network down or rate-limited");
-
-        // Mirror PluginService.GetRemotePlugin filter (plugins branch, May 2026 source):
-        //   - !Draft
-        //   - target_commitish is main/master (case-insensitive)
-        //   - asset name contains "net8.0.zip" (case-insensitive)
-        //   - body's "Minimum Lidarr Version" (if present) ≤ host version (we don't enforce here)
-        var installable = releases!.Value.EnumerateArray()
-            .Where(r => !r.GetProperty("draft").GetBoolean())
-            .Where(r => IsDefaultTree(r.GetProperty("target_commitish").GetString()))
-            .Where(r => r.GetProperty("assets").EnumerateArray()
-                .Any(a => a.GetProperty("name").GetString()?.Contains($"{Framework}.zip", StringComparison.OrdinalIgnoreCase) == true))
-            .ToList();
-
-        Assert.True(installable.Count > 0,
-            $"No release passes Lidarr's PluginService filter. " +
-            $"At least one non-draft release on main/master with a `*{Framework}.zip` asset is required. " +
-            $"This means the UI Install button on https://github.com/{Owner}/{Repo} would silently fail.");
-    }
+    public Task LatestPublishedRelease_PassesLidarrInstallFilter() =>
+        PublishedReleaseInstallabilityContract
+            .AssertLatestReleasePassesLidarrInstallFilterAsync(Owner, Repo);
 
     [SkippableFact]
     [Trait("Category", "ReleaseE2E")]
-    public async Task LatestPublishedRelease_ZipContents_Match_PackagingPolicy()
-    {
-        using HttpClient http = CreateClient();
-
-        var releases = await TryGetReleasesAsync(http);
-        Skip.If(releases is null, "GitHub releases unavailable — network down or rate-limited");
-
-        var topRelease = releases!.Value.EnumerateArray()
-            .Where(r => !r.GetProperty("draft").GetBoolean())
-            .Where(r => IsDefaultTree(r.GetProperty("target_commitish").GetString()))
-            .FirstOrDefault(r => r.GetProperty("assets").EnumerateArray()
-                .Any(a => a.GetProperty("name").GetString()?.Contains($"{Framework}.zip", StringComparison.OrdinalIgnoreCase) == true));
-
-        Skip.If(topRelease.ValueKind == JsonValueKind.Undefined,
-            "No installable release found (see LatestPublishedRelease_PassesLidarrInstallFilter for diagnosis)");
-
-        var asset = topRelease.GetProperty("assets").EnumerateArray()
-            .First(a => a.GetProperty("name").GetString()?.Contains($"{Framework}.zip", StringComparison.OrdinalIgnoreCase) == true);
-
-        var downloadUrl = asset.GetProperty("browser_download_url").GetString()!;
-        await using Stream zipStream = await http.GetStreamAsync(downloadUrl);
-        using var ms = new MemoryStream();
-        await zipStream.CopyToAsync(ms);
-        ms.Position = 0;
-        using var archive = new ZipArchive(ms, ZipArchiveMode.Read);
-
-        var fileNames = archive.Entries
-            .Select(e => Path.GetFileName(e.FullName))
-            .Where(n => !string.IsNullOrWhiteSpace(n))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        var assetName = asset.GetProperty("name").GetString();
-        foreach (var required in RequiredFiles)
-        {
-            Assert.True(fileNames.Contains(required),
-                $"Published release asset '{assetName}' is missing required file '{required}'. " +
-                $"Contents: {string.Join(", ", fileNames)}");
-        }
-
-        foreach (var forbidden in ForbiddenAssemblies)
-        {
-            Assert.False(fileNames.Contains(forbidden),
-                $"Published release asset '{assetName}' ships FORBIDDEN '{forbidden}' — " +
-                $"this would cause type-identity conflicts or regress multi-plugin co-existence. " +
-                $"Contents: {string.Join(", ", fileNames)}");
-        }
-
-        // Merged DLL sanity — ILRepack should have produced a ≥2MB DLL with internalized
-        // Common + Abstractions. Sub-threshold means the merge didn't run and the plugin
-        // will fail at runtime trying to load the (correctly-omitted) sidecars.
-        var mainDllEntry = archive.Entries.FirstOrDefault(e =>
-            Path.GetFileName(e.FullName).Equals("Lidarr.Plugin.Brainarr.dll", StringComparison.OrdinalIgnoreCase));
-        Assert.NotNull(mainDllEntry);
-        Assert.True(mainDllEntry!.Length >= 2_000_000,
-            $"Lidarr.Plugin.Brainarr.dll in '{assetName}' is only {mainDllEntry.Length} bytes. " +
-            $"Expected ≥2MB (merged DLL with internalized Common + Abstractions). " +
-            $"Sub-threshold means ILRepack didn't run — runtime will fail with " +
-            $"'Could not load Lidarr.Plugin.Common / Abstractions'.");
-    }
-
-    private static bool IsDefaultTree(string? target) =>
-        string.Equals(target, "main", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(target, "master", StringComparison.OrdinalIgnoreCase);
-
-    private static HttpClient CreateClient()
-    {
-        var client = new HttpClient
-        {
-            Timeout = TimeSpan.FromSeconds(30)
-        };
-        client.DefaultRequestHeaders.UserAgent.ParseAdd($"{Repo}-tests/1.0");
-        var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-        if (!string.IsNullOrWhiteSpace(token))
-        {
-            client.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
-        }
-        return client;
-    }
-
-    private static async Task<JsonElement?> TryGetReleasesAsync(HttpClient http)
-    {
-        try
-        {
-            using var response = await http.GetAsync($"https://api.github.com/repos/{Owner}/{Repo}/releases?per_page=30");
-            if (!response.IsSuccessStatusCode) return null;
-            var json = await response.Content.ReadAsStringAsync();
-            using var doc = JsonDocument.Parse(json);
-            // Clone the root element so it survives the using-scope.
-            return doc.RootElement.Clone();
-        }
-        catch (Exception)
-        {
-            return null;
-        }
-    }
+    public Task LatestPublishedRelease_ZipContents_Match_PackagingPolicy() =>
+        PublishedReleaseInstallabilityContract
+            .AssertLatestReleaseZipMatchesPolicyAsync(Owner, Repo, Policy);
 }


### PR DESCRIPTION
## Summary

Replaces ~381 lines of brainarr-specific contract test logic with ~44 lines of glue that delegates to the lifted contracts in `Lidarr.Plugin.Common.TestKit`.

**Blocked by Common PR #510** (`feat/lift-plugin-contracts`) — this branch's submodule pin must point at the merged SHA before this can land on main.

### Test-code reduction

```
 Brainarr.Tests/Contracts/VersionContractTests.cs      |  89 ++--------
 Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests |  147 ++-------
 Brainarr.Tests/ReleaseE2E/PublishedReleaseInstall...  |  189 ++-------------
 3 files changed, 44 insertions(+), 381 deletions(-)
```

### What moves where

| Contract | Was (brainarr-only) | Now (Common.TestKit) |
|---|---|---|
| Assembly version ≡ plugin.json ≡ VERSION ≡ manifest.json | `Brainarr.Tests/Contracts/VersionContractTests.cs` (~89 LOC) | `PluginVersionContract.AssertAssemblyVersionMatchesPluginJson` + 2 siblings |
| Required files + forbidden DLLs + merged-DLL size ≥2MB | `Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests.cs` (~147 LOC) | `PluginPackagingContract.AssertZipMatchesPolicy` + `MergedDllPolicy` preset |
| GitHub-releases install filter + zip-contents check | `Brainarr.Tests/ReleaseE2E/PublishedReleaseInstallabilityTests.cs` (~189 LOC) | `PublishedReleaseInstallabilityContract.AssertLatestRelease*Async` |

### Behaviour preserved

Verified against the published v1.4.1 release:

- VersionContract: **3/3 pass**
- Packaging (consolidated): **1/1 pass** (was 4 narrower tests)
- ReleaseE2E: **2/2 pass**

### Rollout

This is the first of four adoption PRs. Sibling PRs for qobuzarr/tidalarr/applemusicarr will follow the same pattern.

## Test plan

- [x] Tests pass locally against v1.4.1 release zip
- [ ] After Common PR #510 merges, rebase this branch onto main and bump the submodule pin to the new Common SHA
- [ ] Re-verify all three contract test sets still pass