### PR TITLE
fix: harden recommendation pipeline against untrusted LLM data (defect hunt)

### DIFF
--- a/Brainarr.Plugin/Services/Core/BrainarrOrchestrator.cs
+++ b/Brainarr.Plugin/Services/Core/BrainarrOrchestrator.cs
@@ -285,8 +285,12 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
             int applied = 0;
             foreach (var key in settings.ReviewApproveKeys)
             {
-                var parts = (key ?? "").Split('|');
-                if (parts.Length >= 2 && _reviewQueue.SetStatus(parts[0], parts[1], ReviewQueueService.ReviewStatus.Accepted))
+                // Split on the LAST '|' to match SafetyGateService's key contract: an artist that
+                // contains '|' (e.g. "AC|DC") encodes as "AC|DC|Album", so a first-pipe split
+                // misparsed artist/album and the approval silently never matched a pending entry.
+                var k = key ?? "";
+                var lastPipe = k.LastIndexOf('|');
+                if (lastPipe > 0 && _reviewQueue.SetStatus(k.Substring(0, lastPipe), k.Substring(lastPipe + 1), ReviewQueueService.ReviewStatus.Accepted))
                 {
                     applied++;
                 }

--- a/Brainarr.Plugin/Services/Core/RecommendationGenerator.cs
+++ b/Brainarr.Plugin/Services/Core/RecommendationGenerator.cs
@@ -303,7 +303,9 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
                     Album = r.Album,
                     ArtistMusicBrainzId = string.IsNullOrWhiteSpace(r.ArtistMusicBrainzId) ? null : r.ArtistMusicBrainzId,
                     AlbumMusicBrainzId = string.IsNullOrWhiteSpace(r.AlbumMusicBrainzId) ? null : r.AlbumMusicBrainzId,
-                    ReleaseDate = r.Year.HasValue ? new DateTime(r.Year.Value, 1, 1) : DateTime.MinValue
+                    // Guard year range [1,9999]; untrusted LLM Year out of range previously threw
+                    // ArgumentOutOfRangeException and the orchestrator's broad catch dropped the whole batch.
+                    ReleaseDate = (r.Year is int y && y >= 1 && y <= 9999) ? new DateTime(y, 1, 1) : DateTime.MinValue
                 })
                 .ToList();
         }

--- a/Brainarr.Plugin/Services/Core/RecommendationPipeline.cs
+++ b/Brainarr.Plugin/Services/Core/RecommendationPipeline.cs
@@ -266,7 +266,11 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
                     Album = r.Album,
                     ArtistMusicBrainzId = string.IsNullOrWhiteSpace(r.ArtistMusicBrainzId) ? null : r.ArtistMusicBrainzId,
                     AlbumMusicBrainzId = string.IsNullOrWhiteSpace(r.AlbumMusicBrainzId) ? null : r.AlbumMusicBrainzId,
-                    ReleaseDate = r.Year.HasValue ? new DateTime(r.Year.Value, 1, 1) : DateTime.MinValue
+                    // Guard the year range: DateTime requires [1,9999], but Year comes from untrusted
+                    // LLM JSON and is not range-checked upstream. An out-of-range value (0, negative,
+                    // 50000, ...) previously threw ArgumentOutOfRangeException here, and the orchestrator's
+                    // broad catch then discarded the ENTIRE recommendation batch. Out-of-range -> MinValue.
+                    ReleaseDate = (r.Year is int y && y >= 1 && y <= 9999) ? new DateTime(y, 1, 1) : DateTime.MinValue
                 })
                 .ToList();
         }

--- a/Brainarr.Plugin/Services/Core/ReviewQueueActionHandler.cs
+++ b/Brainarr.Plugin/Services/Core/ReviewQueueActionHandler.cs
@@ -344,10 +344,14 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
             int applied = 0;
             foreach (var key in keys)
             {
-                var parts = (key ?? "").Split('|');
-                if (parts.Length >= 2)
+                // Split on the LAST '|' to match SafetyGateService's key contract: an artist that
+                // contains '|' (e.g. "AC|DC") encodes as "AC|DC|Album", so a first-pipe split
+                // misparsed artist/album and the approval silently never matched a pending entry.
+                var k = key ?? "";
+                var lastPipe = k.LastIndexOf('|');
+                if (lastPipe > 0)
                 {
-                    if (_reviewQueue.SetStatus(parts[0], parts[1], ReviewQueueService.ReviewStatus.Accepted))
+                    if (_reviewQueue.SetStatus(k.Substring(0, lastPipe), k.Substring(lastPipe + 1), ReviewQueueService.ReviewStatus.Accepted))
                     {
                         applied++;
                     }
@@ -722,19 +726,23 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
             int applied = 0;
             foreach (var key in keys)
             {
-                var parts = (key ?? "").Split('|');
-                if (parts.Length >= 2)
+                // Last-pipe split: see ApplyApprovalsNow — keeps artists containing '|' intact.
+                var k = key ?? "";
+                var lastPipe = k.LastIndexOf('|');
+                if (lastPipe > 0)
                 {
-                    if (_reviewQueue.SetStatus(parts[0], parts[1], status))
+                    var artist = k.Substring(0, lastPipe);
+                    var album = k.Substring(lastPipe + 1);
+                    if (_reviewQueue.SetStatus(artist, album, status))
                     {
                         applied++;
                         if (status == ReviewQueueService.ReviewStatus.Rejected)
                         {
-                            _history.MarkAsRejected(parts[0], parts[1], reason: "Batch reject");
+                            _history.MarkAsRejected(artist, album, reason: "Batch reject");
                         }
                         else if (status == ReviewQueueService.ReviewStatus.Never)
                         {
-                            _history.MarkAsDisliked(parts[0], parts[1], RecommendationHistory.DislikeLevel.NeverAgain);
+                            _history.MarkAsDisliked(artist, album, RecommendationHistory.DislikeLevel.NeverAgain);
                         }
                     }
                 }

--- a/Brainarr.Plugin/Services/Core/TopUpPlanner.cs
+++ b/Brainarr.Plugin/Services/Core/TopUpPlanner.cs
@@ -110,7 +110,9 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
                             Album = r.Album,
                             ArtistMusicBrainzId = string.IsNullOrWhiteSpace(r.ArtistMusicBrainzId) ? null : r.ArtistMusicBrainzId,
                             AlbumMusicBrainzId = string.IsNullOrWhiteSpace(r.AlbumMusicBrainzId) ? null : r.AlbumMusicBrainzId,
-                            ReleaseDate = r.Year.HasValue ? new DateTime(r.Year.Value, 1, 1) : DateTime.MinValue
+                            // Guard year range [1,9999]; untrusted LLM Year out of range previously threw
+                            // ArgumentOutOfRangeException, aborting the top-up batch.
+                            ReleaseDate = (r.Year is int y && y >= 1 && y <= 9999) ? new DateTime(y, 1, 1) : DateTime.MinValue
                         }));
 
                     var preHistory = importItems.Count;

--- a/Brainarr.Plugin/Services/Enrichment/MusicBrainzResolver.cs
+++ b/Brainarr.Plugin/Services/Enrichment/MusicBrainzResolver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -202,7 +203,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment
             var artistId = bestAc?.First?["artist"]?["id"]?.ToString();
             var firstReleaseDate = best.Value<string>("first-release-date");
             int? year = null;
-            if (DateTime.TryParse(firstReleaseDate, out var dt))
+            if (DateTime.TryParse(firstReleaseDate, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
             {
                 year = dt.Year;
             }

--- a/Brainarr.Plugin/Services/Providers/Parsing/RecommendationJsonParser.cs
+++ b/Brainarr.Plugin/Services/Providers/Parsing/RecommendationJsonParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
 using Brainarr.Plugin.Services.Security;
@@ -193,7 +194,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Providers.Parsing
         {
             if (!obj.TryGetProperty(prop, out var el)) return null;
             if (el.ValueKind == JsonValueKind.Number && el.TryGetInt32(out var i)) return i;
-            if (el.ValueKind == JsonValueKind.String && int.TryParse(el.GetString(), out var s)) return s;
+            if (el.ValueKind == JsonValueKind.String && int.TryParse(el.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var s)) return s;
             return null;
         }
 
@@ -201,7 +202,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Providers.Parsing
         {
             if (!obj.TryGetProperty(prop, out var el)) return null;
             if (el.ValueKind == JsonValueKind.Number && el.TryGetDouble(out var d)) return d;
-            if (el.ValueKind == JsonValueKind.String && double.TryParse(el.GetString(), out var s)) return s;
+            if (el.ValueKind == JsonValueKind.String && double.TryParse(el.GetString(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var s)) return s;
             return null;
         }
     }

--- a/Brainarr.Tests/EdgeCases/EnhancedConcurrencyTests.cs
+++ b/Brainarr.Tests/EdgeCases/EnhancedConcurrencyTests.cs
@@ -136,16 +136,19 @@ namespace Brainarr.Tests.EdgeCases
         public async Task RateLimiter_ConcurrentRequests_EnforcesLimits()
         {
             // Arrange — token bucket waits (never rejects), so use a fast rate
-            // to keep the test under a few seconds.
+            // to keep the test under a second. Kept small (5 burst + 3 wait) so the
+            // concurrent Task.Run fan-out does not starve the thread pool when this runs
+            // inside the full ~3k-test parallel suite — the previous 15-task / 10s form
+            // intermittently threw TaskCanceledException under that load.
             var rateLimiter = new RateLimiter(_logger);
-            var maxRequests = 10;
+            var maxRequests = 5;
             rateLimiter.Configure("test", maxRequests, TimeSpan.FromSeconds(1));
 
-            var totalRequests = 15; // 10 burst + 5 wait ≈ 0.5s
+            var totalRequests = 8; // 5 burst + 3 wait ≈ 0.6s at 5/sec
             var executionTimes = new ConcurrentBag<DateTime>();
 
-            // Act
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            // Act — generous timeout so thread-pool-starved tasks still get scheduled.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             var tasks = Enumerable.Range(0, totalRequests).Select(_ => Task.Run(async () =>
             {
                 await rateLimiter.ExecuteAsync("test", async (ct) =>

--- a/Brainarr.Tests/Services/Core/BrainarrOrchestratorReviewActionsTests.cs
+++ b/Brainarr.Tests/Services/Core/BrainarrOrchestratorReviewActionsTests.cs
@@ -113,6 +113,24 @@ namespace Brainarr.Tests.Services.Core
         }
 
         [Fact]
+        public void Review_Apply_KeyWithPipeInArtist_ReleasesItem()
+        {
+            // Regression (#11): ReviewApproveKeys "Artist|Album" were split on the FIRST '|',
+            // so an artist containing '|' (e.g. "AC|DC" → key "AC|DC|Highway To Hell") parsed
+            // as artist="AC", album="DC" and never matched the pending entry — silently dropping
+            // the approval. SafetyGateService splits on the LAST '|'; the orchestrator must match.
+            _queue.Enqueue(new[] { new Recommendation { Artist = "AC|DC", Album = "Highway To Hell" } });
+
+            var settings = new BrainarrSettings { ReviewApproveKeys = new[] { "AC|DC|Highway To Hell" } };
+            var apply = _orch.HandleAction("review/apply", new Dictionary<string, string>(), settings);
+            var applyJson = JsonSerializer.Serialize(apply);
+
+            applyJson.Should().Contain("\"ok\":true");
+            applyJson.Should().Contain("\"released\":1");
+            _queue.GetPending().Should().BeEmpty();
+        }
+
+        [Fact]
         public async Task Review_Reject_RecordsHistory_WhenSuggested()
         {
             // Ensure suggestion exists and wait minimal time to allow rejection record (test mode uses ~5ms)

--- a/Brainarr.Tests/Services/Core/RecommendationPipelineTests.cs
+++ b/Brainarr.Tests/Services/Core/RecommendationPipelineTests.cs
@@ -68,6 +68,51 @@ namespace Brainarr.Tests.Services.Core
         }
 
         [Fact]
+        public async Task ProcessAsync_OutOfRangeYear_DoesNotDiscardBatch()
+        {
+            // Regression (CRITICAL): an out-of-range LLM Year hit `new DateTime(Year,1,1)` and threw
+            // ArgumentOutOfRangeException; the broad orchestrator catch then discarded the ENTIRE
+            // recommendation batch. Out-of-range years must be tolerated (no throw), valid recs kept.
+            var (pipeline, dupFilter, validator, gates, topUp, mbids, artists, dedup, metrics, history, logger, tmp) = CreatePipeline();
+            try
+            {
+                var settings = new BrainarrSettings { MaxRecommendations = 5, RecommendationMode = RecommendationMode.SpecificAlbums };
+                var recs = new List<Recommendation>
+                {
+                    new Recommendation { Artist = "Good", Album = "Valid", Year = 1999 },
+                    new Recommendation { Artist = "Bad", Album = "GarbageYear", Year = 50000 }, // out of DateTime range
+                    new Recommendation { Artist = "AlsoBad", Album = "ZeroYear", Year = 0 }
+                };
+                validator.Setup(v => v.ValidateBatch(It.IsAny<List<Recommendation>>(), false))
+                    .Returns(new NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult
+                    {
+                        ValidRecommendations = recs,
+                        FilteredRecommendations = new List<Recommendation>(),
+                        TotalCount = recs.Count,
+                        ValidCount = recs.Count,
+                        FilteredCount = 0
+                    });
+                dedup.Setup(d => d.DeduplicateRecommendations(It.IsAny<List<ImportListItemInfo>>()))
+                    .Returns<List<ImportListItemInfo>>(lst => lst);
+
+                var items = await pipeline.ProcessAsync(
+                    settings,
+                    recs,
+                    new LibraryProfile(),
+                    new ReviewQueueService(logger, tmp),
+                    Mock.Of<IAIProvider>(p => p.ProviderName == "OpenAI"),
+                    Mock.Of<ILibraryAwarePromptBuilder>(),
+                    CancellationToken.None);
+
+                // Pre-fix this threw ArgumentOutOfRangeException and the whole batch was lost.
+                Assert.Equal(3, items.Count);
+                Assert.Contains(items, i => i.Artist == "Good");
+                Assert.Contains(items, i => i.Artist == "Bad");
+            }
+            finally { try { Directory.Delete(tmp, true); } catch { } }
+        }
+
+        [Fact]
         public async Task ProcessAsync_BaseDuplicates_UsesBothDedupAndLibraryFilters()
         {
             var (pipeline, dupFilter, validator, gates, topUp, mbids, artists, dedup, metrics, history, logger, tmp) = CreatePipeline();

--- a/Brainarr.Tests/Services/Providers/Parsing/RecommendationJsonParserInvariantTests.cs
+++ b/Brainarr.Tests/Services/Providers/Parsing/RecommendationJsonParserInvariantTests.cs
@@ -48,6 +48,33 @@ namespace Brainarr.Tests.Services.Providers.Parsing
                 !HasDoubleSpaces(r.Artist) && !HasDoubleSpaces(r.Album));
         }
 
+        [Theory]
+        [InlineData("de-DE")]
+        [InlineData("fr-FR")]
+        public void Parse_StringNumericFields_UseInvariantCulture_RegardlessOfAmbientCulture(string cultureName)
+        {
+            // Regression (#12): double.TryParse / int.TryParse without an explicit culture read the
+            // ambient decimal separator. Under de-DE/fr-FR (comma decimal), an LLM's string "0.95"
+            // parsed as 95.0 (period treated as a thousands separator), silently corrupting the
+            // confidence before the sanitizer clamped it to 1.0 — masking the real value.
+            var original = System.Globalization.CultureInfo.CurrentCulture;
+            try
+            {
+                System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo(cultureName);
+                var json = @"{ ""recommendations"": [ { ""artist"": ""A"", ""album"": ""B"", ""confidence"": ""0.95"", ""year"": ""1999"" } ] }";
+
+                var parsed = RecommendationJsonParser.Parse(json, _logger);
+
+                parsed.Should().ContainSingle();
+                parsed[0].Confidence.Should().BeApproximately(0.95, 0.0001);
+                parsed[0].Year.Should().Be(1999);
+            }
+            finally
+            {
+                System.Globalization.CultureInfo.CurrentCulture = original;
+            }
+        }
+
         private static bool NoHtml(string? s)
             => string.IsNullOrEmpty(s) || (!s.Contains("<") && !s.Contains(">"));
 


### PR DESCRIPTION
## Summary

Adversarial defect-hunt pass over the recommendation pipeline. Four findings + one flaky-test fix. All inputs treated here originate from an **untrusted LLM response**, so the theme is "don't let a malformed model reply corrupt or drop a whole batch."

## Findings

### 🔴 CRITICAL — out-of-range `Year` discarded the entire batch
An LLM-supplied `Year` fed straight into `new DateTime(Year, 1, 1)`. Any value outside `[1,9999]` (e.g. `0`, `50000`) threw `ArgumentOutOfRangeException`, which the orchestrator's broad `catch` swallowed — **silently discarding every recommendation in the batch**, not just the bad one. Guarded all three sinks (`RecommendationPipeline`, `RecommendationGenerator`, `TopUpPlanner`) to collapse out-of-range years to `DateTime.MinValue` ("no release date").

### 🟠 #11 — review-approval key contract drift (artists containing `|`)
`ReviewApproveKeys` of the form `Artist|Album` were split on the **first** `|`. An artist containing `|` (e.g. `AC|DC` → key `AC|DC|Highway`) parsed as artist=`AC`, album=`DC` and never matched the pending entry — the approval was **silently dropped**. `SafetyGateService` already splits on the **last** `|`; aligned the three drifted sites (`BrainarrOrchestrator.ApplyPendingReviewApprovals` + both `ReviewQueueActionHandler` sites) to the same last-pipe contract.

### 🟡 #12 — culture-sensitive numeric parsing
`int`/`double.TryParse` on string-valued JSON fields read the ambient decimal separator. Under comma-decimal cultures (de-DE/fr-FR) an LLM's `"0.95"` parsed as `95.0` (period treated as a thousands separator), silently corrupting confidence. Pinned to `InvariantCulture`.

### 🟡 #14 — culture-sensitive MusicBrainz date parsing
`MusicBrainzResolver` parsed `first-release-date` with ambient culture; pinned to `InvariantCulture` (MusicBrainz dates are always ISO-8601).

### 🧪 Flaky test — `RateLimiter_ConcurrentRequests_EnforcesLimits`
15-task / 10s form threw `TaskCanceledException` under full-suite thread-pool starvation (passes 3/3 in isolation). Shrunk to 5-burst+3-wait with a 60s timeout — mirrors the documented `RateLimiter_WithThreadPoolExhaustion` fix. Throttling assertion preserved.

## Tests
New regression coverage:
- `ProcessAsync_OutOfRangeYear_DoesNotDiscardBatch` — Year=50000/0 no longer drops the batch
- `Review_Apply_KeyWithPipeInArtist_ReleasesItem` — `AC|DC|Album` key now releases the item
- `Parse_StringNumericFields_UseInvariantCulture_RegardlessOfAmbientCulture` (de-DE, fr-FR)

**Full suite: 3036 passed, 9 skipped, 0 failed.**