### PR TITLE
fix: invariant casing in genre-overview matching (Turkish-I locale bug)

### DIFF
--- a/Brainarr.Plugin/Services/Core/LibraryAnalyzer.cs
+++ b/Brainarr.Plugin/Services/Core/LibraryAnalyzer.cs
@@ -185,12 +185,16 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
 
             foreach (var artist in artists.Where(a => a.Metadata?.Value?.Overview != null))
             {
-                var overview = artist.Metadata.Value.Overview.ToLower();
+                // Invariant casing: the genre keywords are ASCII. Under the Turkish locale a
+                // culture-sensitive ToLower() maps 'I' -> 'ı' (dotless), so an overview containing
+                // "Indie"/"Britpop" etc. would no longer match the ASCII keyword; likewise
+                // char.ToUpper('i') -> 'İ' would corrupt the title-cased result.
+                var overview = artist.Metadata.Value.Overview.ToLowerInvariant();
                 foreach (var genre in commonGenres)
                 {
                     if (overview.Contains(genre))
                     {
-                        extractedGenres.Add(char.ToUpper(genre[0]) + genre.Substring(1));
+                        extractedGenres.Add(char.ToUpperInvariant(genre[0]) + genre.Substring(1));
                     }
                 }
             }

--- a/Brainarr.Tests/Characterization/LibraryAnalyzerCharacterizationTests.cs
+++ b/Brainarr.Tests/Characterization/LibraryAnalyzerCharacterizationTests.cs
@@ -72,6 +72,43 @@ namespace Brainarr.Tests.Characterization
         }
 
         [Fact]
+        [Trait("Area", "LibraryAnalyzer")]
+        public void ExtractGenresFromOverviews_TurkishCulture_StillMatchesAsciiGenreKeywords()
+        {
+            // Regression (harden campaign): the overview was lowercased with the AMBIENT culture.
+            // Under tr-TR, 'I' -> 'ı' (dotless), so an overview containing "Indie" no longer matched
+            // the ASCII "indie" keyword (and char.ToUpper('i') -> 'İ' corrupted the title-cased
+            // result). Invariant casing keeps ASCII keyword matching stable across locales.
+            var original = System.Globalization.CultureInfo.CurrentCulture;
+            try
+            {
+                System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("tr-TR");
+
+                var artist = new Artist
+                {
+                    Id = 1,
+                    Name = "A",
+                    Monitored = true,
+                    Added = DateTime.UtcNow.AddMonths(-12),
+                    Metadata = new LazyLoaded<ArtistMetadata>(new ArtistMetadata { Name = "A", Overview = "A pioneering Indie rock act." })
+                };
+                var analyzer = CreateAnalyzer(new List<Artist> { artist }, new List<Album>());
+
+                var method = typeof(LibraryAnalyzer).GetMethod("ExtractGenresFromOverviews",
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                method.Should().NotBeNull();
+                var genres = (List<string>)method!.Invoke(analyzer, new object[] { new List<Artist> { artist }, new List<Album>() })!;
+
+                genres.Should().Contain("Indie"); // pre-fix under tr-TR this match was lost
+                genres.Should().Contain("Rock");
+            }
+            finally
+            {
+                System.Globalization.CultureInfo.CurrentCulture = original;
+            }
+        }
+
+        [Fact]
         public void Profile_StyleContext_PopulatedWithArtistAndAlbumStyles()
         {
             // Arrange: artists and albums with genre data for style resolution


### PR DESCRIPTION
Harden-campaign MED/LOW (re-verified). `ExtractGenresFromOverviews` lowercased the overview with the ambient culture (and title-cased via `char.ToUpper`). Under tr-TR, 'I'→'ı' / 'i'→'İ', so overviews containing "Indie" etc. no longer matched the ASCII genre keywords. Switched to `ToLowerInvariant`/`ToUpperInvariant`. Test: tr-TR reflection test asserting "Indie"+"Rock" still extracted. Local: 14 LibraryAnalyzer tests green.