### PR TITLE
feat(sampling): capacity-aware prompt budget + style-discovery dedup audit (#47)

### DIFF
--- a/Brainarr.Plugin/Services/Prompting/LibraryPromptRenderer.cs
+++ b/Brainarr.Plugin/Services/Prompting/LibraryPromptRenderer.cs
@@ -124,7 +124,13 @@ public class LibraryPromptRenderer : IPromptRenderer
         }
 
         var artistLines = BuildArtistGroups(plan);
-        builder.AppendLine(Heading($"\U0001f3b6 LIBRARY ARTISTS & KEY ALBUMS ({artistLines.Count} groups shown):", $"LIBRARY ARTISTS & KEY ALBUMS ({artistLines.Count} groups shown):"));
+        // Genre-first discovery: the section below is purely a dedup list (the recommendations come
+        // from the seed styles, not the library), so make the "avoid duplicates" intent explicit in
+        // the header. Keep the stable "LIBRARY ARTISTS & KEY ALBUMS" substring for determinism tests.
+        var librarySectionLabel = styleSeeded
+            ? $"LIBRARY ARTISTS & KEY ALBUMS — EXISTING LIBRARY (avoid these duplicates) ({artistLines.Count} groups shown):"
+            : $"LIBRARY ARTISTS & KEY ALBUMS ({artistLines.Count} groups shown):";
+        builder.AppendLine(Heading($"\U0001f3b6 {librarySectionLabel}", librarySectionLabel));
         foreach (var line in artistLines)
         {
             builder.AppendLine(line);

--- a/Brainarr.Plugin/Services/Prompting/Policies/DefaultContextPolicy.cs
+++ b/Brainarr.Plugin/Services/Prompting/Policies/DefaultContextPolicy.cs
@@ -16,7 +16,7 @@ public sealed class DefaultContextPolicy : IContextPolicy
             return Math.Min(60, Math.Max(30, totalArtists / 2));
         }
 
-        return Math.Min(90, Math.Max(32, tokenBudget / 260));
+        return Math.Min(250, Math.Max(32, tokenBudget / 260));
     }
 
     public int DetermineTargetAlbumCount(int totalAlbums, int tokenBudget)
@@ -31,6 +31,6 @@ public sealed class DefaultContextPolicy : IContextPolicy
             return Math.Min(160, Math.Max(60, totalAlbums / 2));
         }
 
-        return Math.Min(220, Math.Max(70, tokenBudget / 120));
+        return Math.Min(600, Math.Max(70, tokenBudget / 120));
     }
 }

--- a/Brainarr.Plugin/Services/Prompting/Services/DefaultSamplingService.cs
+++ b/Brainarr.Plugin/Services/Prompting/Services/DefaultSamplingService.cs
@@ -200,7 +200,106 @@ public sealed class DefaultSamplingService : ISamplingService
             }
         }
 
+        // Style-seeded ("genre-first") dedup fallback: the user selected styles their library has
+        // ZERO coverage of, so the strict+relaxed match lists came back empty and the prompt would
+        // print "0 groups" — the model gets no "avoid these duplicates" signal. Surface the closest
+        // library artists (adjacent styles, then the library's dominant artists, then any artist) as a
+        // pure dedup audit. These carry NO matched styles and score 0 so they are NEVER registered as
+        // seed-style matches: the genre-first decision gate (sum of selected-style coverage == 0,
+        // computed identically by the renderer and RecommendationPipeline) is preserved.
+        //
+        // GATE on the genre-first condition (zero selected-style coverage) — NOT merely on an empty
+        // match list. A library-aligned selection whose styles DO have coverage can still yield zero
+        // matches (e.g. a below-threshold relaxed match, or artists missing style tags); that is a
+        // sparse library-aligned case, not genre-first, and must keep its empty list (the prompt stays
+        // grounded in collaborators). Only the true zero-coverage case gets the dedup audit.
+        if (IsStyleSeededZeroCoverage(selection) && matches.Count == 0 && artists.Count > 0)
+        {
+            var fallbackArtists = SelectDedupFallbackArtists(artists, context, selection);
+            foreach (var artist in fallbackArtists)
+            {
+                matches.Add(new ArtistMatch(artist, new HashSet<string>(StringComparer.OrdinalIgnoreCase), 0.0));
+            }
+
+            if (matches.Count > 0)
+            {
+                _logger.Debug(
+                    "Style-seeded dedup fallback engaged for artists: zero seed-style coverage, surfaced {Count} library artists as a dedup audit (selected=[{Selected}])",
+                    matches.Count,
+                    string.Join(", ", selection.SelectedSlugs));
+            }
+        }
+
         return matches;
+    }
+
+    private List<Artist> SelectDedupFallbackArtists(
+        IReadOnlyList<Artist> artists,
+        LibraryStyleContext context,
+        StylePlanContext selection)
+    {
+        var lookup = artists.ToDictionary(a => a.Id);
+
+        // 1) Adjacent styles: the library lacks the seed styles, but it may have a sibling/parent the
+        //    catalog considers similar. Those artists are the most relevant dedup candidates.
+        var adjacentSlugs = CollectAdjacentSlugs(selection);
+        if (adjacentSlugs.Count > 0 && context.StyleIndex != null)
+        {
+            var ids = context.StyleIndex.GetArtistsForStyles(adjacentSlugs);
+            var resolved = ResolveArtists(ids, lookup);
+            if (resolved.Count > 0)
+            {
+                return resolved;
+            }
+        }
+
+        // 2) The library's dominant styles (its actual character) — still useful as a dedup list even
+        //    when unrelated to the seed styles.
+        if (context.DominantStyles.Count > 0 && context.StyleIndex != null)
+        {
+            var ids = context.StyleIndex.GetArtistsForStyles(context.DominantStyles);
+            var resolved = ResolveArtists(ids, lookup);
+            if (resolved.Count > 0)
+            {
+                return resolved;
+            }
+        }
+
+        // 3) Last resort: the whole library is the dedup pool (SampleArtists caps it to the target).
+        return artists.ToList();
+    }
+
+    private List<string> CollectAdjacentSlugs(StylePlanContext selection)
+    {
+        var adjacent = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var seed in selection.SelectedSlugs)
+        {
+            foreach (var similar in _styleCatalog.GetSimilarSlugs(seed))
+            {
+                if (string.IsNullOrWhiteSpace(similar.Slug) || selection.SelectedSlugs.Contains(similar.Slug))
+                {
+                    continue;
+                }
+
+                adjacent.Add(similar.Slug);
+            }
+        }
+
+        return adjacent.ToList();
+    }
+
+    private static List<Artist> ResolveArtists(IReadOnlyList<int> ids, Dictionary<int, Artist> lookup)
+    {
+        var resolved = new List<Artist>(ids.Count);
+        foreach (var id in ids)
+        {
+            if (lookup.TryGetValue(id, out var artist))
+            {
+                resolved.Add(artist);
+            }
+        }
+
+        return resolved;
     }
 
     private List<AlbumMatch> BuildAlbumMatchList(
@@ -312,7 +411,91 @@ public sealed class DefaultSamplingService : ISamplingService
             }
         }
 
+        // Style-seeded dedup fallback (album side) — mirrors the artist fallback above. See its comment
+        // for the genre-first-gate-preservation rationale. Score 0, no matched styles → dedup audit only.
+        if (IsStyleSeededZeroCoverage(selection) && matches.Count == 0 && albums.Count > 0)
+        {
+            var fallbackAlbums = SelectDedupFallbackAlbums(albums, context, selection);
+            foreach (var album in fallbackAlbums)
+            {
+                matches.Add(new AlbumMatch(album, new HashSet<string>(StringComparer.OrdinalIgnoreCase), 0.0));
+            }
+
+            if (matches.Count > 0)
+            {
+                _logger.Debug(
+                    "Style-seeded dedup fallback engaged for albums: zero seed-style coverage, surfaced {Count} library albums as a dedup audit (selected=[{Selected}])",
+                    matches.Count,
+                    string.Join(", ", selection.SelectedSlugs));
+            }
+        }
+
         return matches;
+    }
+
+    private List<Album> SelectDedupFallbackAlbums(
+        IReadOnlyList<Album> albums,
+        LibraryStyleContext context,
+        StylePlanContext selection)
+    {
+        var lookup = albums.ToDictionary(a => a.Id);
+
+        var adjacentSlugs = CollectAdjacentSlugs(selection);
+        if (adjacentSlugs.Count > 0 && context.StyleIndex != null)
+        {
+            var ids = context.StyleIndex.GetAlbumsForStyles(adjacentSlugs);
+            var resolved = ResolveAlbums(ids, lookup);
+            if (resolved.Count > 0)
+            {
+                return resolved;
+            }
+        }
+
+        if (context.DominantStyles.Count > 0 && context.StyleIndex != null)
+        {
+            var ids = context.StyleIndex.GetAlbumsForStyles(context.DominantStyles);
+            var resolved = ResolveAlbums(ids, lookup);
+            if (resolved.Count > 0)
+            {
+                return resolved;
+            }
+        }
+
+        return albums.ToList();
+    }
+
+    private static List<Album> ResolveAlbums(IReadOnlyList<int> ids, Dictionary<int, Album> lookup)
+    {
+        var resolved = new List<Album>(ids.Count);
+        foreach (var id in ids)
+        {
+            if (lookup.TryGetValue(id, out var album))
+            {
+                resolved.Add(album);
+            }
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// Genre-first ("style-seeded") detector — TRUE when the user selected styles whose summed library
+    /// coverage is zero. This is the SAME signal <c>LibraryPromptRenderer</c> and
+    /// <c>RecommendationPipeline.IsStyleSeededDiscovery</c> compute (sum of
+    /// <c>StyleContext.Coverage[selectedSlug]</c> == 0); gating the dedup fallback on it keeps the
+    /// sampler, the prompt, and the post-filter in lockstep and prevents the fallback from firing on a
+    /// merely-sparse library-aligned selection.
+    /// </summary>
+    private static bool IsStyleSeededZeroCoverage(StylePlanContext selection)
+    {
+        if (selection == null || !selection.HasStyles)
+        {
+            return false;
+        }
+
+        var selectedCoverage = selection.SelectedSlugs.Sum(slug =>
+            selection.Coverage.TryGetValue(slug, out var c) ? c : 0);
+        return selectedCoverage == 0;
     }
 
     private bool TryMatchStyles(HashSet<string> itemSlugs, StylePlanContext selection, out HashSet<string> matched, out double score)

--- a/Brainarr.Plugin/Services/TokenBudgetResolver.cs
+++ b/Brainarr.Plugin/Services/TokenBudgetResolver.cs
@@ -25,6 +25,12 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
         internal const double ComprehensiveRatio = 1.00;
         internal const int MinimalPromptFloor = 1500;
 
+        // Top bound on the prompt budget for metered cloud providers. The prompt already
+        // scales with the model's context window via the completion/headroom reserves
+        // (see ResolvePromptBudget lines computing completionReserve/headroomTokens); this
+        // ceiling just bounds the top to control cost on metered providers (user-approved ~96K).
+        internal const int CloudPromptCeiling = 96000;
+
         internal static readonly Dictionary<AIProvider, int> DefaultContextTokens = new()
         {
             [AIProvider.Ollama] = 32768,
@@ -36,6 +42,10 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
             [AIProvider.DeepSeek] = 48000,
             [AIProvider.Gemini] = 32000,
             [AIProvider.Groq] = 32000,
+            // 128K — conservative provider default safe for all GLM models; per-model
+            // precision (e.g. GLM-5.1's 200K) comes from the model registry when present.
+            [AIProvider.ZaiGlm] = 131072,
+            [AIProvider.ZaiCoding] = 131072,
         };
 
         public TokenBudgetResolver(Logger logger, ModelContextResolver modelContextResolver, ITokenBudgetPolicy tokenBudgetPolicy)
@@ -116,7 +126,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
             return provider switch
             {
                 AIProvider.Ollama or AIProvider.LMStudio => int.MaxValue,
-                _ => 20000
+                _ => CloudPromptCeiling
             };
         }
 

--- a/Brainarr.Tests/Services/Core/StyleSeededDiscoveryTests.cs
+++ b/Brainarr.Tests/Services/Core/StyleSeededDiscoveryTests.cs
@@ -93,6 +93,79 @@ namespace Brainarr.Tests.Services.Core
             RecommendationPipeline.IsStyleSeededDiscovery(null, settings, ProfileWithCoverage(("rock", 10))).Should().BeFalse();
         }
 
+        // ---- Improvement B invariant guard ----------------------------------------------------
+        // Enriching the dedup sample (improvement B) must NOT alter the genre-first DECISION gate.
+        // This exercises BOTH layers with the SAME catalog + slug-keyed coverage signal:
+        //   1. DefaultSamplingService now produces a NON-EMPTY dedup audit for the zero-coverage case.
+        //   2. RecommendationPipeline.IsStyleSeededDiscovery STILL returns true (gate preserved).
+
+        [Fact]
+        public void StyleSeeded_DedupFallback_PopulatesSample_AndLeavesGateTrue()
+        {
+            // "lo-fi" → lofi-hip-hop; the library has only the adjacent "hip-hop". Genre-first gate fires.
+            var catalog = Catalog();
+            var settings = new BrainarrSettings { StyleFilters = new[] { "lo-fi" }, MaxSelectedStyles = 10 };
+
+            // Slug-keyed coverage with ZERO lofi-hip-hop → the exact renderer/pipeline signal.
+            var styleContext = new LibraryStyleContext();
+            styleContext.SetCoverage(new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["hip-hop"] = 3
+            });
+            styleContext.SetDominantStyles(new[] { "hip-hop" });
+            styleContext.ArtistStyles[1] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.ArtistStyles[2] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.ArtistStyles[3] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.SetStyleIndex(new LibraryStyleIndex(
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["hip-hop"] = new List<int> { 1, 2, 3 }
+                },
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)));
+
+            var profile = new LibraryProfile { StyleContext = styleContext };
+
+            // Gate BEFORE sampling: genre-first.
+            RecommendationPipeline.IsStyleSeededDiscovery(catalog, settings, profile).Should().BeTrue(
+                "precondition: zero exact coverage of the seed style is genre-first discovery");
+
+            // Build the real style selection (resolves "lo-fi" → lofi-hip-hop) and sample.
+            var selectionService = new DefaultStyleSelectionService(Logger, catalog);
+            var selection = selectionService.Build(profile, settings, styleContext,
+                new DefaultCompressionPolicy(), CancellationToken.None);
+
+            var samplingService = new DefaultSamplingService(Logger, catalog, new DefaultContextPolicy());
+            var artists = Enumerable.Range(1, 3)
+                .Select(id =>
+                {
+                    var a = new NzbDrone.Core.Music.Artist { Id = id, Added = DateTime.UtcNow.AddDays(-id) };
+                    a.Metadata.Value.Name = $"Hip Hop Artist {id}";
+                    return a;
+                })
+                .ToList();
+
+            var sample = samplingService.Sample(
+                artists,
+                Array.Empty<NzbDrone.Core.Music.Album>(),
+                styleContext,
+                selection,
+                settings,
+                tokenBudget: 8000,
+                seed: 7,
+                CancellationToken.None);
+
+            // Improvement B: the dedup audit is now populated (was empty → "0 groups").
+            sample.ArtistCount.Should().BeGreaterThan(0,
+                "the genre-first dedup audit must surface adjacent-style library artists");
+
+            // CRITICAL: the gate is UNCHANGED after enrichment — same catalog, same coverage signal.
+            RecommendationPipeline.IsStyleSeededDiscovery(catalog, settings, profile).Should().BeTrue(
+                "enriching the dedup sample must NOT change the genre-first decision gate");
+            // The selection's slug-keyed coverage the renderer sums must still be 0 for the seed slug.
+            selection.SelectedSlugs.Sum(s => selection.Coverage.TryGetValue(s, out var c) ? c : 0)
+                .Should().Be(0, "renderer's styleSeeded signal must remain selectedCoverage==0");
+        }
+
         // ---- B2: freestyle passthrough --------------------------------------------------------
 
         [Fact]

--- a/Brainarr.Tests/Services/LibraryAwarePromptBuilderSimpleTests.cs
+++ b/Brainarr.Tests/Services/LibraryAwarePromptBuilderSimpleTests.cs
@@ -17,12 +17,14 @@ namespace Brainarr.Tests.Services
             var logger = Helpers.TestLogger.CreateNullLogger();
             var b = new LibraryAwarePromptBuilder(logger);
 
-            var balancedCloud = b.GetEffectiveTokenLimit(SamplingStrategy.Balanced, AIProvider.OpenAI);
-            var balancedOllama = b.GetEffectiveTokenLimit(SamplingStrategy.Balanced, AIProvider.Ollama);
+            var balancedSmallCtxCloud = b.GetEffectiveTokenLimit(SamplingStrategy.Balanced, AIProvider.Gemini); // 32K default
+            var balancedLargeCtxCloud = b.GetEffectiveTokenLimit(SamplingStrategy.Balanced, AIProvider.OpenAI); // 64K default
             var minimalCloud = b.GetEffectiveTokenLimit(SamplingStrategy.Minimal, AIProvider.OpenAI);
             var compCloud = b.GetEffectiveTokenLimit(SamplingStrategy.Comprehensive, AIProvider.OpenAI);
 
-            Assert.True(balancedOllama > balancedCloud);
+            // Provider context-window awareness: larger context window -> larger budget at the same strategy.
+            Assert.True(balancedLargeCtxCloud > balancedSmallCtxCloud);
+            // Strategy ordering on the same provider.
             Assert.True(compCloud > minimalCloud);
         }
 

--- a/Brainarr.Tests/Services/LibraryAwarePromptBuilderTests.cs
+++ b/Brainarr.Tests/Services/LibraryAwarePromptBuilderTests.cs
@@ -96,11 +96,17 @@ namespace Brainarr.Tests.Services
         {
             var b = new LibraryAwarePromptBuilder(Logger);
             var minOllama = b.GetEffectiveTokenLimit(SamplingStrategy.Minimal, AIProvider.Ollama);
-            var balCloud = b.GetEffectiveTokenLimit(SamplingStrategy.Balanced, AIProvider.OpenAI);
-            var compLocal = b.GetEffectiveTokenLimit(SamplingStrategy.Comprehensive, AIProvider.LMStudio);
+            var compOllama = b.GetEffectiveTokenLimit(SamplingStrategy.Comprehensive, AIProvider.Ollama);
+            // Smaller- vs larger-context cloud providers at the same strategy: the effective
+            // limit must scale with the model's context window (capacity-aware budget).
+            var balSmallCtxCloud = b.GetEffectiveTokenLimit(SamplingStrategy.Balanced, AIProvider.Gemini); // 32K default
+            var balLargeCtxCloud = b.GetEffectiveTokenLimit(SamplingStrategy.Balanced, AIProvider.OpenAI); // 64K default
 
             Assert.True(minOllama > 0);
-            Assert.True(compLocal > balCloud); // comprehensive(local) should exceed balanced(cloud)
+            // Strategy ordering on the same provider: comprehensive yields a larger budget than minimal.
+            Assert.True(compOllama > minOllama, $"comprehensive ({compOllama}) should exceed minimal ({minOllama}) on the same provider");
+            // Context-window awareness: a larger-context cloud model gets a larger budget at the same strategy.
+            Assert.True(balLargeCtxCloud > balSmallCtxCloud, $"larger-context cloud ({balLargeCtxCloud}) should exceed smaller-context cloud ({balSmallCtxCloud})");
         }
 
         [Fact]

--- a/Brainarr.Tests/Services/Prompting/DefaultContextPolicyTests.cs
+++ b/Brainarr.Tests/Services/Prompting/DefaultContextPolicyTests.cs
@@ -1,0 +1,61 @@
+using NzbDrone.Core.ImportLists.Brainarr.Services.Prompting.Policies;
+using Xunit;
+
+namespace Brainarr.Tests.Services.Prompting
+{
+    /// <summary>
+    /// Capacity-aware context-depth tests. The per-budget target artist/album counts must
+    /// scale deeper for frontier (large) token budgets while remaining unchanged for small
+    /// budgets. Only the upper clamp rises (artist 90 -> 250, album 220 -> 600); the
+    /// tokenBudget/260 and tokenBudget/120 scaling is preserved.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Category", "PromptBuilder")]
+    public class DefaultContextPolicyTests
+    {
+        private static readonly DefaultContextPolicy Policy = new();
+
+        // Large library so the tokenBudget-scaled branch (totalArtists > 200 / totalAlbums > 400) is taken.
+        private const int LargeArtists = 5000;
+        private const int LargeAlbums = 20000;
+
+        [Fact]
+        public void LargeBudget_AllowsDeeperArtistContext()
+        {
+            // tokenBudget/260 == 461 at 120000. Old cap clamped to 90; new cap allows up to 250.
+            var count = Policy.DetermineTargetArtistCount(LargeArtists, tokenBudget: 120000);
+
+            Assert.True(count > 90, $"Expected large-budget artist count > old cap 90, got {count}");
+            Assert.Equal(250, count);
+        }
+
+        [Fact]
+        public void LargeBudget_AllowsDeeperAlbumContext()
+        {
+            // tokenBudget/120 == 1000 at 120000. Old cap clamped to 220; new cap allows up to 600.
+            var count = Policy.DetermineTargetAlbumCount(LargeAlbums, tokenBudget: 120000);
+
+            Assert.True(count > 220, $"Expected large-budget album count > old cap 220, got {count}");
+            Assert.Equal(600, count);
+        }
+
+        [Fact]
+        public void SmallBudget_ArtistCountUnchanged()
+        {
+            // tokenBudget/260 == 15 at 4000 -> Max(32, 15) == 32. Below both old and new caps,
+            // so raising the ceiling must not change small-budget behavior.
+            var count = Policy.DetermineTargetArtistCount(LargeArtists, tokenBudget: 4000);
+
+            Assert.Equal(32, count);
+        }
+
+        [Fact]
+        public void SmallBudget_AlbumCountUnchanged()
+        {
+            // tokenBudget/120 == 33 at 4000 -> Max(70, 33) == 70. Below both old and new caps.
+            var count = Policy.DetermineTargetAlbumCount(LargeAlbums, tokenBudget: 4000);
+
+            Assert.Equal(70, count);
+        }
+    }
+}

--- a/Brainarr.Tests/Services/Prompting/DefaultSamplingServiceTests.cs
+++ b/Brainarr.Tests/Services/Prompting/DefaultSamplingServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NLog;
 using NzbDrone.Core.ImportLists.Brainarr;
 using NzbDrone.Core.ImportLists.Brainarr.Configuration;
@@ -78,6 +79,355 @@ namespace Brainarr.Tests.Services.Prompting
                 token: CancellationToken.None);
 
             Assert.True(sample.ArtistCount <= 1200);
+        }
+
+        // ---------------------------------------------------------------------
+        // Improvement B: style-seeded zero-coverage dedup fallback.
+        // When the user selects styles their library has ZERO exact coverage of
+        // (genre-first discovery), the strict + relaxed style match lists are empty,
+        // so the library/dedup sample comes back empty and the prompt prints
+        // "0 groups" — the model gets no "avoid these duplicates" signal. The
+        // fallback surfaces the closest library artists/albums (adjacent styles,
+        // then dominant artists) so the dedup audit is non-empty.
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        [Trait("Category", "Sampling")]
+        public void Sample_StyleSeededZeroCoverage_AdjacentStylesExist_PopulatesDedupArtists()
+        {
+            // Seed style "lo-fi-hip-hop" has ZERO library coverage; the library only
+            // contains the adjacent style "hip-hop" (a sibling the catalog returns from
+            // GetSimilarSlugs). Today the artist match list is empty → dedup list empty.
+            var catalog = new SimilarityStubStyleCatalog(
+                ("lo-fi-hip-hop", new[] { new StyleSimilarity("hip-hop", 0.75, "sibling") }));
+            var contextPolicy = new StubContextPolicy(artistCount: 40, albumCount: 0);
+            var service = new DefaultSamplingService(Logger, catalog, contextPolicy);
+
+            var styleContext = new LibraryStyleContext();
+            // The library does NOT cover the seed style at all (genre-first gate fires).
+            styleContext.SetCoverage(new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["hip-hop"] = 3
+            });
+            styleContext.ArtistStyles[1] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.ArtistStyles[2] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.ArtistStyles[3] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.SetStyleIndex(new LibraryStyleIndex(
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["hip-hop"] = new List<int> { 1, 2, 3 }
+                },
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)));
+
+            var selection = new StylePlanContext(
+                selected: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "lo-fi-hip-hop" },
+                expanded: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "lo-fi-hip-hop" },
+                entries: new List<StyleEntry> { new StyleEntry { Name = "Lo-Fi Hip Hop", Slug = "lo-fi-hip-hop" } },
+                adjacent: new List<StyleEntry>(),
+                // Renderer's genre-first signal: sum of selected-slug coverage == 0.
+                coverage: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["lo-fi-hip-hop"] = 0 },
+                relaxed: false,
+                threshold: 1.0,
+                trimmed: new List<string>(),
+                inferred: new List<string>());
+
+            var artists = Enumerable.Range(1, 3)
+                .Select(id => CreateArtist(id, $"Hip Hop Artist {id}"))
+                .ToList();
+
+            var sample = service.Sample(
+                artists,
+                Array.Empty<Album>(),
+                styleContext,
+                selection,
+                new BrainarrSettings(),
+                tokenBudget: 4000,
+                seed: 42,
+                token: CancellationToken.None);
+
+            sample.ArtistCount.Should().BeGreaterThan(0,
+                "the dedup audit must surface adjacent-style library artists so the prompt is not '0 groups'");
+        }
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        [Trait("Category", "Sampling")]
+        public void Sample_StyleSeededZeroCoverage_NoAdjacentStyles_FallsBackToDominantArtists()
+        {
+            // Seed style "lo-fi-hip-hop" has ZERO coverage AND there is no adjacent style
+            // in the library (GetSimilarSlugs returns nothing useful). The fallback must
+            // still surface the library's dominant artists for the dedup audit.
+            var catalog = new SimilarityStubStyleCatalog(); // returns empty similars
+            var contextPolicy = new StubContextPolicy(artistCount: 40, albumCount: 0);
+            var service = new DefaultSamplingService(Logger, catalog, contextPolicy);
+
+            var styleContext = new LibraryStyleContext();
+            styleContext.SetCoverage(new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["rock"] = 5
+            });
+            styleContext.SetDominantStyles(new[] { "rock" });
+            styleContext.ArtistStyles[1] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rock" };
+            styleContext.ArtistStyles[2] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rock" };
+            styleContext.SetStyleIndex(new LibraryStyleIndex(
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["rock"] = new List<int> { 1, 2 }
+                },
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)));
+
+            var selection = new StylePlanContext(
+                selected: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "lo-fi-hip-hop" },
+                expanded: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "lo-fi-hip-hop" },
+                entries: new List<StyleEntry> { new StyleEntry { Name = "Lo-Fi Hip Hop", Slug = "lo-fi-hip-hop" } },
+                adjacent: new List<StyleEntry>(),
+                coverage: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["lo-fi-hip-hop"] = 0 },
+                relaxed: false,
+                threshold: 1.0,
+                trimmed: new List<string>(),
+                inferred: new List<string>());
+
+            var artists = Enumerable.Range(1, 2)
+                .Select(id => CreateArtist(id, $"Rock Artist {id}"))
+                .ToList();
+
+            var sample = service.Sample(
+                artists,
+                Array.Empty<Album>(),
+                styleContext,
+                selection,
+                new BrainarrSettings(),
+                tokenBudget: 4000,
+                seed: 42,
+                token: CancellationToken.None);
+
+            sample.ArtistCount.Should().BeGreaterThan(0,
+                "with no adjacent style coverage the dedup audit must fall back to the library's dominant artists");
+        }
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        [Trait("Category", "Sampling")]
+        public void Sample_StyleSeededZeroCoverage_DoesNotFlipSelectedCoverageToNonZero()
+        {
+            // CRITICAL INVARIANT: the genre-first gate is sum(Coverage[selectedSlug]) == 0,
+            // computed identically by the renderer AND RecommendationPipeline. Enriching the
+            // dedup sample must NOT change that value — the fallback artists are a dedup audit
+            // ONLY; they must not register as matches against the seed slugs.
+            var catalog = new SimilarityStubStyleCatalog(
+                ("lo-fi-hip-hop", new[] { new StyleSimilarity("hip-hop", 0.75, "sibling") }));
+            var contextPolicy = new StubContextPolicy(artistCount: 40, albumCount: 0);
+            var service = new DefaultSamplingService(Logger, catalog, contextPolicy);
+
+            var styleContext = new LibraryStyleContext();
+            styleContext.SetCoverage(new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["hip-hop"] = 3
+            });
+            styleContext.ArtistStyles[1] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.ArtistStyles[2] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.ArtistStyles[3] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.SetStyleIndex(new LibraryStyleIndex(
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["hip-hop"] = new List<int> { 1, 2, 3 }
+                },
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)));
+
+            var selection = new StylePlanContext(
+                selected: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "lo-fi-hip-hop" },
+                expanded: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "lo-fi-hip-hop" },
+                entries: new List<StyleEntry> { new StyleEntry { Name = "Lo-Fi Hip Hop", Slug = "lo-fi-hip-hop" } },
+                adjacent: new List<StyleEntry>(),
+                coverage: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["lo-fi-hip-hop"] = 0 },
+                relaxed: false,
+                threshold: 1.0,
+                trimmed: new List<string>(),
+                inferred: new List<string>());
+
+            var artists = Enumerable.Range(1, 3)
+                .Select(id => CreateArtist(id, $"Hip Hop Artist {id}"))
+                .ToList();
+
+            // The renderer computes styleSeeded from selection.Coverage; capture it the same way.
+            int SelectedCoverage() =>
+                selection.SelectedSlugs.Sum(s => selection.Coverage.TryGetValue(s, out var c) ? c : 0);
+
+            SelectedCoverage().Should().Be(0, "precondition: genre-first gate must be active before sampling");
+
+            service.Sample(
+                artists,
+                Array.Empty<Album>(),
+                styleContext,
+                selection,
+                new BrainarrSettings(),
+                tokenBudget: 4000,
+                seed: 42,
+                token: CancellationToken.None);
+
+            SelectedCoverage().Should().Be(0,
+                "the dedup-fallback must NOT flip the selected-style coverage to non-zero (genre-first gate preserved)");
+            selection.MatchedCounts.Should().NotContainKey("lo-fi-hip-hop",
+                "fallback dedup artists must not register as seed-style matches");
+        }
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        [Trait("Category", "Sampling")]
+        public void Sample_StyleSeededZeroCoverage_AdjacentAlbumsExist_PopulatesDedupAlbums()
+        {
+            // Album-side parity: zero seed coverage but adjacent-style albums exist.
+            var catalog = new SimilarityStubStyleCatalog(
+                ("lo-fi-hip-hop", new[] { new StyleSimilarity("hip-hop", 0.75, "sibling") }));
+            var contextPolicy = new StubContextPolicy(artistCount: 0, albumCount: 40);
+            var service = new DefaultSamplingService(Logger, catalog, contextPolicy);
+
+            var styleContext = new LibraryStyleContext();
+            styleContext.SetCoverage(new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["hip-hop"] = 3
+            });
+            styleContext.AlbumStyles[10] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.AlbumStyles[11] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.AlbumStyles[12] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hip-hop" };
+            styleContext.SetStyleIndex(new LibraryStyleIndex(
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase),
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["hip-hop"] = new List<int> { 10, 11, 12 }
+                }));
+
+            var selection = new StylePlanContext(
+                selected: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "lo-fi-hip-hop" },
+                expanded: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "lo-fi-hip-hop" },
+                entries: new List<StyleEntry> { new StyleEntry { Name = "Lo-Fi Hip Hop", Slug = "lo-fi-hip-hop" } },
+                adjacent: new List<StyleEntry>(),
+                coverage: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["lo-fi-hip-hop"] = 0 },
+                relaxed: false,
+                threshold: 1.0,
+                trimmed: new List<string>(),
+                inferred: new List<string>());
+
+            var albums = new[] { 10, 11, 12 }
+                .Select(id => CreateAlbum(id, $"Hip Hop Album {id}", artistId: id))
+                .ToList();
+
+            var sample = service.Sample(
+                Array.Empty<Artist>(),
+                albums,
+                styleContext,
+                selection,
+                new BrainarrSettings(),
+                tokenBudget: 4000,
+                seed: 42,
+                token: CancellationToken.None);
+
+            sample.AlbumCount.Should().BeGreaterThan(0,
+                "the dedup audit must surface adjacent-style library albums for the genre-first path");
+        }
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        [Trait("Category", "Sampling")]
+        public void Sample_LibraryAligned_DoesNotEngageDedupFallback()
+        {
+            // Guard against over-reach: when the library DOES cover the selected style,
+            // matching proceeds normally and the fallback must not fire (no behavior change).
+            var catalog = new SimilarityStubStyleCatalog();
+            var contextPolicy = new StubContextPolicy(artistCount: 40, albumCount: 0);
+            var service = new DefaultSamplingService(Logger, catalog, contextPolicy);
+
+            var styleContext = new LibraryStyleContext();
+            styleContext.SetCoverage(new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["rock"] = 2
+            });
+            styleContext.ArtistStyles[1] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rock" };
+            styleContext.ArtistStyles[2] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rock" };
+            styleContext.SetStyleIndex(new LibraryStyleIndex(
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["rock"] = new List<int> { 1, 2 }
+                },
+                new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)));
+
+            var selection = new StylePlanContext(
+                selected: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rock" },
+                expanded: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rock" },
+                entries: new List<StyleEntry> { new StyleEntry { Name = "Rock", Slug = "rock" } },
+                adjacent: new List<StyleEntry>(),
+                coverage: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["rock"] = 2 },
+                relaxed: false,
+                threshold: 1.0,
+                trimmed: new List<string>(),
+                inferred: new List<string>());
+
+            var artists = Enumerable.Range(1, 2)
+                .Select(id => CreateArtist(id, $"Rock Artist {id}"))
+                .ToList();
+
+            var sample = service.Sample(
+                artists,
+                Array.Empty<Album>(),
+                styleContext,
+                selection,
+                new BrainarrSettings(),
+                tokenBudget: 4000,
+                seed: 42,
+                token: CancellationToken.None);
+
+            // Normal style match (rock matches rock) → both artists present with the matched style.
+            sample.ArtistCount.Should().Be(2);
+            sample.Artists.Should().OnlyContain(a => a.MatchedStyles.Contains("rock"));
+        }
+
+        private static Artist CreateArtist(int id, string name)
+        {
+            var artist = new Artist
+            {
+                Id = id,
+                Added = DateTime.UtcNow.AddDays(-id)
+            };
+            artist.Metadata.Value.Name = name;
+            return artist;
+        }
+
+        private static Album CreateAlbum(int id, string title, int artistId)
+        {
+            return new Album
+            {
+                Id = id,
+                Title = title,
+                ArtistId = artistId,
+                Added = DateTime.UtcNow.AddDays(-id),
+                ReleaseDate = DateTime.UtcNow.AddYears(-1)
+            };
+        }
+
+        // Stub catalog that returns configured similar-slugs per seed slug (for the
+        // adjacent-style dedup fallback) and otherwise behaves like an empty catalog.
+        private sealed class SimilarityStubStyleCatalog : IStyleCatalogService
+        {
+            private readonly Dictionary<string, IReadOnlyList<StyleSimilarity>> _similars;
+
+            public SimilarityStubStyleCatalog(params (string Slug, StyleSimilarity[] Similars)[] entries)
+            {
+                _similars = entries.ToDictionary(
+                    e => e.Slug,
+                    e => (IReadOnlyList<StyleSimilarity>)e.Similars,
+                    StringComparer.OrdinalIgnoreCase);
+            }
+
+            public IReadOnlyList<StyleEntry> GetAll() => Array.Empty<StyleEntry>();
+            public IEnumerable<StyleEntry> Search(string query, int limit = 50) => Array.Empty<StyleEntry>();
+            public ISet<string> Normalize(IEnumerable<string> selected) => new HashSet<string>(selected ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            public bool IsMatch(ICollection<string> libraryGenres, ISet<string> selectedStyleSlugs, bool relaxParentMatch = false) => false;
+            public string? ResolveSlug(string value) => value;
+            public StyleEntry? GetBySlug(string slug) => null;
+            public IEnumerable<StyleSimilarity> GetSimilarSlugs(string slug)
+                => _similars.TryGetValue(slug ?? string.Empty, out var s) ? s : Array.Empty<StyleSimilarity>();
+            public Task RefreshAsync(CancellationToken token = default) => Task.CompletedTask;
         }
 
         private sealed class StubStyleCatalog : IStyleCatalogService

--- a/Brainarr.Tests/Services/Prompting/LibraryPromptRendererTests.cs
+++ b/Brainarr.Tests/Services/Prompting/LibraryPromptRendererTests.cs
@@ -520,6 +520,87 @@ namespace Brainarr.Tests.Services.Prompting
             Assert.Equal(promptA, promptB);
         }
 
+        [Fact]
+        [Trait("Category", "Unit")]
+        [Trait("Category", "PromptRenderer")]
+        public void Render_StyleSeeded_WithPopulatedDedupSample_ShowsLibrarySection_AndGenreFirstLanguage()
+        {
+            // Improvement B: for genre-first discovery (selected-style coverage == 0) the dedup sample is
+            // now populated (adjacent/dominant library artists). The prompt must:
+            //   - render the genre-first "recommend artists OF the seed styles; library is dedup-only" intent
+            //   - NOT print "0 groups" — the library/dedup section is populated
+            var sample = new LibrarySample();
+            var artist = new LibrarySampleArtist
+            {
+                ArtistId = 1,
+                Name = "Existing Hip Hop Artist",
+                // Dedup-fallback artists carry NO matched styles (they're a dedup audit, not seed matches).
+                MatchedStyles = Array.Empty<string>(),
+                Weight = 0.5
+            };
+            artist.Albums.Add(new LibrarySampleAlbum
+            {
+                AlbumId = 10,
+                ArtistId = 1,
+                ArtistName = "Existing Hip Hop Artist",
+                Title = "Old Beats",
+                MatchedStyles = Array.Empty<string>(),
+                Added = DateTime.UtcNow.AddDays(-30),
+                Year = DateTime.UtcNow.Year - 3
+            });
+            sample.Artists.Add(artist);
+
+            // Style-seeded StylePlanContext: selected slug with ZERO coverage (the renderer's genre-first gate).
+            var styleContext = new StylePlanContext(
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "lofi-hip-hop" },
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "lofi-hip-hop" },
+                new List<StyleEntry> { new() { Name = "Lo-Fi Hip Hop", Slug = "lofi-hip-hop" } },
+                new List<StyleEntry>(),
+                new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["lofi-hip-hop"] = 0 },
+                relaxed: false,
+                threshold: 1.0,
+                trimmed: new List<string>(),
+                inferred: new List<string>());
+
+            var plan = new PromptPlan(sample, new[] { "lofi-hip-hop" })
+            {
+                Profile = new LibraryProfile
+                {
+                    TotalArtists = 50,
+                    TotalAlbums = 120,
+                    Metadata = new Dictionary<string, object>(),
+                    StyleContext = new LibraryStyleContext()
+                },
+                Settings = new BrainarrSettings
+                {
+                    DiscoveryMode = DiscoveryMode.Adjacent,
+                    SamplingStrategy = SamplingStrategy.Balanced,
+                    MaxRecommendations = 10
+                },
+                StyleContext = styleContext,
+                ShouldRecommendArtists = true,
+                Compression = new PromptCompressionState(maxArtists: 5, maxAlbumGroups: 5, maxAlbumsPerGroup: 3, minAlbumsPerGroup: 1)
+            };
+
+            var renderer = new LibraryPromptRenderer();
+            var prompt = renderer.Render(plan, ModelPromptTemplate.Default, CancellationToken.None);
+
+            // Genre-first intent is explicit.
+            Assert.Contains("genre-first discovery", prompt, StringComparison.Ordinal);
+            Assert.Contains("avoid duplicates", prompt, StringComparison.Ordinal);
+            Assert.Contains("SEED STYLES (recommend artists OF these styles):", prompt, StringComparison.Ordinal);
+
+            // The dedup/library section is populated (NOT "0 groups") and lists the existing artist.
+            Assert.DoesNotContain("(0 groups shown)", prompt, StringComparison.Ordinal);
+            Assert.Contains("Existing Hip Hop Artist", prompt, StringComparison.Ordinal);
+            // Genre-first header makes the dedup-only intent explicit (still keeps the stable substring).
+            Assert.Contains("LIBRARY ARTISTS & KEY ALBUMS", prompt, StringComparison.Ordinal);
+            Assert.Contains("EXISTING LIBRARY (avoid these duplicates)", prompt, StringComparison.Ordinal);
+
+            // The seed style is NOT presented as library-aligned coverage in this mode.
+            Assert.DoesNotContain("STYLE FILTERS (library-aligned)", prompt, StringComparison.Ordinal);
+        }
+
         private static PromptPlan CreateMinimalPlan(bool recommendArtists = false)
         {
             var sample = new LibrarySample();

--- a/Brainarr.Tests/Services/TokenBudgetResolverTests.cs
+++ b/Brainarr.Tests/Services/TokenBudgetResolverTests.cs
@@ -1,0 +1,79 @@
+using NLog;
+using NzbDrone.Core.ImportLists.Brainarr;
+using NzbDrone.Core.ImportLists.Brainarr.Configuration;
+using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Prompting.Policies;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Providers.Capabilities;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Registry;
+using Xunit;
+
+namespace Brainarr.Tests.Services
+{
+    /// <summary>
+    /// Model-capacity-aware budget tests. The prompt token budget must scale with the
+    /// model's context window: a frontier 128K/200K provider (z.ai GLM) should get a
+    /// large prompt budget bounded by the cloud ceiling, while a small-context provider
+    /// must stay modest. See TokenBudgetResolver.DefaultContextTokens + CloudPromptCeiling.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Category", "PromptBuilder")]
+    public class TokenBudgetResolverTests
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        private static TokenBudgetResolver CreateResolver()
+        {
+            // registryUrl null -> ModelContextResolver resolves no per-model context
+            // tokens from the network registry, so the provider-level DefaultContextTokens
+            // fallback is exercised (the path this feature widens for z.ai GLM).
+            var modelContextResolver = new ModelContextResolver(Logger, new ModelRegistryLoader(), registryUrl: null);
+            return new TokenBudgetResolver(Logger, modelContextResolver, new DefaultTokenBudgetPolicy());
+        }
+
+        [Fact]
+        public void ZaiGlm_Comprehensive_GetsLargePromptBudget()
+        {
+            var resolver = CreateResolver();
+            var settings = new BrainarrSettings
+            {
+                Provider = AIProvider.ZaiGlm,
+                SamplingStrategy = SamplingStrategy.Comprehensive,
+                MaxRecommendations = 20
+            };
+
+            var budget = resolver.ResolvePromptBudget(settings, ProviderCapabilities.Get(AIProvider.ZaiGlm));
+
+            // Today (RED): ZaiGlm is absent from DefaultContextTokens -> 24000 fallback,
+            // then the flat 20000 cloud ceiling clamps it to ~20000. After the fix the
+            // 128K provider default + 96K cloud ceiling yield a much larger budget.
+            Assert.True(
+                budget.PromptTokens >= 60000,
+                $"Expected ZaiGlm comprehensive prompt budget >= 60000 (capacity-aware), got {budget.PromptTokens}");
+        }
+
+        [Fact]
+        public void SmallContextProvider_StaysBelowCloudCeiling()
+        {
+            var resolver = CreateResolver();
+            // Gemini has DefaultContextTokens == 32000 (a small-context cloud provider).
+            // Its prompt budget must remain well under the cloud ceiling, proving small
+            // models are unchanged by the capacity-aware widening.
+            var settings = new BrainarrSettings
+            {
+                Provider = AIProvider.Gemini,
+                SamplingStrategy = SamplingStrategy.Comprehensive,
+                MaxRecommendations = 20
+            };
+
+            var budget = resolver.ResolvePromptBudget(settings, ProviderCapabilities.Get(AIProvider.Gemini));
+
+            Assert.True(
+                budget.PromptTokens < TokenBudgetResolver.CloudPromptCeiling,
+                $"Expected small-context Gemini prompt budget < cloud ceiling {TokenBudgetResolver.CloudPromptCeiling}, got {budget.PromptTokens}");
+            // A 32K-context provider should land in a modest band, nowhere near the ceiling.
+            Assert.True(
+                budget.PromptTokens <= 32000,
+                $"Expected small-context Gemini prompt budget <= 32000, got {budget.PromptTokens}");
+        }
+    }
+}

--- a/docs/models.example.json
+++ b/docs/models.example.json
@@ -183,6 +183,330 @@
         "max": 1,
         "backoff_ms": 100
       }
+    },
+    {
+      "name": "Z.AI GLM (PaaS)",
+      "slug": "zaiglm",
+      "endpoint": "https://api.z.ai/api/paas/v4/chat/completions",
+      "auth": {
+        "type": "bearer",
+        "env": "ZAI_API_KEY"
+      },
+      "models": [
+        {
+          "id": "glm-5.1",
+          "label": "GLM-5.1",
+          "context_tokens": 200000,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-5",
+          "label": "GLM-5",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-5-turbo",
+          "label": "GLM-5-Turbo",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.7",
+          "label": "GLM-4.7",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.7-flash",
+          "label": "GLM-4.7-Flash",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.7-flashx",
+          "label": "GLM-4.7-FlashX",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.6",
+          "label": "GLM-4.6",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.5",
+          "label": "GLM-4.5",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.5-air",
+          "label": "GLM-4.5-Air",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.5-airx",
+          "label": "GLM-4.5-AirX",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.5-flash",
+          "label": "GLM-4.5-Flash",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4-plus",
+          "label": "GLM-4-Plus",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4-32b-0414-128k",
+          "label": "GLM-4-32B",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": true,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        }
+      ],
+      "timeouts": {
+        "connect_ms": 5000,
+        "request_ms": 90000
+      },
+      "retries": {
+        "max": 2,
+        "backoff_ms": 200
+      }
+    },
+    {
+      "name": "Z.AI GLM (Coding Plan)",
+      "slug": "zaicoding",
+      "endpoint": "https://api.z.ai/api/anthropic/v1/messages",
+      "auth": {
+        "type": "bearer",
+        "env": "ZAI_API_KEY"
+      },
+      "models": [
+        {
+          "id": "glm-5.1",
+          "label": "GLM-5.1",
+          "context_tokens": 200000,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-5",
+          "label": "GLM-5",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-5-turbo",
+          "label": "GLM-5-Turbo",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.7",
+          "label": "GLM-4.7",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.7-flash",
+          "label": "GLM-4.7-Flash",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.7-flashx",
+          "label": "GLM-4.7-FlashX",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.6",
+          "label": "GLM-4.6",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.5",
+          "label": "GLM-4.5",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.5-air",
+          "label": "GLM-4.5-Air",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.5-airx",
+          "label": "GLM-4.5-AirX",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4.5-flash",
+          "label": "GLM-4.5-Flash",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4-plus",
+          "label": "GLM-4-Plus",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        },
+        {
+          "id": "glm-4-32b-0414-128k",
+          "label": "GLM-4-32B",
+          "context_tokens": 131072,
+          "capabilities": {
+            "stream": true,
+            "json_mode": false,
+            "tools": true,
+            "tool_choice": "auto"
+          }
+        }
+      ],
+      "timeouts": {
+        "connect_ms": 5000,
+        "request_ms": 90000
+      },
+      "retries": {
+        "max": 2,
+        "backoff_ms": 200
+      }
     }
   ]
 }


### PR DESCRIPTION
## What

Implements **#47 — capacity-aware sampling** in two parts:

- **A. Prompt budget scales with the model's context window** (frontier models get a far richer prompt; small/local models unchanged).
- **B. Style-discovery dedup audit** — for style-seeded ("genre-first") discovery, populate the "existing library (avoid duplicates)" section so the model doesn't re-suggest what you already own.

---

## A — Budget scales with context window

Today z.ai GLM-5.1 (200K context) gets a ~15K prompt because (1) no `ZaiGlm`/`ZaiCoding` entry in the context-token map → fell back to 24000, and (2) a flat **20000** cloud prompt ceiling re-clamped everything — so a 200K window was never used.

- `TokenBudgetResolver`: `ZaiGlm`/`ZaiCoding` default context = **131072** (128K — safe floor for all GLM models); cloud prompt ceiling `20000` → `CloudPromptCeiling = 96000`. The prompt already scales with the context window via the completion/headroom reserves; this ceiling just bounds the top to control cost.
- `DefaultContextPolicy`: sampling caps **90→250** artists, **220→600** albums (same `tokenBudget/260` & `/120` scaling — only the ceiling rises, so **small budgets are unchanged**).
- `docs/models.example.json` (embedded fallback registry): added `zaiglm`/`zaicoding` with per-model `context_tokens` (GLM-5.1 = **200000**).

**Effect:** GLM-5.1 prompt budget **~15.6K → ~90K**. `SamplingStrategy` still multiplies on top.

## B — Style-discovery dedup audit

**Problem:** When you select styles your library has ZERO coverage of (e.g. "lo-fi" with no lo-fi artists), discovery is correctly genre-first — but the dedup sample was empty, so the prompt was `sparse` and the model had no "avoid these" list. **Live-observed**: the 18:09 lo-fi run logged `sparse=true, pre=482` tokens.

**Fix:** `DefaultSamplingService` now fills the dedup sample for style-seeded zero-coverage via a 3-tier fallback — adjacent styles (`GetSimilarSlugs`) → dominant library styles → whole library — bounded by the same `DefaultContextPolicy` targets (no flood). Fallback items carry empty `MatchedStyles`/score 0, rendered under "EXISTING LIBRARY (avoid these duplicates)" — never mistaken for seed-style matches.

**Invariant preserved (critical):** the genre-first gate `sum(StyleCoverage[selectedSlug])==0` (computed identically in `LibraryPromptRenderer` + `RecommendationPipeline.IsStyleSeededDiscovery`) is untouched — the fallback reads `Coverage` and only ever writes `MatchedCounts`, so it is **structurally immune** to flipping genre-first into library-grounded. The over-reach is gated on the zero-coverage signal (not bare empty-matches). Guarded by `Sample_StyleSeededZeroCoverage_DoesNotFlipSelectedCoverageToNonZero`.

---

## Tests (TDD)

- **A:** new `TokenBudgetResolverTests` + `DefaultContextPolicyTests` (RED→GREEN); 2 pre-existing 20K-crush-artifact tests rewritten to assert context-window awareness.
- **B:** new `DefaultSamplingServiceTests` + `StyleSeededDiscoveryTests` (incl. the invariant guard + dedup-fallback-populates-but-keeps-gate-true) + renderer test (RED→GREEN).
- Full suite: **3207 passed** (2 pre-existing flaky). Independently reviewed: **A APPROVE-WITH-NITS, B APPROVE**.

## Live verification (lidarr-e2e :8787)

- **A — verified live:** GLM-5.1 `prompt_plan … budget=90551` (was ~15.6K). ✅
- **B —** unit + adversarial-review verified; the exact gap it fills was live-observed (the 18:09 `sparse=true, pre=482` lo-fi prompt). Capturing the *filled* prompt live is gated by Lidarr's import-list refresh interval (the list won't re-sync brainarr until the interval elapses; `ImportListSync`/`definitionId`/`Test` all skip it mid-interval). A delayed post-interval capture is running.

## ⚠️ Cost note (release-note worthy)

The 96K ceiling applies to **all** cloud providers. **Anthropic** resolves to a 200K context window by default → its prompt budget rises from ~20K to up to **~96K** (a concentrated input-token cost increase on upgrade). Intentional per the approved ~96K bound; dial down via `SamplingStrategy`. A per-provider lower cap is a possible follow-up.

## CI note

The `provider-matrix-sync` check fails on **pre-existing** docs drift (README "Verified in v1.5.7" vs `providers.yaml` v1.3.2) — **not** introduced here (neither commit touches `providers.yaml`/README/registry; verified via `git diff --name-only origin/main..HEAD`). Provider-matrix/docs domain; flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
