### PR TITLE
docs(readme): enrich README via wiki/doc cross-links (no duplication)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,44 @@ Latest release: **v1.6.1**
 
 Discover albums with deterministic, local-first AI. Pick a provider (local or cloud), set budgets, and get reproducible, high-signal recommendations.
 
+## Features & Capabilities
+
+### Core
+
+- **11 AI providers** — 2 local (Ollama, LM Studio), 7 cloud (OpenAI, Anthropic, Gemini, Perplexity, Groq, DeepSeek, OpenRouter), 2 subscription (Claude Code, OpenAI Codex).
+- **Deterministic planning** — fingerprint your library, select representative styles, sample artists/albums, render prompts in a reproducible pipeline.
+- **Dual recommendation modes** — specific albums or artist-only discovery.
+- **Iterative refinement (top-up)** — backfill sparse results automatically until the target count is met.
+- **Discovery-mode escalation** — when dedup saturation stalls top-up, the engine widens from Similar → Adjacent → Exploratory to break out of the cluster.
+
+### Safety & Quality
+
+- **Confidence floor (`MinConfidence`)** — drop or queue items below the threshold; parsers fabricate a default score only when the model omits one.
+- **MusicBrainz enrichment** — resolve MBIDs for artists and albums; gate items missing required MBIDs.
+- **Hallucination filters** — pattern-based validation (`PossiblyLegitimatePattern` list), custom substring filters, and optional strict mode.
+- **Review Queue** — borderline items queue for manual approval; triage advisor scores each item with confidence band, MBID status, and dedup checks.
+- **JSON salvage** — `RecommendationJsonParser` extracts valid array elements from truncated provider output, handling both bare arrays and object-wrapped shapes.
+
+### Resilience & Performance
+
+- **Circuit breaker** — per-provider auth-failure gates with sliding-window semantics (3 failures in 5 min → latch for 30 min).
+- **Adaptive rate limiting** — per-model concurrency caps with automatic throttle decay after HTTP 429 responses.
+- **Fingerprinted LRU cache** — plan cache with sliding TTL; automatic invalidation when styles or library fingerprint change.
+- **Timeout-aware token budgets** — `max_tokens` scales to the configured request timeout so the output never overshoots the HTTP deadline.
+- **Run cancellation** — cancellation tokens propagate through the entire top-up/enrichment chain; partial results are preserved on abort.
+
+### Observability
+
+- **Prometheus metrics** — `metrics/prometheus` endpoint exposes latency histograms, error counters, and 429 rates per `{provider}:{model}`.
+- **Built-in Observability UI** — lightweight HTML preview under Advanced settings showing last 15 minutes of data.
+- **Structured logging** — run-summary logs with attainment %, provider success, confidence-floor gate counts, and token-budget diagnostics.
+
+### Security
+
+- **API keys stored via Lidarr's config** — never hardcoded; Gemini suppresses host HTTP errors to prevent key-in-URL log leaks.
+- **SHA256-hashed circuit keys** — raw LLM API keys never appear as dictionary keys on the heap.
+- **SBOM + SHA-256 checksums** per release; v1.5.7+ also signed with Sigstore Cosign (keyless).
+
 ## Reliability & Timeouts
 
 Brainarr avoids UI hangs by executing provider calls and tests on a dedicated thread with strict timeouts. Local defaults (Ollama/LM Studio) work entirely offline; when networked features are enabled (e.g., styles catalog refresh or cloud providers), short timeouts and retries ensure the plugin remains responsive even under provider issues.
@@ -35,6 +73,7 @@ Notes
 
 - Values are configurable per provider in Advanced Settings. Brainarr enforces an upper guardrail of 600 seconds (10 minutes) for any single request to accommodate slow local models.
 - Local providers (Ollama/LM Studio) automatically use a 360-second (6-minute) timeout when the configured timeout is at or below the default of 30 seconds.
+- For a deeper dive into timeout tuning, see the wiki's [Timeouts & Retries](./wiki-content/Timeouts-and-Retries.md) page and [docs/PERFORMANCE_TUNING.md](./docs/PERFORMANCE_TUNING.md).
 
 ## Install via Lidarr UI (recommended)
 
@@ -54,21 +93,22 @@ There are two ways to install Brainarr:
 1. From the Latest release page (recommended)
 
 - Go to GitHub Releases and download the ZIP asset for the latest version (currently v1.6.1).
-- Extract the contents into Lidarr’s plugins directory:
+- Extract the contents into Lidarr's plugins directory:
   - Docker: `/config/plugins/RicherTunes/Brainarr/`
   - Linux: `/var/lib/lidarr/plugins/RicherTunes/Brainarr/`
-  - Windows: `%ProgramData%\\Lidarr\\plugins\\RicherTunes\\Brainarr\\`
+  - Windows: `%ProgramData%\Lidarr\plugins\RicherTunes\Brainarr\`
 - Restart Lidarr, then add Brainarr under Settings → Import Lists.
 
 1. Using the moving tag "latest"
 
-- The repository maintains a tag named `latest` that points to the newest stable tag (presently v1.6.1). Any automation that follows
-eleases/latest will pick up the most recent stable build automatically when we publish a new version.
+- The repository maintains a tag named `latest` that points to the newest stable tag (presently v1.6.1). Any automation that follows releases/latest will pick up the most recent stable build automatically when we publish a new version.
 
 Notes
 
 - Brainarr requires Lidarr 3.0.0.4855+ on the plugins/nightly branch. Our CI extracts assemblies from the plugins Docker image to validate compatibility.
 - The packaged manifest.json is included in the ZIP so Lidarr recognizes the plugin in the Installed list after manual installs.
+
+For detailed Docker and manual setup instructions, see the wiki's [Installation](./wiki-content/Installation.md) page.
 
 ## Upgrade Notes: 1.3.0
 
@@ -134,18 +174,25 @@ Troubleshooting
 
 ## Contents
 
+- [Features & Capabilities](#features--capabilities)
+- [Reliability & Timeouts](#reliability--timeouts)
+- [Install via Lidarr UI](#install-via-lidarr-ui-recommended)
+- [Installing from Releases](#installing-from-releases)
+- [Screenshots](#screenshots)
 - [What is Brainarr](#what-is-brainarr)
 - [Quickstart](#quickstart)
 - [Configuration](#configuration)
+- [Documentation](#documentation)
 - [Provider compatibility](#provider-compatibility)
 - [Upgrade Notes: 1.3.0](#upgrade-notes-130)
 - [Troubleshooting](#troubleshooting)
 - [Security](#security)
+- [Shared Infrastructure](#shared-infrastructure)
 - [Contributing](#contributing)
 
 ## What is Brainarr
 
-Brainarr is an import list plugin that enriches Lidarr with AI-assisted album discovery while staying inside Lidarr’s import-list workflow.
+Brainarr is an import list plugin that enriches Lidarr with AI-assisted album discovery while staying inside Lidarr's import-list workflow.
 
 It leans on a local-first stance by default—install the plugin, point it at your Lidarr nightly instance, and you can start running recommendations without sending prompts off-box. See the [configuration guide](./docs/configuration.md) for the full option set.
 
@@ -155,7 +202,7 @@ A fingerprinted LRU cache with a sliding TTL keeps recent plans warm. When you c
 
 Token budgeting uses a registry-plus-tokenizer model. When a tokenizer is missing we fall back to an estimator, emit a one-time warning, and log `tokenizer.fallback`; learn how to tighten drift in [tokenization & estimates](./docs/tokenization-and-estimates.md).
 
-Telemetry is built in: metrics such as `prompt.plan_cache_*`, `prompt.headroom_violation`, and tokenizer fallbacks surface in Lidarr’s Prometheus endpoint. The [metrics reference](./docs/METRICS_REFERENCE.md) and [troubleshooting](./docs/troubleshooting.md) explain how to interpret them.
+Telemetry is built in: metrics such as `prompt.plan_cache_*`, `prompt.headroom_violation`, and tokenizer fallbacks surface in Lidarr's Prometheus endpoint. The [metrics reference](./docs/METRICS_REFERENCE.md) and [troubleshooting](./docs/troubleshooting.md) explain how to interpret them.
 
 Out of the box Brainarr stays purely local through Ollama/LM Studio, including iterative refinement defaults that backfill sparse runs. If you opt into cloud providers, they share the same configuration surface—see [configuration](./docs/configuration.md) for how to enable each one.
 
@@ -205,26 +252,86 @@ For day-to-day operations, start with the [upgrade notes](./docs/upgrade-notes-1
 32. Note any `tokenizer.fallback` warnings so you can add accurate tokenizers later.
 33. Open `Activity → Import Lists` to inspect the generated recommendations.
 34. Approve or reject the suggested albums according to your collection policy.
-35. Expose Lidarr’s metrics endpoint and scrape `prompt.plan_cache_*` and `tokenizer.fallback` if you monitor Brainarr centrally.
+35. Expose Lidarr's metrics endpoint and scrape `prompt.plan_cache_*` and `tokenizer.fallback` if you monitor Brainarr centrally.
 36. Bookmark [docs/upgrade-notes-1.3.0](./docs/upgrade-notes-1.3.0.md) and [docs/troubleshooting](./docs/troubleshooting.md) so your team shares the canonical guidance.
+
+For a richer walkthrough with tuning tips, see the wiki's [First Run Guide](./wiki-content/First-Run-Guide.md).
 
 ## Configuration
 
 The Brainarr configuration surface covers provider selection, planner and cache tuning, and tokenization controls. See the [configuration guide](./docs/configuration.md) for defaults, rationale, and links to the tokenization and planner deep dives. Keep in mind that local providers stay enabled by default and cloud providers remain opt-in.
 
-## Documentation map
+The wiki also provides focused guides:
 
-Use these focused guides when you need more than the README overview. Each link points at the canonical source in `docs/` so the README stays concise.
-> Note: The GitHub Wiki mirrors these docs from wiki-content/ and the README. Please submit edits via PRs; CI auto-publishes the wiki.
+- [Provider Setup Hub](./wiki-content/Provider-Setup.md) — pick a provider and follow the dedicated guide.
+- [Local Providers](./wiki-content/Local-Providers.md) — Ollama, LM Studio, hardware tips, and smoke tests.
+- [Cloud Providers](./wiki-content/Cloud-Providers.md) — API key creation, rate limits, and model selection.
+- [Advanced Settings](./wiki-content/Advanced-Settings.md) — tuning discovery, confidence, sampling, strictness, and concurrency.
+- [Settings Best Practices](./wiki-content/Settings-Best-Practices.md) — opinionated defaults by provider type and library size.
 
-- [Configuration & provider setup](./docs/configuration.md) — enable local-first defaults, wire up optional cloud providers, and learn the required tokens/script prerequisites.
-- [Planner & cache deep dive](./docs/planner-and-cache.md) — understand plan fingerprints, cache TTL behaviour, and deterministic ordering guarantees.
-- [Tokenization & estimates](./docs/tokenization-and-estimates.md) — improve tokenizer accuracy, interpret `tokenizer.fallback`, and keep headroom drift within ±15%.
-- [Troubleshooting playbook](./docs/troubleshooting.md) — resolve trimmed prompts, cache confusion, or provider JSON quirks with step-by-step guidance.
-- [Upgrade notes 1.3.0](./docs/upgrade-notes-1.3.0.md) — checklist for moving from 1.2.x, including new planner settings and cache metrics.
-- [Release process & verification](./docs/RELEASE_PROCESS.md) — follow the release workflow, provider verification steps, and documentation sync scripts.
+## Documentation
+
+Use these focused guides when you need more than the README overview. Each link points at the canonical source so the README stays concise.
+
+> **Note:** The GitHub Wiki mirrors these docs from `wiki-content/` and the README. Please submit edits via PRs; CI auto-publishes the wiki.
+
+### Repo docs (`docs/`)
+
+| Guide | What it covers |
+| --- | --- |
+| [Configuration & provider setup](./docs/configuration.md) | Enable local-first defaults, wire up optional cloud providers, learn required tokens/script prerequisites. |
+| [Planner & cache deep dive](./docs/planner-and-cache.md) | Plan fingerprints, cache TTL behaviour, and deterministic ordering guarantees. |
+| [Tokenization & estimates](./docs/tokenization-and-estimates.md) | Improve tokenizer accuracy, interpret `tokenizer.fallback`, and keep headroom drift within ±15%. |
+| [Troubleshooting playbook](./docs/troubleshooting.md) | Resolve trimmed prompts, cache confusion, or provider JSON quirks with step-by-step guidance. |
+| [Upgrade notes 1.3.0](./docs/upgrade-notes-1.3.0.md) | Checklist for moving from 1.2.x, including new planner settings and cache metrics. |
+| [Release process & verification](./docs/RELEASE_PROCESS.md) | Follow the release workflow, provider verification steps, and documentation sync scripts. |
+| [Architecture overview](./docs/ARCHITECTURE.md) | Planner flow, cache lifecycle, and component diagram. |
+| [Provider guide](./docs/PROVIDER_GUIDE.md) | Per-provider model options, offline mode, and subscription provider setup. |
+| [Recommendation modes](./docs/RECOMMENDATION_MODES.md) | Artist-only vs. specific albums, sampling shape, and token budget implications. |
+| [Metrics reference](./docs/METRICS_REFERENCE.md) | Every metric Brainarr exposes — names, tags, meaning, and PromQL examples. |
+| [Performance tuning](./docs/PERFORMANCE_TUNING.md) | Provider benchmarks, KPI targets, and optimization strategies by deployment scenario. |
+| [Security best practices](./docs/SECURITY.md) | API key management, data privacy, network security, and audit guidance. |
+| [API reference](./docs/API_REFERENCE.md) | Plugin action endpoints (test, fetch, observability, review queue). |
+| [Testing guide](./docs/TESTING_GUIDE.md) | Unit, integration, and E2E test patterns and how to run them. |
+| [Build instructions](./BUILD.md) | Full bootstrap: fetch Lidarr assemblies, build, and package. |
+| [Development guide](./DEVELOPMENT.md) | Local development workflows, debugging, and IDE setup. |
 
 Developers updating docs should also run `pwsh ./scripts/sync-provider-matrix.ps1` and `bash ./scripts/check-docs-consistency.sh` so the generated tables and badges stay aligned.
+
+### Wiki (`wiki-content/`)
+
+The wiki provides user-facing walk-throughs that complement the technical docs above.
+
+| Wiki page | Focus |
+| --- | --- |
+| [Home](./wiki-content/Home.md) | Orientation, install quick-start, provider matrix, and link index. |
+| [Start Here](./wiki-content/Start-Here.md) | Three-step onboarding checklist pointing to canonical docs. |
+| [Installation](./wiki-content/Installation.md) | Detailed install and Docker setup. |
+| [First Run Guide](./wiki-content/First-Run-Guide.md) | Walk-through from first config through optimization. |
+| [Provider Setup](./wiki-content/Provider-Setup.md) | Hub for per-provider configuration with dedicated guides. |
+| [Provider Basics](./wiki-content/Provider-Basics.md) | Quick comparisons — privacy, cost, speed. |
+| [Local Providers](./wiki-content/Local-Providers.md) | Ollama, LM Studio, hardware tips, and smoke tests. |
+| [Cloud Providers](./wiki-content/Cloud-Providers.md) | API keys, rate limits, model selection, and multi-provider failover. |
+| [Advanced Settings](./wiki-content/Advanced-Settings.md) | Discovery, confidence, sampling, strictness, and concurrency tuning. |
+| [Settings Best Practices](./wiki-content/Settings-Best-Practices.md) | Opinionated defaults by provider type and library size. |
+| [Review Queue](./wiki-content/Review-Queue.md) | Triage and approval workflow for borderline recommendations. |
+| [Timeouts & Retries](./wiki-content/Timeouts-and-Retries.md) | Timeout-aware budgets and retry behaviour summary. |
+| [Hallucination Reduction](./wiki-content/Hallucination-Reduction.md) | Practical settings and prompts to keep local-model results grounded. |
+| [Observability & Metrics](./wiki-content/Observability-and-Metrics.md) | Prometheus endpoint, metric keys, tuning playbooks, and dashboards. |
+| [Operations](./wiki-content/Operations.md) | Day-0 through day-N runbook: prerequisites, first-run validation, incident response. |
+| [Troubleshooting](./wiki-content/Troubleshooting.md) | Common issues and diagnostics (mirrors `docs/troubleshooting.md`). |
+
+### Shared library — Lidarr.Plugin.Common
+
+Brainarr is built on [Lidarr.Plugin.Common](https://github.com/RicherTunes/Lidarr.Plugin.Common). For foundation topics shared across the ecosystem:
+
+| Common wiki page | What it covers |
+| --- | --- |
+| [Home](https://github.com/RicherTunes/Lidarr.Plugin.Common/blob/main/wiki/Home.md) | Project overview, quick links, and cross-plugin conventions. |
+| [Architecture Overview](https://github.com/RicherTunes/Lidarr.Plugin.Common/blob/main/wiki/Architecture-Overview.md) | Plugin lifecycle, module wiring, and DI patterns. |
+| [SDK and Extension Points](https://github.com/RicherTunes/Lidarr.Plugin.Common/blob/main/wiki/SDK-and-Extension-Points.md) | Interfaces and base classes for providers, bridges, and services. |
+| [Shared Helpers Catalog](https://github.com/RicherTunes/Lidarr.Plugin.Common/blob/main/wiki/Shared-Helpers-Catalog.md) | Reusable utilities (caching, health, resilience, logging, security). |
+| [Versioning and Submodule Pinning](https://github.com/RicherTunes/Lidarr.Plugin.Common/blob/main/wiki/Versioning-and-Submodule-Pinning.md) | How Common versions are pinned, bumped, and validated across plugins. |
 
 ## Provider compatibility
 
@@ -250,7 +357,23 @@ Developers updating docs should also run `pwsh ./scripts/sync-provider-matrix.ps
 - Ollama: `qwen2.5:latest` (default) — balanced quality and speed for 1.3.x.
 - Ollama: `llama3.2:latest` or `llama3.2:8b` — solid fallback with smaller footprint.
 
-See the Hallucination Reduction guide for tuning tips and prompt examples: `wiki-content/Hallucination-Reduction.md`.
+See the [Hallucination Reduction guide](./wiki-content/Hallucination-Reduction.md) for tuning tips and prompt examples.
+
+### Provider model options
+
+For per-provider model lists, defaults, and subscription setup, see [docs/PROVIDER_GUIDE.md](./docs/PROVIDER_GUIDE.md). Key defaults:
+
+| Provider | Default model | Notes |
+| --- | --- | --- |
+| **Ollama** | `qwen2.5:latest` | Auto-detected from local instance |
+| **LM Studio** | `local-model` | Auto-detected from local instance |
+| **OpenAI** | `GPT41_Mini` | GPT-4.1 series available |
+| **Anthropic** | `ClaudeSonnet4` | Claude 4 Sonnet |
+| **Gemini** | `Gemini_25_Flash` | Gemini 2.5 Flash |
+| **Groq** | `Llama33_70B_Versatile` | Low-latency inference |
+| **DeepSeek** | `DeepSeek_Chat` | Budget-friendly |
+| **Perplexity** | `Sonar_Pro` | Web-augmented |
+| **OpenRouter** | `Auto` | Gateway to many models |
 
 ## Upgrade Notes: 1.3.0
 
@@ -262,6 +385,8 @@ Consult [docs/troubleshooting.md](./docs/troubleshooting.md) for symptom-driven 
 
 - **Prompt shows `headroom_guard` or trims frequently** – increase the provider context window, loosen style filters, or switch to a larger local model. After adjusting, run the list once to warm the cache and watch `prompt.plan_cache_*` metrics stabilize.
 - **Token counts look off** – add a model-specific tokenizer in the registry or accept the basic estimator after confirming the `tokenizer.fallback` metric fires only once per model. Track `prompt.actual_tokens` vs `prompt.tokens_pre` to confirm drift stays within the ±25% guardrail.
+
+For additional help, the wiki provides a dedicated [Troubleshooting](./wiki-content/Troubleshooting.md) page and the [Operations](./wiki-content/Operations.md) runbook covers incident response.
 
 ## Security
 
@@ -286,13 +411,6 @@ Brainarr is built on [Lidarr.Plugin.Common](https://github.com/RicherTunes/Lidar
 - `SmartCache<T>` — LRU-with-TTL cache backing recommendation plan storage
 
 **Ecosystem version contract:** Brainarr tracks `commonVersion: 1.18.0-dev`. The `ecosystem-parity-lint.ps1 -Check VersionContract` gate enforces that the plugin's `VERSION` file, `plugin.json`, and the Common submodule pin all agree. See [Common's ECOSYSTEM_VERSION_CONTRACT.md](https://github.com/RicherTunes/Lidarr.Plugin.Common/blob/main/docs/ECOSYSTEM_VERSION_CONTRACT.md) for details.
-
-## Documentation
-
-- [Changelog](CHANGELOG.md)
-- [Contributing](CONTRIBUTING.md)
-- [Security](SECURITY.md)
-- [Docs directory](docs/)
 
 ## Contributing
 


### PR DESCRIPTION
Richer README entry point: keeps the feature/capability overview and install, and adds a Documentation section deep-linking this repo's wiki, key docs, and the shared Common library wiki — no duplication. Net-positive; claims verified vs source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)