### PR TITLE
refactor(ci): use Common's reusable notify-failure workflow

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -1,6 +1,9 @@
 name: Notify on Failure
 
-# Triggers on workflow failures for critical CI workflows
+# Thin caller of Common's reusable notify-failure workflow (Common #539).
+# Keeps brainarr's own workflow_run trigger + monitored-workflow list (plugin-specific)
+# and delegates the Discord/Slack/summary notification to the shared reusable so the
+# message format and webhook handling (secret + vars fallback) are single-sourced.
 
 on:
   workflow_run:
@@ -18,85 +21,12 @@ permissions:
 
 jobs:
   notify:
-    name: Send Failure Notification
-    runs-on: ubuntu-latest
+    # Only delegate when the monitored workflow actually failed.
     if: github.event.workflow_run.conclusion == 'failure'
-
-    steps:
-      - name: Prepare notification data
-        id: data
-        run: |
-          echo "workflow_name=${{ github.event.workflow_run.name }}" >> $GITHUB_OUTPUT
-          echo "run_url=${{ github.event.workflow_run.html_url }}" >> $GITHUB_OUTPUT
-          echo "branch=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
-          echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
-          echo "commit=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
-          echo "actor=${{ github.event.workflow_run.actor.login }}" >> $GITHUB_OUTPUT
-
-      - name: Send Discord notification
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK || vars.DISCORD_WEBHOOK }}
-        if: env.DISCORD_WEBHOOK != ''
-        run: |
-          curl -H "Content-Type: application/json" \
-            -d '{
-              "embeds": [{
-                "title": "❌ CI Failure: ${{ steps.data.outputs.workflow_name }}",
-                "description": "Workflow failed on **${{ steps.data.outputs.branch }}**",
-                "color": 15158332,
-                "fields": [
-                  {"name": "Repository", "value": "`${{ steps.data.outputs.repo }}`", "inline": true},
-                  {"name": "Branch", "value": "`${{ steps.data.outputs.branch }}`", "inline": true},
-                  {"name": "Triggered by", "value": "`${{ steps.data.outputs.actor }}`", "inline": true}
-                ],
-                "url": "${{ steps.data.outputs.run_url }}",
-                "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
-              }]
-            }' \
-            "$DISCORD_WEBHOOK" || echo "Discord notification failed (webhook may not be configured)"
-
-      - name: Send Slack notification
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK || vars.SLACK_WEBHOOK }}
-        if: env.SLACK_WEBHOOK != ''
-        run: |
-          curl -X POST -H "Content-Type: application/json" \
-            -d '{
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {"type": "plain_text", "text": "❌ CI Failure: Brainarr", "emoji": true}
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {"type": "mrkdwn", "text": "*Workflow:*\n${{ steps.data.outputs.workflow_name }}"},
-                    {"type": "mrkdwn", "text": "*Branch:*\n${{ steps.data.outputs.branch }}"},
-                    {"type": "mrkdwn", "text": "*Triggered by:*\n${{ steps.data.outputs.actor }}"}
-                  ]
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {"type": "plain_text", "text": "View Run"},
-                      "url": "${{ steps.data.outputs.run_url }}"
-                    }
-                  ]
-                }
-              ]
-            }' \
-            "$SLACK_WEBHOOK" || echo "Slack notification failed (webhook may not be configured)"
-
-      - name: Log failure to summary
-        run: |
-          echo "## ❌ Workflow Failure Detected" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Workflow | ${{ steps.data.outputs.workflow_name }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Repository | ${{ steps.data.outputs.repo }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Branch | ${{ steps.data.outputs.branch }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Triggered by | ${{ steps.data.outputs.actor }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Run URL | [${{ steps.data.outputs.run_url }}](${{ steps.data.outputs.run_url }}) |" >> $GITHUB_STEP_SUMMARY
+    uses: RicherTunes/Lidarr.Plugin.Common/.github/workflows/notify-failure.yml@533c14317131f4ec178f4c15a49ea6d9633ecd35 # main (notify-failure secrets-context fix)
+    with:
+      workflow_name: ${{ github.event.workflow_run.name }}
+      run_url: ${{ github.event.workflow_run.html_url }}
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary

Converts brainarr's hand-rolled `notify-failure.yml` (103 lines) into a thin caller (32 lines) of Common's reusable notify-failure (Common #539). Third pipeline converged onto a shared source (after docker-e2e #579, codeql #580).

Keeps brainarr's own `workflow_run` trigger + monitored-workflow list (plugin-specific) and the `conclusion == 'failure'` gate; delegates the Discord/Slack/summary notification to the shared reusable. Forwards `DISCORD_WEBHOOK`/`SLACK_WEBHOOK` secrets; the reusable also reads repo/org **vars** as a fallback (parity with the prior inline `secrets.X || vars.X`).

## Notes
- No webhook is currently configured on brainarr, so this is a functional no-op today (hits the reusable's summary-log branch); the value is single-sourcing the format + dedup.
- Minor cosmetic: the shared message omits the "Triggered by" actor field the inline version had — acceptable for a single shared format.
- Can't be end-to-end CI-validated without a real monitored-workflow failure; `actionlint` clean and the reusable was fixed/validated in Common #539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)