### PR TITLE
fix(topup): use resolved model key for top-up token estimates, not <default>

### DIFF
--- a/Brainarr.Plugin/Services/IterativeRecommendationStrategy.cs
+++ b/Brainarr.Plugin/Services/IterativeRecommendationStrategy.cs
@@ -171,6 +171,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 // Render the prompt under the (possibly escalated) discovery mode. The scope restores
                 // settings.DiscoveryMode immediately after so nothing else observes the override.
                 string prompt;
+                string? modelKey;
                 using (SettingScope.Apply(
                     getter: () => settings.DiscoveryMode,
                     setter: v => settings.DiscoveryMode = v,
@@ -185,11 +186,12 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                         rejectedAlbums,
                         allRecommendations,
                         rejectedNames,
+                        out modelKey,
                         shouldRecommendArtists,
                         validationReasons,
                         rejectedExamplesFromValidation);
                 }
-                try { tokenEstimates.Add(_promptBuilder.EstimateTokens(prompt)); }
+                try { tokenEstimates.Add(_promptBuilder.EstimateTokens(prompt, modelKey)); }
                 catch (OperationCanceledException) { throw; } // Propagate cancellation
                 catch (Exception) { /* Token estimation failure is non-critical */ }
 
@@ -264,7 +266,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                         try
                         {
                             var limit = _promptBuilder.GetEffectiveTokenLimit(settings.SamplingStrategy, settings.Provider);
-                            var est = _promptBuilder.EstimateTokens(prompt);
+                            var est = _promptBuilder.EstimateTokens(prompt, modelKey);
                             _logger.Info($"[Brainarr Debug] Iteration Summary => SuccessRate={successRate:P1}, Tokens≈{est}/{limit}, Requested={requestSize}, Unique={uniqueRecs.Count}");
                         }
                         catch (OperationCanceledException) { throw; }
@@ -437,6 +439,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
             HashSet<string> rejectedAlbums,
             List<Recommendation> existingRecommendations,
             List<string> rejectedNames,
+            out string? modelKey,
             bool shouldRecommendArtists = false,
             Dictionary<string, int>? validationReasons = null,
             List<Recommendation>? rejectedExamplesFromValidation = null)
@@ -453,6 +456,14 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
             {
                 baseRes = null;
             }
+
+            // Surface the resolved model key (e.g. "zaicoding:glm-5.1") the metrics path computed so
+            // the top-up's token-estimate diagnostics resolve the SAME model-specific tokenizer the
+            // initial prompt used — rather than passing null and silently falling back to the
+            // "<default>" tokenizer (which both diverges the estimate and emits a misleading
+            // "no tokenizer registered for <default>" WARN). Null/empty when unresolved; callers
+            // pass it straight through to EstimateTokens, whose registry treats blank as <default>.
+            modelKey = baseRes?.BudgetModelKey;
 
             // Backwards-compat fallback for tests/mocks that only implement BuildLibraryAwarePrompt
             if (string.IsNullOrWhiteSpace(basePrompt))
@@ -485,7 +496,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 try
                 {
                     var limit = _promptBuilder.GetEffectiveTokenLimit(settings.SamplingStrategy, settings.Provider);
-                    var est = _promptBuilder.EstimateTokens(prompt);
+                    var est = _promptBuilder.EstimateTokens(prompt, modelKey);
                     _logger.Info($"[Brainarr Debug] Iteration Tokens => Strategy={settings.SamplingStrategy}, Provider={settings.Provider}, Limit≈{limit}, EstimatedUsed≈{est}, Sampled: {baseRes.SampledArtists} artists, {baseRes.SampledAlbums} albums, Request={requestSize}");
                 }
                 catch (OperationCanceledException) { throw; }

--- a/Brainarr.Tests/Services/IterativeRecommendationStrategyAdvancedTests.cs
+++ b/Brainarr.Tests/Services/IterativeRecommendationStrategyAdvancedTests.cs
@@ -150,5 +150,58 @@ namespace Brainarr.Tests.Services
             Assert.Equal(3, result.Count);
             Assert.Equal(2, callCount);
         }
+
+        [Fact]
+        public async Task GetIterativeRecommendationsAsync_TopUpTokenEstimate_UsesResolvedModelKeyNotDefault()
+        {
+            // The initial (main) prompt path resolves the tokenizer via the budget's ModelKey
+            // (e.g. "ollama:test-model"), but the top-up loop historically called EstimateTokens(prompt)
+            // with no model key, so it silently fell back to the "<default>" tokenizer — emitting a
+            // misleading "no tokenizer registered for <default>" WARN and diverging from the main path's
+            // tokenizer. The top-up must thread the same BudgetModelKey the metrics path computed.
+            const string expectedModelKey = "ollama:test-model";
+
+            _mockPromptBuilder
+                .Setup(p => p.BuildLibraryAwarePromptWithMetrics(
+                    It.IsAny<LibraryProfile>(),
+                    It.IsAny<List<Artist>>(),
+                    It.IsAny<List<Album>>(),
+                    It.IsAny<BrainarrSettings>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(new LibraryPromptResult
+                {
+                    Prompt = "base prompt",
+                    SampledArtists = 1,
+                    SampledAlbums = 1,
+                    BudgetModelKey = expectedModelKey
+                });
+
+            // Drive at least one full iteration (provider returns a usable rec) so all top-up
+            // EstimateTokens diagnostics fire.
+            _mockProvider
+                .Setup(p => p.GetRecommendationsAsync(It.IsAny<string>()))
+                .ReturnsAsync(new List<Recommendation>
+                {
+                    new Recommendation { Artist = "New Artist", Album = "New Album" }
+                });
+
+            _settings.EnableDebugLogging = true; // gate for the Iteration Tokens / Summary diagnostics
+
+            // Act
+            await _strategy.GetIterativeRecommendationsAsync(
+                _mockProvider.Object, _profile, _existingArtists, _existingAlbums, _settings);
+
+            // Assert: the top-up estimated tokens against the resolved model key, never the
+            // null/empty key that resolves to the "<default>" tokenizer.
+            _mockPromptBuilder.Verify(
+                p => p.EstimateTokens(It.IsAny<string>(), expectedModelKey),
+                Times.AtLeastOnce(),
+                "top-up token estimation must use the resolved BudgetModelKey, not the <default> tokenizer");
+            _mockPromptBuilder.Verify(
+                p => p.EstimateTokens(It.IsAny<string>(), null),
+                Times.Never(),
+                "top-up must not estimate tokens with a null model key (falls back to <default>)");
+        }
     }
 }


### PR DESCRIPTION
## Problem

The initial (main) prompt path resolves its tokenizer via the budget's `ModelKey` (e.g. `zaicoding:glm-5.1`), but the iterative **top-up** loop called `EstimateTokens(prompt)` with **no model key** at all three of its diagnostic call sites (`tokenEstimates.Add`, "Iteration Tokens", "Iteration Summary").

With a null key, `ModelTokenizerRegistry.Get` falls back to the `BasicTokenizer` under the synthetic `<default>` label. Consequences, observed live on lidarr-e2e (GLM_5_1):

1. Every **multi-iteration** top-up run emitted a misleading second WARN:
   `Tokenizer fallback: no tokenizer registered for "<default>"` — implying a distinct, unconfigured model when it's really the same `zaicoding:glm-5.1` already warned about.
2. The top-up's token estimates were computed against a **different tokenizer** than the main prompt path (inconsistent token accounting in the `[Brainarr Debug] Iteration Tokens`/`Summary` lines).

## Fix

`BuildIterativePrompt` already builds the metrics result (`LibraryPromptResult`) whose `BudgetModelKey` is the exact key the main path uses. Surface it via an `out` param and thread it to the three top-up `EstimateTokens` calls so the top-up resolves the **same** model-specific tokenizer.

- No new dependency (uses already-computed state).
- No behavior change beyond tokenizer selection + the log label.
- The test/mock backwards-compat fallback (`BuildLibraryAwarePrompt`) is intentionally left as-is — `BudgetModelKey` isn't available there.

## Measured impact (live, lidarr-e2e, styles = shoegaze/post-rock/slowcore)

| | pre-fix run | post-fix run |
|---|---|---|
| `no tokenizer registered for "<default>"` WARN | **1** | **0** |
| `no tokenizer registered for "zaicoding:glm-5.1"` WARN (WarnOnce) | 1 | 1 |

The `<default>` noise is eliminated; the real-model WARN still fires exactly once and is now shared (WarnOnce) across the main and top-up phases.

## Tests

Strict TDD. New characterization test `GetIterativeRecommendationsAsync_TopUpTokenEstimate_UsesResolvedModelKeyNotDefault` asserts the top-up estimates against the resolved `BudgetModelKey` and **never** with a null key. RED before the fix, GREEN after.

Full suite: **3102 passed / 0 failed / 18 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)