### PR TITLE
fix(ci): nightly packaging tests skip without a package + block host-coupled major dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,21 +30,28 @@ updates:
           - "Moq"
           - "xunit*"
     # Host-boundary packages: types cross plugin<->host boundary via NzbDrone APIs.
-    # Bumping major versions causes type-identity conflicts at runtime.
+    # The Lidarr plugins host ships Microsoft.Extensions.* 8.0.x, FluentValidation 9.x,
+    # and NLog 5.x. A merged plugin carrying a newer-MAJOR copy of any of these fails to
+    # load (type-identity / assembly-load conflicts) — Docker E2E + co-existence smoke fail.
     # Only bump when the Lidarr host itself upgrades first.
+    #
+    # Block ALL host-coupled major bumps so dependabot stops re-proposing host-incompatible
+    # upgrades. The wildcard `Microsoft.Extensions.*` major-block catches the whole family
+    # (DependencyInjection[.Abstractions], Logging[.Abstractions], Http, Options, Primitives,
+    # Caching.Abstractions, Caching.Memory) — including any future M.E.* package — so a bump
+    # like "Microsoft.Extensions.Caching.Memory 8.0.1 -> 10.0.8" can't slip through again.
     ignore:
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "FluentValidation"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "NLog"
-        versions: [">=6.0.0"]
+        update-types: ["version-update:semver-major"]
+      # Belt-and-suspenders pins narrower than the major-block above:
       - dependency-name: "FluentValidation"
         versions: [">9.5.4"]  # Must match Lidarr host exactly (pr-plugins-3.1.2.4913 ships 9.5.4)
-      - dependency-name: "Microsoft.Extensions.DependencyInjection"
-        versions: [">=9.0.0"]
-      - dependency-name: "Microsoft.Extensions.DependencyInjection.Abstractions"
-        versions: [">=9.0.0"]
-      - dependency-name: "Microsoft.Extensions.Logging.Abstractions"
-        versions: [">=9.0.0"]
       - dependency-name: "System.Text.Json"
-        versions: [">=9.0.0"]
+        versions: [">=9.0.0"]  # Host-provided; merged plugin must not carry a newer copy.
       - dependency-name: "Newtonsoft.Json"
         versions: [">13.0.3"]  # Must match Lidarr's version
       - dependency-name: "FluentAssertions"

--- a/Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests.cs
+++ b/Brainarr.Tests/Packaging/BrainarrPackagingPolicyTests.cs
@@ -51,11 +51,11 @@ namespace Brainarr.Tests.Packaging
             "Lidarr.Plugin.Common.dll"
         };
 
-        [PackagingFact]
+        [SkippableFact]
         [Trait("Category", "Packaging")]
         public void Package_Should_Contain_Required_Files()
         {
-            var zipPath = GetPackagePathOrThrow();
+            var zipPath = GetPackagePathOrSkip();
             var entries = ReadZipEntries(zipPath);
 
             entries.Should().Contain(RequiredFiles);
@@ -69,11 +69,11 @@ namespace Brainarr.Tests.Packaging
         /// the sidecar was correctly omitted by the packaging policy but the merge
         /// didn't actually merge anything.
         /// </summary>
-        [PackagingFact]
+        [SkippableFact]
         [Trait("Category", "Packaging")]
         public void Plugin_Dll_Should_Be_Merged_Size()
         {
-            var zipPath = GetPackagePathOrThrow();
+            var zipPath = GetPackagePathOrSkip();
             using var archive = ZipFile.OpenRead(zipPath);
 
             var entry = archive.Entries.FirstOrDefault(e =>
@@ -87,11 +87,11 @@ namespace Brainarr.Tests.Packaging
                 "'Could not load file or assembly Lidarr.Plugin.Abstractions/Common'");
         }
 
-        [PackagingFact]
+        [SkippableFact]
         [Trait("Category", "Packaging")]
         public void Package_Should_Not_Contain_Forbidden_Assemblies()
         {
-            var zipPath = GetPackagePathOrThrow();
+            var zipPath = GetPackagePathOrSkip();
             var entries = ReadZipEntries(zipPath);
 
             entries.Should().NotContain(ForbiddenAssemblies);
@@ -114,11 +114,11 @@ namespace Brainarr.Tests.Packaging
         ///
         /// The plugin must use the host's FluentValidation assembly for type identity to match.
         /// </summary>
-        [PackagingFact]
+        [SkippableFact]
         [Trait("Category", "Packaging")]
         public void Package_Must_Not_Ship_FluentValidation()
         {
-            var zipPath = GetPackagePathOrThrow();
+            var zipPath = GetPackagePathOrSkip();
             var entries = ReadZipEntries(zipPath);
 
             entries.Should().NotContain(
@@ -128,7 +128,21 @@ namespace Brainarr.Tests.Packaging
                 "when ValidationResult resolves from different assembly load contexts");
         }
 
-        private static string GetPackagePathOrThrow()
+        // Returns the package zip path, or SKIPS the test (via SkippableFact) when no package
+        // is present. Packaging tests only make sense once a package has been built — the
+        // dedicated packaging workflow (.github/workflows/plugin-package.yml) builds the zip,
+        // sets PLUGIN_PACKAGE_PATH, and validates the contents both here and via standalone
+        // unzip steps. Broad test runs (e.g. the Nightly workflow, which builds with
+        // PluginPackagingDisable=true and never produces a zip) would otherwise throw
+        // "No plugin package found" for all four packaging tests. Skipping there loses no
+        // coverage: packaging is independently gated by plugin-package.yml.
+        //
+        // One case still hard-fails: when an explicit package-path env var (PLUGIN_PACKAGE_PATH
+        // or BRAINARR_PACKAGE_PATH) is set but points at a non-existent file. That means a
+        // workflow promised a package and the build silently failed to produce it — a genuine
+        // error that must not be masked by a skip. (In plugin-package.yml the zip is also
+        // validated by separate unzip steps, so this is belt-and-suspenders.)
+        private static string GetPackagePathOrSkip()
         {
             var zipPath = PackagingTestPaths.TryFindPackagePath();
             if (zipPath != null)
@@ -136,12 +150,23 @@ namespace Brainarr.Tests.Packaging
                 return zipPath;
             }
 
-            if (PackagingTestPaths.IsStrictMode())
+            var explicitPath =
+                Environment.GetEnvironmentVariable("PLUGIN_PACKAGE_PATH") ??
+                Environment.GetEnvironmentVariable("BRAINARR_PACKAGE_PATH");
+
+            if (!string.IsNullOrWhiteSpace(explicitPath))
             {
-                throw new InvalidOperationException("No plugin package found. Set PLUGIN_PACKAGE_PATH or run `./build.ps1 -Package`.");
+                throw new InvalidOperationException(
+                    $"Package path '{explicitPath}' was set via env var but no file exists there. " +
+                    "The packaging build did not produce the expected zip. Run `./build.ps1 -Package`.");
             }
 
-            throw new InvalidOperationException("PackagingFact should have skipped when package is missing.");
+            Skip.If(true,
+                "No plugin package found. Packaging is gated by the plugin-package workflow; " +
+                "build a package (./build.ps1 -Package) or set PLUGIN_PACKAGE_PATH to run these tests locally.");
+
+            // Unreachable: Skip.If(true, ...) always throws SkipException.
+            throw new InvalidOperationException("Skip.If(true) should have skipped the test.");
         }
 
         private static HashSet<string> ReadZipEntries(string zipPath)


### PR DESCRIPTION
Fixes two CI failures. Scope is **test-gating + dependabot config only** — no provider/`src` code is touched.

## Failure 1 — Nightly: 4 packaging tests throw "No plugin package found"

`Brainarr.Tests.Packaging.BrainarrPackagingPolicyTests` (`Package_Should_Contain_Required_Files`, `Package_Must_Not_Ship_FluentValidation`, `Plugin_Dll_Should_Be_Merged_Size`, `Package_Should_Not_Contain_Forbidden_Assemblies`) all threw `InvalidOperationException: No plugin package found` under the **Nightly** workflow.

**Root cause:** The Nightly job builds with `PluginPackagingDisable=true` and never produces a package zip. The tests called `GetPackagePathOrThrow()`, and because GitHub Actions sets `CI=true`, the shared `PackagingTestPaths.IsStrictMode()` returns `true` — so `[PackagingFact]` did **not** skip and the helper threw for all four tests. `IsStrictMode()` conflated *"CI"* with *"a package was built"*, which only holds for the dedicated packaging workflow, not the nightly.

**Fix:** Convert the four tests to `[SkippableFact]` and replace `GetPackagePathOrThrow` with `GetPackagePathOrSkip`, which `Skip.If(...)`s when no package is discoverable. It still **hard-fails** when an explicit package-path env var (`PLUGIN_PACKAGE_PATH` / `BRAINARR_PACKAGE_PATH`) is set but the file is missing — a genuine "build promised a package and silently failed" error that must not be masked. `Xunit.SkippableFact` was already referenced in `Brainarr.Tests.csproj`.

**No coverage is lost:** packaging is independently gated by `.github/workflows/plugin-package.yml`, which builds the zip, sets `PLUGIN_PACKAGE_PATH` + `REQUIRE_PACKAGE_TESTS=true`, and validates contents (both via these unit tests and via standalone unzip steps).

Verified locally against the real merged DLL:

| Scenario | Result |
|---|---|
| `CI=true`, no package, no env path (the **nightly** case) | 4 **skipped** |
| `CI=true`, valid `PLUGIN_PACKAGE_PATH` (the **packaging-workflow** case) | 4 **passed** |
| `CI=true`, `PLUGIN_PACKAGE_PATH` → missing file (misconfig) | 4 **failed** (guard fires) |

## Failure 2 — Dependabot proposed a host-incompatible major bump

Dependabot PR #584 ("Bump Microsoft.Extensions.Caching.Memory from 8.0.1 to 10.0.8") broke **Docker E2E** + **co-existence smoke**. The Lidarr plugins host ships `Microsoft.Extensions.*` 8.0.x, so a merged plugin carrying a 10.x assembly fails to load. The existing ignore list pinned a few `M.E.*` packages individually but had **no rule for `Caching.Memory`**, so the bump slipped through.

**Fix:**
- Closed PR #584 with an explanatory comment.
- Added `ignore` rules to `.github/dependabot.yml` blocking **all** host-coupled major bumps:
  - `Microsoft.Extensions.*` (wildcard — catches the whole family incl. `Caching.Memory` and any future `M.E.*` package)
  - `FluentValidation`
  - `NLog`

  each with `update-types: ["version-update:semver-major"]`. Existing narrower pins (`FluentValidation >9.5.4`, `System.Text.Json`, `Newtonsoft.Json`, `FluentAssertions`) are retained as belt-and-suspenders. YAML validated well-formed.

## Verification

- `Brainarr.Tests` builds clean (0 errors); the three packaging scenarios above all behave as designed.
- Broader sanity slices pass: `Brainarr.Tests.Contracts` (5 passed) + `Brainarr.Tests.Configuration` (496 passed under `CI=true`).
- `.github/dependabot.yml` parses as valid YAML (2 ecosystems: nuget + github-actions; 7 nuget ignore entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)