### PR TITLE
ci(plugin-package): set LIDARR_PATH so TestKit shim compiles (fix CS0234)

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -12,6 +12,7 @@ on:
       - "Nightly"
       - "Test and Coverage"
       - "Sanity Build"
+      - "📦 Plugin Package"
     types:
       - completed
 

--- a/.github/workflows/plugin-package.yml
+++ b/.github/workflows/plugin-package.yml
@@ -93,6 +93,15 @@ jobs:
           exit 1
         fi
 
+    - name: Set LIDARR_PATH
+      shell: bash
+      # Export the extracted Lidarr assemblies path so Brainarr.Tests + the Common TestKit
+      # resolve $(LidarrPath) when the packaging-validation step builds the test project.
+      # Without this, the TestKit drops Http/HttpResponseFactory.cs from compilation
+      # (it requires Lidarr.Common.dll), and the Brainarr.Tests forwarding shim fails with
+      # CS0234. Matches the green "Test and Coverage" job (which sets LIDARR_PATH).
+      run: echo "LIDARR_PATH=${{ github.workspace }}/ext/Lidarr-docker/_output/net8.0" >> "$GITHUB_ENV"
+
     - name: Build Plugin
       shell: bash
       run: |
@@ -191,7 +200,8 @@ jobs:
         dotnet test Brainarr.Tests/Brainarr.Tests.csproj \
           --configuration Release \
           --filter "Category=Packaging" \
-          --nologo
+          --nologo \
+          -p:PluginPackagingDisable=true
 
     - name: Upload Package Artifact
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Problem
The push-only **📦 Plugin Package** workflow's job **Build Plugin Package** → step **Validate packaging policy (unit tests)** has been failing on every push to `main` (latent red for 12+ consecutive pushes, predating #623). Failing run: [26832812666](https://github.com/RicherTunes/Brainarr/actions/runs/26832812666).

It fails to compile `Brainarr.Tests` with **CS0234** at `Brainarr.Tests/Helpers/HttpResponseFactory.cs` (lines 17/20/23/26):
> The type or namespace name 'HttpResponseFactory' does not exist in the namespace 'Lidarr.Plugin.Common.TestKit.Http'

The "Test and Coverage" job compiles the same shim fine on the same commit — so this is a **build-config difference, not a missing type / not a pin issue / not from #623**.

## Root cause
`ext/Lidarr.Plugin.Common/testkit/Lidarr.Plugin.Common.TestKit.csproj` removes `Http/HttpResponseFactory.cs` from compilation when `$(LidarrPath)` does **not** resolve to a directory containing `Lidarr.Common.dll`:

```xml
<ItemGroup Condition="'$(LidarrPath)' == '' OR !Exists('$(LidarrPath)\Lidarr.Common.dll')">
  <Compile Remove="Http\HttpResponseFactory.cs" />
</ItemGroup>
```

The Plugin Package job extracts assemblies to `ext/Lidarr-docker/_output/net8.0` but **never exports `LIDARR_PATH`** — the only `LidarrPath` it sets is an MSBuild property scoped to the single "Build Plugin" `dotnet build`. The "Validate packaging policy" step then runs `dotnet test Brainarr.Tests` (no `--no-build`, no `LidarrPath`), so the TestKit builds with `$(LidarrPath)` empty → `HttpResponseFactory.cs` is dropped → the type is absent → the forwarding shim fails with CS0234.

The TestKit csproj's own fallback paths look for `ext/Lidarr/_output/net8.0` (not `Lidarr-docker`), so on a fresh runner they never resolve either.

The green **Test and Coverage** job avoids this because it exports `LIDARR_PATH` (and passes `-p:PluginPackagingDisable=true`).

## Fix (workflow-only, no test code / no repin)
- `plugin-package.yml`: add a **Set LIDARR_PATH** step (mirrors Test and Coverage) exporting `LIDARR_PATH=…/ext/Lidarr-docker/_output/net8.0` to `$GITHUB_ENV` before the build/test steps.
- `plugin-package.yml`: add `-p:PluginPackagingDisable=true` to the validation `dotnet test` for parity with the green job.
- `notify-failure.yml`: add `"📦 Plugin Package"` to the monitored-workflows list — it was missing, which is why notify showed **skipped** on the failing pushes (this failure class never alerted).

No production code touched; no submodule re-pin; the `HttpResponseFactory.cs` shim is unchanged.

## Validation (local, CI-faithful)
Reproduced on a clean worktree with assemblies extracted to `ext/Lidarr-docker/_output/net8.0` and `ext/Lidarr/_output` absent (matches the runner):
- **Before** (`dotnet build Brainarr.Tests` with no `LIDARR_PATH`): CS0234 at lines 17/20/23/26 — exact CI repro.
- **After** (`LIDARR_PATH` exported): `Build succeeded. 0 Error(s)`, and `dotnet test --filter Category=Packaging` → **Passed! 4 passed, 0 failed**.

`actionlint` passes on both edited workflows.

> Note: the Plugin Package workflow only runs on push-to-main + `workflow_dispatch` (not on PRs), so this PR's checks won't include it. After merge I'll dispatch a Plugin Package run on the new `main` SHA to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)