### PR TITLE
fix(parser): strip markdown code fence before strict JSON parse to kill GLM log noise

### DIFF
--- a/Brainarr.Plugin/Services/Providers/Parsing/RecommendationJsonParser.cs
+++ b/Brainarr.Plugin/Services/Providers/Parsing/RecommendationJsonParser.cs
@@ -20,6 +20,16 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Providers.Parsing
             var results = new List<Recommendation>();
             if (string.IsNullOrWhiteSpace(json)) return results;
 
+            // Strip a leading/trailing Markdown code fence (```json … ```, or a bare ```) BEFORE the
+            // strict parse. Verbose chat models (Z.AI Coding / GLM in particular, but also OpenRouter,
+            // DeepSeek, etc.) wrap their JSON answer in a fence; the strict parse then throws on the
+            // opening backtick ("'`' is an invalid start of a value") and only the salvage path below
+            // recovered the items — emitting a misleading exception-bearing Debug line on every
+            // otherwise-successful run. Cleaning the fence up front lets the strict parse succeed, so
+            // there is no exception to capture and no noise. This is a generic clean (not GLM-only) and
+            // a no-op for unfenced payloads, so it cannot regress providers that already return raw JSON.
+            json = StripCodeFence(json);
+
             // Captured (not logged immediately): the primary parse may throw on a truncated/fenced
             // payload that salvage recovers below. The log LEVEL is decided at the end from the outcome.
             Exception parseFailure = null;
@@ -287,6 +297,46 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Providers.Parsing
                         break;
                 }
             }
+        }
+
+        /// <summary>
+        /// Removes a Markdown code fence wrapping the payload so the strict parse sees raw JSON.
+        /// Handles the common chat-model shapes: an opening <c>```</c> optionally followed by a
+        /// language tag (<c>```json</c>, <c>```JSON</c>) on its own line, and a closing <c>```</c>
+        /// line. The closing fence is optional — a response truncated at the token cap keeps the
+        /// opening fence but loses the close, and we still want to drop the leading backtick that
+        /// makes the strict parse throw. Returns the input unchanged when no fence is present (so it
+        /// never alters raw-JSON payloads), and leaves any non-fence prose around the JSON intact for
+        /// the existing array-extraction / salvage passes to handle.
+        /// </summary>
+        private static string StripCodeFence(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return text;
+
+            var trimmed = text.Trim();
+
+            // Only act when the payload actually starts with a fence; otherwise leave it untouched so
+            // prose-wrapped JSON (e.g. "Some text before ```json [..] ```") still flows to the
+            // text-extraction fallback unchanged.
+            if (!trimmed.StartsWith("```", StringComparison.Ordinal))
+            {
+                return text;
+            }
+
+            // Drop the opening fence line in full (covers ``` and ```<lang>). The fence marker runs to
+            // the end of its line; the JSON begins on the next line.
+            var afterOpen = trimmed.Substring(3);
+            var newline = afterOpen.IndexOf('\n');
+            var body = newline >= 0 ? afterOpen.Substring(newline + 1) : afterOpen;
+
+            // Drop a trailing closing fence if present (it may be absent on a truncated response).
+            body = body.TrimEnd();
+            if (body.EndsWith("```", StringComparison.Ordinal))
+            {
+                body = body.Substring(0, body.Length - 3);
+            }
+
+            return body.Trim();
         }
 
         private static string TryExtractJsonArrayFromText(string text)

--- a/Brainarr.Tests/Services/Providers/Parsing/RecommendationJsonParserSalvageLogLevelTests.cs
+++ b/Brainarr.Tests/Services/Providers/Parsing/RecommendationJsonParserSalvageLogLevelTests.cs
@@ -27,6 +27,48 @@ namespace Brainarr.Tests.Services.Providers.Parsing
             return (factory.GetLogger(name), warnTarget, factory);
         }
 
+        // Capture DEBUG-and-above, rendering any attached exception. The fence-noise we are killing is
+        // a Debug line ("Primary recommendations-JSON parse failed but recovered N item(s)...") that
+        // carries the full JsonReaderException render — invisible to WarnCapture but spammed on every
+        // GLM run because the live host logs at Debug. An empty target == "primary parse did not fail".
+        private static (Logger logger, MemoryTarget debugTarget, LogFactory factory) DebugCapture(string name)
+        {
+            var debugTarget = new MemoryTarget { Layout = "${message}${onexception:|${exception:format=Type,Message}}" };
+            var config = new LoggingConfiguration();
+            config.AddRule(LogLevel.Debug, LogLevel.Fatal, debugTarget, name);
+            var factory = new LogFactory(config);
+            return (factory.GetLogger(name), debugTarget, factory);
+        }
+
+        [Fact]
+        public void CompleteFencedPayload_ParsesCleanly_NoPrimaryParseFailureNoise()
+        {
+            // The dominant live GLM shape: a COMPLETE, well-formed JSON array wrapped in a ```json fence
+            // (response did NOT truncate). Before the fix the strict parse threw JsonReaderException on
+            // the leading backtick and the catch logged a Debug line carrying the full exception render
+            // on every successful run (~5x/session). After the fix the fence is stripped BEFORE the
+            // strict parse, so the strict parse succeeds: items are extracted AND no parse-failure /
+            // exception line is logged at all.
+            var content = "```json\n[\n" +
+                          "  { \"artist\": \"Nujabes\", \"album\": \"Modal Soul\", \"confidence\": 0.95 },\n" +
+                          "  { \"artist\": \"J Dilla\", \"album\": \"Donuts\", \"confidence\": 0.9 }\n" +
+                          "]\n```";
+
+            var (logger, debugTarget, factory) = DebugCapture("complete-fence");
+            using (factory)
+            {
+                var list = RecommendationJsonParser.Parse(content, logger);
+
+                list.Should().HaveCount(2, "the fenced array is complete and must parse fully");
+                debugTarget.Logs.Should().NotContain(
+                    l => l.Contains("Primary recommendations-JSON parse failed"),
+                    "stripping the fence before the strict parse must make the primary parse succeed");
+                debugTarget.Logs.Should().NotContain(
+                    l => l.Contains("JsonReaderException"),
+                    "no JsonReaderException should be captured/rendered when the fence is stripped up front");
+            }
+        }
+
         [Fact]
         public void TruncatedPayload_SalvageRecovers_DoesNotWarn()
         {


### PR DESCRIPTION
## Problem

Verbose chat models (Z.AI Coding / GLM in particular, also OpenRouter/DeepSeek) wrap their recommendation JSON in a ` ```json ` Markdown fence. `RecommendationJsonParser.Parse` attempted the strict `System.Text.Json` parse on the **raw fenced text**, which throws:

```
System.Text.Json.JsonReaderException: '`' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0.
```

on the opening backtick. The salvage fallback then recovered the items correctly, but the deferred `catch` logged a **Debug line carrying the full exception render** on *every otherwise-successful run*. Observed live on the `lidarr-e2e` `zaicoding/GLM_5_1` import list ~5×/session, e.g.:

```
Debug|Brainarr|Primary recommendations-JSON parse failed but recovered 20 item(s) via fallback/salvage; not warning
[v3.1.2.4913] System.Text.Json.JsonReaderException: '`' is an invalid start of a value...
   at ... LlmJsonSerializer.ParseDocumentRelaxed(String json)
   at ... RecommendationJsonParser.Parse(String json, Logger logger)
```

Misleading log noise + latent fragility (recovery depended on the catch path firing).

## Fix

Strip a leading/trailing Markdown code fence **before** the strict parse (`StripCodeFence`). On the dominant complete-fence case the strict parse now succeeds → no exception captured → no noisy Debug line. 

- **Generic, not GLM-only**: helps any provider that fences (` ```json `, ` ```JSON `, bare ` ``` `).
- **No-op for unfenced payloads** (returns input unchanged unless it starts with a fence) → cannot regress providers that return raw JSON.
- **Salvage fallback retained unchanged** as defense for truncated responses (where the closing fence is lost at the token cap).
- Prose-wrapped JSON still flows to the existing `TryExtractJsonArrayFromText` fallback.

## TDD

- **RED**: `CompleteFencedPayload_ParsesCleanly_NoPrimaryParseFailureNoise` reproduces the exact live noise (a complete fenced array logs the `JsonReaderException`-bearing Debug line). Captured at Debug level since the noise is invisible to the existing WARN-only assertions.
- **GREEN**: after the fix the same payload parses fully with **no** parse-failure / exception line.
- Full suite: **3103 passed / 0 failed / 18 skipped** (quarantined OOM + Docker-gated).

## Scope

2 files: `RecommendationJsonParser.cs` (+ helper) and its log-level test. No Common/submodule changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)