### PR TITLE
fix(timeout): sync Fetch() bridge honors configured provider timeout (was hard-capped at 120s)

### DIFF
--- a/Brainarr.Plugin/Services/Core/BrainarrOrchestrator.cs
+++ b/Brainarr.Plugin/Services/Core/BrainarrOrchestrator.cs
@@ -324,8 +324,34 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
 
         public IList<ImportListItemInfo> FetchRecommendations(BrainarrSettings settings)
         {
-            // Synchronous wrapper for backward compatibility (avoid direct GetAwaiter().GetResult())
-            return NzbDrone.Core.ImportLists.Brainarr.Utils.SafeAsyncHelper.RunSafeSync(() => FetchRecommendationsAsync(settings));
+            // Synchronous wrapper for backward compatibility (avoid direct GetAwaiter().GetResult()).
+            // The bridge timeout is derived from the configured per-request budget so it never
+            // aborts a slow-but-valid run before the provider's own timeout elapses.
+            return NzbDrone.Core.ImportLists.Brainarr.Utils.SafeAsyncHelper.RunSafeSync(
+                () => FetchRecommendationsAsync(settings),
+                ResolveSyncFetchTimeoutMs(settings));
+        }
+
+        /// <summary>
+        /// Resolves the timeout for the synchronous Fetch() bridge. A local provider's effective
+        /// per-request budget can reach LocalProviderDefaultTimeout (360s) even when
+        /// AIRequestTimeoutSeconds is left at its 30s default, and a user may raise it up to
+        /// MaxAITimeout (600s). The orchestration also issues follow-up (top-up) calls and
+        /// MusicBrainz enrichment on top of the initial request. The backstop is therefore sized
+        /// off the largest single-call budget, doubled to cover a top-up follow-up, plus a flat
+        /// enrichment headroom — so it only ever fires on a genuine hang, never on a slow-but-valid
+        /// run — and is floored at the legacy default so it can never shrink below it.
+        /// </summary>
+        internal static int ResolveSyncFetchTimeoutMs(BrainarrSettings settings)
+        {
+            var perRequestSeconds = Math.Max(
+                settings?.AIRequestTimeoutSeconds ?? BrainarrConstants.DefaultAITimeout,
+                BrainarrConstants.LocalProviderDefaultTimeout);
+
+            const int orchestrationHeadroomSeconds = 120; // top-up + MusicBrainz enrichment
+            var backstopMs = ((perRequestSeconds * 2) + orchestrationHeadroomSeconds) * 1000;
+
+            return Math.Max(BrainarrConstants.DefaultAsyncTimeoutMs, backstopMs);
         }
 
         // ====== PROVIDER MANAGEMENT ======

--- a/Brainarr.Tests/Services/Core/BrainarrOrchestratorSyncTimeoutTests.cs
+++ b/Brainarr.Tests/Services/Core/BrainarrOrchestratorSyncTimeoutTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using NzbDrone.Core.ImportLists.Brainarr;
+using NzbDrone.Core.ImportLists.Brainarr.Configuration;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Core;
+using Xunit;
+
+namespace Brainarr.Tests.Services.Core
+{
+    /// <summary>
+    /// The synchronous Fetch() entry point bridges to async via SafeAsyncHelper.RunSafeSync.
+    /// Its timeout must never be shorter than the inner per-request budget, otherwise a
+    /// slow-but-valid run (e.g. a local LLM legitimately using the 360s LocalProviderDefaultTimeout)
+    /// is aborted by the bridge before the provider's own timeout elapses.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class BrainarrOrchestratorSyncTimeoutTests
+    {
+        [Fact]
+        public void Resolves_at_least_the_local_provider_budget_for_default_settings()
+        {
+            // Default AIRequestTimeoutSeconds (30s) is auto-bumped to LocalProviderDefaultTimeout
+            // (360s) for local providers inside the pipeline; the sync bridge must outlast that.
+            var settings = new BrainarrSettings { AIRequestTimeoutSeconds = BrainarrConstants.DefaultAITimeout };
+
+            var timeoutMs = BrainarrOrchestrator.ResolveSyncFetchTimeoutMs(settings);
+
+            timeoutMs.Should().BeGreaterThanOrEqualTo(BrainarrConstants.LocalProviderDefaultTimeout * 1000);
+            timeoutMs.Should().BeGreaterThan(BrainarrConstants.DefaultAsyncTimeoutMs,
+                "the old fixed 120s cap aborted valid local-provider runs");
+        }
+
+        [Fact]
+        public void Resolves_at_least_a_raised_request_timeout()
+        {
+            var settings = new BrainarrSettings { AIRequestTimeoutSeconds = BrainarrConstants.MaxAITimeout };
+
+            var timeoutMs = BrainarrOrchestrator.ResolveSyncFetchTimeoutMs(settings);
+
+            timeoutMs.Should().BeGreaterThanOrEqualTo(BrainarrConstants.MaxAITimeout * 1000);
+        }
+
+        [Fact]
+        public void Never_drops_below_the_legacy_default_floor()
+        {
+            var settings = new BrainarrSettings { AIRequestTimeoutSeconds = BrainarrConstants.MinAITimeout };
+
+            var timeoutMs = BrainarrOrchestrator.ResolveSyncFetchTimeoutMs(settings);
+
+            timeoutMs.Should().BeGreaterThanOrEqualTo(BrainarrConstants.DefaultAsyncTimeoutMs);
+        }
+
+        [Fact]
+        public void Handles_null_settings_without_throwing()
+        {
+            var timeoutMs = BrainarrOrchestrator.ResolveSyncFetchTimeoutMs(null);
+
+            timeoutMs.Should().BeGreaterThanOrEqualTo(BrainarrConstants.LocalProviderDefaultTimeout * 1000);
+        }
+    }
+}


### PR DESCRIPTION
## Problem
`BrainarrOrchestrator.FetchRecommendations` — the Lidarr **sync** import-list entry point — bridged to async via `SafeAsyncHelper.RunSafeSync(...)` with the **default 120s cap** (`DefaultAsyncTimeoutMs`). But the inner per-request budget is much larger:
- local providers auto-bump to `LocalProviderDefaultTimeout` = **360s**,
- a user may raise `AIRequestTimeoutSeconds` up to `MaxAITimeout` = **600s**,
- and the orchestration issues top-up follow-up calls + MusicBrainz enrichment on top.

So a slow-but-valid run (e.g. a local LLM legitimately using its 360s budget) was aborted by the bridge with a `TimeoutException` before the provider's own timeout elapsed — discarding all work.

## Fix
`ResolveSyncFetchTimeoutMs(settings)` derives the bridge backstop from the largest single-call budget — `max(AIRequestTimeoutSeconds, LocalProviderDefaultTimeout)` — doubled to cover a top-up follow-up call, plus a flat enrichment headroom, floored at the legacy 120s default. It can only fire on a genuine hang, never on a valid run, and scales with the user's configured timeout (no hardcoded ceiling that goes stale).

## Tests (TDD — RED first)
`BrainarrOrchestratorSyncTimeoutTests` asserts the bridge timeout is never shorter than the inner budget for default / raised-to-max / min / null settings. Verified RED against the old fixed value, then GREEN. 148 orchestrator + SafeAsync tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)