### PR TITLE
docs(wiki): fix stale Lidarr min-version stragglers

### DIFF
--- a/wiki-content/Operations.md
+++ b/wiki-content/Operations.md
@@ -8,7 +8,7 @@
 
 ## Day 0 – Confirm prerequisites
 
-- Lidarr nightly ≥ 2.14.2.4786 (README compatibility notice).
+- Lidarr nightly ≥ 3.0.0.4855 (README compatibility notice).
 - Brainarr built via `./setup.ps1` / `./setup.sh`; provider matrix regenerated if `docs/providers.yaml` changed.
 - Follow the README quick start and [docs/USER_SETUP_GUIDE.md](../docs/USER_SETUP_GUIDE.md) before proceeding.
 

--- a/wiki-content/Review-Queue.md
+++ b/wiki-content/Review-Queue.md
@@ -5,7 +5,7 @@
 # Review Queue
 
 > Compatibility
-> Requires Lidarr 2.14.2.4786+ on the plugins/nightly branch (Settings > General > Updates > Branch = nightly).
+> Requires Lidarr 3.0.0.4855+ on the plugins/nightly branch (Settings > General > Updates > Branch = nightly).
 
 The Review Queue is Brainarr’s safety net for borderline results. Keep the heavy guidance in sync by updating `docs/troubleshooting.md` first—this page highlights only the key workflow.
 


### PR DESCRIPTION
## Summary

`wiki-content/Operations.md` and `Review-Queue.md` still cited Lidarr **2.14.2.4786**; the real minimum is **3.0.0.4855** (`plugin.json`/`manifest.json` `minHostVersion`, and Home/Installation already updated). Two-line fix; verified against `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)