### PR TITLE
refactor(ci): converge Docker E2E build onto qobuzarr/tidalarr pattern

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -136,42 +136,31 @@ jobs:
         shell: bash
         run: dotnet restore Brainarr.sln
 
-      - name: Build solution (Release, with ILRepack on Plugin csproj)
+      - name: Build tests (un-merged plugin → bin-tests/)
         shell: bash
         run: |
-          # Build the solution so Brainarr.Tests.dll is available for the Docker E2E
-          # action's test runner. Critically: DON'T pass -p:PluginPackagingDisable=true.
-          # Without ILRepack the produced Brainarr.Plugin/bin/Lidarr.Plugin.Brainarr.dll
-          # lacks internalized Common+Abstractions types AND ships every transitive
-          # NuGet dep (Microsoft.Extensions.*.dll, Newtonsoft.Json.dll, etc.) as
-          # siblings. When LidarrContainerFixture mounts that dir into
-          # /config/plugins/RicherTunes/Brainarr, those host-provided DLLs cause
-          # COR_E_INVALIDOPERATION inside the container and /api/v1/system/plugins
-          # returns []. The Plugin csproj wires ILRepack via PluginPackaging.targets
-          # so the merged DLL replaces the un-merged one in bin/ — the test project
-          # still references the un-merged via its bin-tests output (see csproj
-          # PluginPackagingDisable=true on the ProjectReference). Wave 17R fix.
-          dotnet build Brainarr.sln \
+          # Build the test project for the docker-e2e action's `dotnet test --no-build` runner.
+          # Its plugin ProjectReferences redirect the un-merged build to Brainarr.Plugin/bin-tests/
+          # (PluginPackagingDisable=true;OutputPath=bin-tests\), so this never writes the un-merged
+          # DLL into the merged bin/ the E2E harness mounts.
+          dotnet build Brainarr.Tests/Brainarr.Tests.csproj \
             --no-restore \
             --configuration Release \
+            -p:PluginPackagingDisable=true \
             -p:LidarrPath="${{ env.LIDARR_PATH }}" \
             -p:GeneratePackageOnBuild=false \
             -m:1 \
             --disable-build-servers
 
-      - name: Re-merge plugin DLL for E2E mount (clean bin/)
+      - name: Build plugin (merged) for E2E mount
         shell: bash
         run: |
-          # The solution build leaves Brainarr.Plugin/bin/ polluted with the UN-merged plugin
-          # output: because Brainarr.Tests references the plugin with PluginPackagingDisable=true,
-          # the un-merged variant (Lidarr.Plugin.Abstractions.dll, CliWrap.dll,
-          # Microsoft.Extensions.*.dll as siblings) lands in bin/. The Docker E2E harness mounts
-          # that dir into /config/plugins/RicherTunes/Brainarr; those sidecar contract assemblies
-          # cause COR_E_INVALIDOPERATION in the container and the plugin never loads (schema empty).
-          # Rebuilding the plugin project alone re-runs ILRepack (RepackPlugin), which merges +
-          # internalizes the deps and deletes the sidecars, leaving only the merged
-          # Lidarr.Plugin.Brainarr.dll for the harness to mount. (Build-config parity across
-          # plugins is tracked separately.)
+          # Build the plugin project last so Brainarr.Plugin/bin/ holds ONLY the merged
+          # Lidarr.Plugin.Brainarr.dll (ILRepack internalizes Common/Abstractions/CliWrap and
+          # deletes sidecars) — the artifact LidarrContainerFixture mounts into the container.
+          # Mirrors qobuzarr/tidalarr: separate plugin + test builds, no solution build, no
+          # re-merge hack. Relies on EVERY plugin ProjectReference redirecting its un-merged
+          # output to bin-tests\ (Brainarr.Tests + Brainarr.TestKit.Providers).
           dotnet build Brainarr.Plugin/Brainarr.Plugin.csproj \
             --no-restore \
             --configuration Release \
@@ -179,7 +168,7 @@ jobs:
             -p:GeneratePackageOnBuild=false \
             -m:1 \
             --disable-build-servers
-          echo "Plugin bin/ after re-merge:"
+          echo "Plugin bin/ for E2E mount:"
           ls -1 Brainarr.Plugin/bin/*.dll
 
       - name: Docker E2E

--- a/Brainarr.Tests/Brainarr.Tests.csproj
+++ b/Brainarr.Tests/Brainarr.Tests.csproj
@@ -38,9 +38,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Brainarr.Plugin\Brainarr.Plugin.csproj">
-      <!-- Unit tests should run against the unmerged assembly; ILRepack internalization can
-           rewrite public signatures and break direct method calls from test assemblies. -->
-      <AdditionalProperties>PluginPackagingDisable=true</AdditionalProperties>
+      <!-- Unit tests run against the un-merged assembly (ILRepack internalization rewrites
+           public signatures and breaks direct calls from tests). OutputPath=bin-tests\ keeps
+           that un-merged build OUT of Brainarr.Plugin/bin/ so it can't clobber the merged
+           release artifact the Docker E2E harness mounts. Matches qobuzarr/tidalarr. -->
+      <AdditionalProperties>PluginPackagingDisable=true;OutputPath=bin-tests\;EnablePluginDeployment=false</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\tests\Brainarr.TestKit.Providers\Brainarr.TestKit.Providers.csproj" />
     <ProjectReference Include="..\ext\Lidarr.Plugin.Common\testkit\Lidarr.Plugin.Common.TestKit.csproj">

--- a/Brainarr.Tests/BuildConfig/PluginReferenceRedirectTests.cs
+++ b/Brainarr.Tests/BuildConfig/PluginReferenceRedirectTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Brainarr.Tests.BuildConfig
+{
+    /// <summary>
+    /// Regression guard for the Docker E2E `bin/` pollution class of bug.
+    ///
+    /// Every project that references Brainarr.Plugin with
+    /// <c>PluginPackagingDisable=true</c> (i.e. wants the UN-merged assembly for tests) MUST
+    /// also redirect that build to <c>bin-tests\</c> via <c>OutputPath=bin-tests\</c>. Without
+    /// the redirect, the un-merged plugin DLL plus its sidecar contract assemblies
+    /// (Lidarr.Plugin.Abstractions.dll, CliWrap.dll, Microsoft.Extensions.*.dll) land in
+    /// Brainarr.Plugin/bin/ and pollute the merged artifact the Docker E2E harness mounts into
+    /// the Lidarr container, causing COR_E_INVALIDOPERATION and an empty plugin schema.
+    ///
+    /// This is the brainarr-side enforcement of the qobuzarr/tidalarr build-config parity
+    /// pattern.
+    /// </summary>
+    public class PluginReferenceRedirectTests
+    {
+        [Fact]
+        [Trait("Category", "Unit")]
+        public void EveryUnmergedPluginReference_RedirectsOutputToBinTests()
+        {
+            var repoRoot = GetRepoRoot();
+            var offenders = Directory
+                .EnumerateFiles(repoRoot, "*.csproj", SearchOption.AllDirectories)
+                .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                         && !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+                .SelectMany(GetUnmergedPluginRefsMissingRedirect)
+                .ToList();
+
+            offenders.Should().BeEmpty(
+                "every ProjectReference to Brainarr.Plugin with PluginPackagingDisable=true must also " +
+                "set OutputPath=bin-tests\\ so the un-merged build never pollutes the merged bin/ the " +
+                "Docker E2E harness mounts. Offending references:\n" + string.Join("\n", offenders));
+        }
+
+        private static System.Collections.Generic.IEnumerable<string> GetUnmergedPluginRefsMissingRedirect(string csprojPath)
+        {
+            XDocument doc;
+            try { doc = XDocument.Load(csprojPath); }
+            catch { yield break; }
+
+            foreach (var pr in doc.Descendants().Where(e => e.Name.LocalName == "ProjectReference"))
+            {
+                var include = pr.Attribute("Include")?.Value ?? string.Empty;
+                if (!include.Replace('\\', '/').EndsWith("Brainarr.Plugin/Brainarr.Plugin.csproj", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var addProps = pr.Elements().FirstOrDefault(e => e.Name.LocalName == "AdditionalProperties")?.Value ?? string.Empty;
+                if (addProps.IndexOf("PluginPackagingDisable=true", StringComparison.OrdinalIgnoreCase) < 0)
+                    continue; // merged reference — does not pollute bin/
+
+                if (addProps.IndexOf("OutputPath=bin-tests", StringComparison.OrdinalIgnoreCase) < 0)
+                    yield return $"  {Path.GetFileName(csprojPath)}: ProjectReference '{include}' has PluginPackagingDisable=true but no OutputPath=bin-tests\\";
+            }
+        }
+
+        private static string GetRepoRoot()
+        {
+            var dir = AppContext.BaseDirectory;
+            for (var i = 0; i < 8; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "Brainarr.sln"))) return dir;
+                var parent = Directory.GetParent(dir)?.FullName;
+                if (parent == null) break;
+                dir = parent;
+            }
+            throw new DirectoryNotFoundException("Could not locate repo root containing Brainarr.sln");
+        }
+    }
+}

--- a/tests/Brainarr.TestKit.Providers/Brainarr.TestKit.Providers.csproj
+++ b/tests/Brainarr.TestKit.Providers/Brainarr.TestKit.Providers.csproj
@@ -7,8 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../Brainarr.Plugin/Brainarr.Plugin.csproj">
-      <!-- TestKit should also bind against the unmerged plugin assembly for consistent type identity. -->
-      <AdditionalProperties>PluginPackagingDisable=true</AdditionalProperties>
+      <!-- TestKit binds against the unmerged plugin assembly for consistent type identity.
+           OutputPath=bin-tests\ keeps that un-merged build OUT of Brainarr.Plugin/bin/ — without
+           it, building anything that depends on this project leaves the un-merged plugin (+ sidecar
+           contract assemblies) in bin/, polluting the merged artifact the Docker E2E harness mounts.
+           Must match the redirect on every other plugin ProjectReference. -->
+      <AdditionalProperties>PluginPackagingDisable=true;OutputPath=bin-tests\;EnablePluginDeployment=false</AdditionalProperties>
     </ProjectReference>
     <!-- HttpResponseFactory.cs is a forwarding shim onto
          Lidarr.Plugin.Common.TestKit.Http.HttpResponseFactory. That type lives in the


### PR DESCRIPTION
## Summary

Replaces brainarr's one-off "build solution + re-merge plugin" Docker E2E hack with the build-config pattern qobuzarr/tidalarr already use, so the `bin/`-pollution bug can't diverge between plugins again (CI/CD parity).

**Root cause of the divergence:** brainarr has multiple projects referencing `Brainarr.Plugin` with `PluginPackagingDisable=true`, but the `OutputPath=bin-tests\` redirect was missing on `Brainarr.Tests` *and* `Brainarr.TestKit.Providers`. So building the test suite wrote the un-merged plugin (+ `Lidarr.Plugin.Abstractions.dll` / `CliWrap.dll` / `Microsoft.Extensions.*` siblings) into `Brainarr.Plugin/bin/` — the dir the E2E harness mounts → `COR_E_INVALIDOPERATION`. qobuzarr/tidalarr have a single, redirected reference, so their `bin/` stays merged.

## Changes
- `Brainarr.Tests` + `Brainarr.TestKit.Providers` ProjectReferences now use `PluginPackagingDisable=true;OutputPath=bin-tests\;EnablePluginDeployment=false` (the qobuzarr/tidalarr redirect).
- `docker-e2e.yml` builds the plugin project (merged → `bin/`) and test project (un-merged → `bin-tests\`) **separately** — no solution build, no re-merge hack.
- New `PluginReferenceRedirectTests` guard fails if any future un-merged plugin reference forgets the redirect.

## Verification
- Local: plugin build → `bin/` = 1 merged DLL (no external Abstractions/CliWrap refs); test build leaves `bin/` merged, un-merged DLL in `bin-tests\`. Cross-checked against qobuzarr (whose `bin/` stays clean with the same pattern).
- 55-test subset green with the redirect; guard test green.

## Test plan
- [ ] Docker E2E green with the separate-build pattern (the real validation)
- [ ] `test` + Test & Build matrices green

🤖 Generated with [Claude Code](https://claude.com/claude-code)