### PR TITLE
fix(ci): notify-failure monitors "Nightly" not dead "Nightly Tests"

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -9,7 +9,7 @@ on:
   workflow_run:
     workflows:
       - "CI"
-      - "Nightly Tests"
+      - "Nightly"
       - "Test and Coverage"
       - "Sanity Build"
     types:


### PR DESCRIPTION
## Problem
`notify-failure.yml`'s `workflow_run` trigger monitors `"Nightly Tests"`, but **no brainarr workflow has that name**. The nightly workflows are `"Nightly"`, `"Nightly Live-Service Tests"`, `"Nightly Perf/Stress"`. So a failing nightly run fired **no** Discord/Slack notification — a silent observability gap. (`"CI"`, `"Test and Coverage"`, `"Sanity Build"` are correct.)

## Fix
Replace the dead `"Nightly Tests"` → `"Nightly"` (the core nightly run). Minimal 1:1 rename; the live-service and perf nightlies are intentionally left out to avoid notification noise from external-dependency/flaky runs.

## Verification
Actionlint + Workflow Auth Lint (live CI). Found via the ecosystem CI-drift audit; apple's notify-failure has the same dead `"Nightly Tests"` entry (billing-blocked CI, separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)