### PR TITLE
refactor(ci): use Common's reusable Docker E2E workflow

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -1,21 +1,17 @@
 name: Docker E2E
 
-# Wave 24 — adopts the shared docker-e2e composite action that lives in
-# ext/Lidarr.Plugin.Common/.github/actions/docker-e2e (added by common's
-# wave 23). Boots a real Lidarr container with the merged Brainarr DLL
-# mounted and runs the wave-22b ImportList smoke matrix:
+# Thin caller of Common's reusable Docker E2E workflow (added in Common #536).
+# The reusable workflow checks out brainarr, inits the Common submodule, extracts
+# Lidarr host assemblies, builds the test project (un-merged plugin → bin-tests\)
+# then the plugin project (merged → bin/), and runs the Category=DockerE2E smoke
+# matrix via the shared composite action, mounting the merged bin/.
 #
+# Brainarr is an ImportList-only plugin, so the matrix is 2 facts:
 #   - Plugin_Loads_AppearsInImportListSchema
 #   - ImportList_Test_WithEmptySettings_ReturnsSensibleFailure
 #
-# Brainarr is an ImportList-only plugin (HasIndexer=false,
-# HasDownloadClient=false in BrainarrModule), so the matrix is 2 facts —
-# not 4 like indexer/downloadclient plugins. The composite action targets
-# Category=DockerE2E and the [SkippableFact]s in DockerE2ETests skip
-# gracefully when Docker is unavailable.
-#
-# Linux only: the Lidarr image is a Linux container, so this workflow
-# must run on ubuntu-latest.
+# Convergence: all four plugins should call this same reusable workflow so the
+# Docker E2E pipeline stops diverging (the bin/-pollution class of bug).
 
 on:
   push:
@@ -54,127 +50,13 @@ concurrency:
   group: docker-e2e-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  LIDARR_DOCKER_VERSION: pr-plugins-3.1.2.4913
-  DOTNET_CLI_DISABLE_BUILD_SERVERS: '1'
-
 jobs:
   e2e:
-    name: Docker E2E (Brainarr)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: false
-          fetch-depth: 0
-
-      - name: Init Common submodule
-        uses: ./.github/actions/init-common-submodule
-        with:
-          token: ${{ secrets.SUBMODULES_TOKEN }}
-
-      - name: Assert composite action present
-        shell: bash
-        run: |
-          path="ext/Lidarr.Plugin.Common/.github/actions/docker-e2e/action.yml"
-          if [ ! -f "$path" ]; then
-            echo "::error::Composite action not found at $path."
-            echo "::error::Bump ext-common-sha.txt to a wave-23+ commit of Lidarr.Plugin.Common."
-            exit 1
-          fi
-          echo "Composite action present: $path"
-
-      - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'
-
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/NuGet.config') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
-
-      - name: Read pinned plugins digest (if available)
-        id: digest
-        shell: bash
-        run: |
-          if [ -f .github/lidarr_digest.txt ]; then
-            DIG=$(grep -v '^\s*#' .github/lidarr_digest.txt | head -1 | cut -d'#' -f1 | tr -d '[:space:]')
-            if [[ "$DIG" == sha256:* ]]; then
-              echo "LIDARR_DOCKER_DIGEST=$DIG" >> "$GITHUB_ENV"
-              echo "Using pinned digest: $DIG"
-            fi
-          fi
-
-      - name: Extract Lidarr assemblies (plugins Docker)
-        shell: bash
-        run: |
-          set -euo pipefail
-          timeout 12m bash scripts/extract-lidarr-assemblies.sh --mode full --no-tar-fallback --output-dir ext/Lidarr-docker/_output/net8.0
-
-      - name: Verify assemblies present
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -f ext/Lidarr-docker/_output/net8.0/Lidarr.Core.dll || { echo "Missing Lidarr.Core.dll in assemblies"; exit 1; }
-          if ! compgen -G "ext/Lidarr-docker/_output/net8.0/Lidarr.*.dll" > /dev/null; then
-            echo "Missing Lidarr.*.dll assemblies; ensure full /app/bin is extracted from the plugins Docker image"
-            exit 1
-          fi
-          ls -la ext/Lidarr-docker/_output/net8.0/
-
-      - name: Set LIDARR_PATH
-        shell: bash
-        run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" >> $GITHUB_ENV
-
-      - name: Restore
-        shell: bash
-        run: dotnet restore Brainarr.sln
-
-      - name: Build tests (un-merged plugin → bin-tests/)
-        shell: bash
-        run: |
-          # Build the test project for the docker-e2e action's `dotnet test --no-build` runner.
-          # Its plugin ProjectReferences redirect the un-merged build to Brainarr.Plugin/bin-tests/
-          # (PluginPackagingDisable=true;OutputPath=bin-tests\), so this never writes the un-merged
-          # DLL into the merged bin/ the E2E harness mounts.
-          dotnet build Brainarr.Tests/Brainarr.Tests.csproj \
-            --no-restore \
-            --configuration Release \
-            -p:PluginPackagingDisable=true \
-            -p:LidarrPath="${{ env.LIDARR_PATH }}" \
-            -p:GeneratePackageOnBuild=false \
-            -m:1 \
-            --disable-build-servers
-
-      - name: Build plugin (merged) for E2E mount
-        shell: bash
-        run: |
-          # Build the plugin project last so Brainarr.Plugin/bin/ holds ONLY the merged
-          # Lidarr.Plugin.Brainarr.dll (ILRepack internalizes Common/Abstractions/CliWrap and
-          # deletes sidecars) — the artifact LidarrContainerFixture mounts into the container.
-          # Mirrors qobuzarr/tidalarr: separate plugin + test builds, no solution build, no
-          # re-merge hack. Relies on EVERY plugin ProjectReference redirecting its un-merged
-          # output to bin-tests\ (Brainarr.Tests + Brainarr.TestKit.Providers).
-          dotnet build Brainarr.Plugin/Brainarr.Plugin.csproj \
-            --no-restore \
-            --configuration Release \
-            -p:LidarrPath="${{ env.LIDARR_PATH }}" \
-            -p:GeneratePackageOnBuild=false \
-            -m:1 \
-            --disable-build-servers
-          echo "Plugin bin/ for E2E mount:"
-          ls -1 Brainarr.Plugin/bin/*.dll
-
-      - name: Docker E2E
-        uses: ./ext/Lidarr.Plugin.Common/.github/actions/docker-e2e
-        with:
-          plugin-name: brainarr
-          test-project: Brainarr.Tests/Brainarr.Tests.csproj
-          lidarr-docker-version: ${{ inputs.lidarr-docker-version || 'pr-plugins-3.1.2.4913' }}
-          configuration: Release
+    uses: RicherTunes/Lidarr.Plugin.Common/.github/workflows/docker-e2e.yml@68ab73430b27d91294a037235a3cc40815f7cef4 # main (reusable docker-e2e)
+    with:
+      plugin-name: brainarr
+      plugin-csproj: Brainarr.Plugin/Brainarr.Plugin.csproj
+      test-project: Brainarr.Tests/Brainarr.Tests.csproj
+      lidarr-docker-version: ${{ inputs.lidarr-docker-version || 'pr-plugins-3.1.2.4913' }}
+    secrets:
+      submodules-token: ${{ secrets.SUBMODULES_TOKEN }}


### PR DESCRIPTION
## Summary

Converts brainarr's hand-rolled `docker-e2e.yml` into a thin caller of Common's new reusable Docker E2E workflow (Common #536). The reusable workflow does checkout + submodule init + Lidarr assembly extraction + the separate test/plugin builds (un-merged → `bin-tests\`, merged → `bin/`) + the smoke matrix via the shared composite action.

This converges the Docker E2E pipeline onto one shared source so the build/mount logic can't diverge between plugins again — the root of the `bin/`-pollution / `COR_E_INVALIDOPERATION` bug. brainarr is the CI-validated template; qobuzarr/tidalarr/applemusicarr adopt the same caller once their CI billing is restored.

## Test plan
- [ ] Docker E2E green via the reusable workflow (real validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)