### PR TITLE
docs(readme): standardize headers + merge duplicate Upgrade Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Provenance
 - Each tagged release publishes a software bill of materials (SBOM) and a SHA-256 checksum.
 - Starting with v1.5.7, release ZIPs are also signed with Sigstore Cosign (keyless). Verify the `.sig` signature against the GitHub OIDC identity.
 
-## Shared Infrastructure
+## Built on Lidarr.Plugin.Common
 
 Brainarr is built on [Lidarr.Plugin.Common](https://github.com/RicherTunes/Lidarr.Plugin.Common) — the shared library for all RicherTunes Lidarr streaming plugins.
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ For detailed Docker and manual setup instructions, see the wiki's [Installation]
 
 See CHANGELOG.md for the complete 1.3.0 list.
 
+Read the focused upgrade checklist in [docs/upgrade-notes-1.3.0.md](./docs/upgrade-notes-1.3.0.md) for planner changes, cache behaviour updates, and post-upgrade actions.
+
 ## Screenshots
 
 - Landing
@@ -375,10 +377,6 @@ For per-provider model lists, defaults, and subscription setup, see [docs/PROVID
 | **Perplexity** | `Sonar_Pro` | Web-augmented |
 | **OpenRouter** | `Auto` | Gateway to many models |
 
-## Upgrade Notes: 1.3.0
-
-Read the focused upgrade checklist in [docs/upgrade-notes-1.3.0.md](./docs/upgrade-notes-1.3.0.md) for planner changes, cache behaviour updates, and post-upgrade actions.
-
 ## Troubleshooting
 
 Consult [docs/troubleshooting.md](./docs/troubleshooting.md) for symptom-driven guidance, cache reset tips, and links to tokenizer and provider diagnostics. Quick pointers:
@@ -421,7 +419,7 @@ Run the same sanity build locally as CI:
 - PowerShell: `pwsh ./test-local-ci.ps1 -ExcludeHeavy`
 - POSIX: `bash ./test-local-ci.sh --exclude-heavy`
 
-## ⚠️ Disclaimer
+## Disclaimer
 
 Brainarr is an independent, open-source project developed by RicherTunes for **educational and research purposes**. It generates music recommendations using AI providers and returns them to Lidarr as import-list items; it does not download or distribute copyrighted audio.
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Troubleshooting
 - [Upgrade Notes: 1.3.0](#upgrade-notes-130)
 - [Troubleshooting](#troubleshooting)
 - [Security](#security)
-- [Shared Infrastructure](#shared-infrastructure)
+- [Built on Lidarr.Plugin.Common](#built-on-lidarrplugincommon)
 - [Contributing](#contributing)
 
 ## What is Brainarr


### PR DESCRIPTION
## Summary

README-skeleton **standardization**:
- The page had **two** `## Upgrade Notes: 1.3.0` sections. Merged the unique doc-link line into the single retained section (no content lost) and removed the duplicate heading.
- Normalized `## ⚠️ Disclaimer` → `## Disclaimer` to match the canonical plain-header style.

Docs-only; no net content deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)