### PR TITLE
fix(topup): MBID-enrich + gate album-mode top-up recs (RequireMbids parity)

### DIFF
--- a/Brainarr.Plugin/Services/Core/ITopUpPlanner.cs
+++ b/Brainarr.Plugin/Services/Core/ITopUpPlanner.cs
@@ -25,6 +25,8 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
             // T1: recommendations already delivered this run (avoid re-suggesting them in top-up).
             IReadOnlyList<ImportListItemInfo>? alreadyAccepted = null,
             // T2: resolver used to MBID-enrich top-up recs before the require-MBID filter (artist mode).
-            IArtistMbidResolver? artistResolver = null);
+            IArtistMbidResolver? artistResolver = null,
+            // Album-mode parity: resolver used to MBID-enrich album top-up recs before the require-MBID gate.
+            IMusicBrainzResolver? mbidResolver = null);
     }
 }

--- a/Brainarr.Plugin/Services/Core/RecommendationPipeline.cs
+++ b/Brainarr.Plugin/Services/Core/RecommendationPipeline.cs
@@ -203,7 +203,9 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
                     // T1: exclude the already-delivered set from the top-up prompt + dedup.
                     alreadyAccepted: importItems,
                     // T2: MBID-enrich top-up recs (artist mode) with the same resolver as the initial batch.
-                    artistResolver: _artistResolver).ConfigureAwait(false) ?? new List<ImportListItemInfo>();
+                    artistResolver: _artistResolver,
+                    // Album-mode parity: enrich album top-up recs with the same MBID resolver as the first pass.
+                    mbidResolver: _mbidResolver).ConfigureAwait(false) ?? new List<ImportListItemInfo>();
                 if (topUp.Count > 0)
                 {
                     var beforeAdd = importItems.Count;

--- a/Brainarr.Plugin/Services/Core/TopUpPlanner.cs
+++ b/Brainarr.Plugin/Services/Core/TopUpPlanner.cs
@@ -38,7 +38,8 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
             NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult? initialValidation,
             CancellationToken cancellationToken,
             IReadOnlyList<ImportListItemInfo>? alreadyAccepted = null,
-            IArtistMbidResolver? artistResolver = null)
+            IArtistMbidResolver? artistResolver = null,
+            IMusicBrainzResolver? mbidResolver = null)
         {
             var importItems = new List<ImportListItemInfo>();
             if (provider == null)
@@ -137,6 +138,30 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
                         topUpRecs = topUpRecs.Where(r => !string.IsNullOrWhiteSpace(r.ArtistMusicBrainzId)).ToList();
                         // Genuinely-unresolvable artists still drop (real gate, not a bug) — but the drop
                         // is now ATTRIBUTED in the summary below instead of silently lost.
+                        noMbidDropped = beforeMbidFilter - topUpRecs.Count;
+                    }
+                    else if (!shouldRecommendArtists && settings.RequireMbids)
+                    {
+                        // Album-mode parity with the artist-mode T2 fix above: album top-up recs also arrive
+                        // from the provider WITHOUT MBIDs and are not enrichment-resolved anywhere else on the
+                        // top-up path (the initial-batch MusicBrainz enrichment at RecommendationPipeline runs
+                        // BEFORE top-up). Without this, every album top-up item was added RAW — bypassing the
+                        // RequireMbids gate the first pass enforces (SafetyGateService requires BOTH artist and
+                        // album MBIDs in album mode), so the user's MBID-reliability contract silently did not
+                        // apply to top-up items. Resolve here with the SAME injected resolver as the initial
+                        // batch (bounded by the deficit; the resolver owns its rate-limit/LRU cache).
+                        if (mbidResolver != null)
+                        {
+                            topUpRecs = await mbidResolver.EnrichWithMbidsAsync(topUpRecs, cancellationToken).ConfigureAwait(false);
+                        }
+                        var beforeMbidFilter = topUpRecs.Count;
+                        enrichmentDropped = suggested - beforeMbidFilter;
+                        // Album mode needs BOTH artist+album MBIDs for reliable import mapping (mirrors the
+                        // first-pass gate). Items still missing either after enrichment drop here — now
+                        // ATTRIBUTED in the summary below rather than slipping through unguarded.
+                        topUpRecs = topUpRecs
+                            .Where(r => !string.IsNullOrWhiteSpace(r.ArtistMusicBrainzId) && !string.IsNullOrWhiteSpace(r.AlbumMusicBrainzId))
+                            .ToList();
                         noMbidDropped = beforeMbidFilter - topUpRecs.Count;
                     }
 

--- a/Brainarr.Tests/Services/Core/RecommendationPipelineTests.cs
+++ b/Brainarr.Tests/Services/Core/RecommendationPipelineTests.cs
@@ -161,7 +161,7 @@ namespace Brainarr.Tests.Services.Core
                 dedup.Verify(d => d.DeduplicateRecommendations(It.IsAny<List<ImportListItemInfo>>()), Times.AtLeastOnce);
                 topUp.Verify(t => t.TopUpAsync(
                     It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(),
-                    It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()), Times.Never);
+                    It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()), Times.Never);
             }
             finally { try { Directory.Delete(tmp, true); } catch { } }
         }
@@ -225,7 +225,7 @@ namespace Brainarr.Tests.Services.Core
                         It.IsAny<IDuplicationPrevention>(),
                         It.IsAny<LibraryProfile>(),
                         It.Is<int>(need => need >= 1 && need <= 3),
-                        It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()))
+                        It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()))
                     .ReturnsAsync(new List<ImportListItemInfo>
                     {
                         new ImportListItemInfo { Artist = "B" },
@@ -289,7 +289,7 @@ namespace Brainarr.Tests.Services.Core
                         It.IsAny<IDuplicationPrevention>(),
                         It.IsAny<LibraryProfile>(),
                         It.Is<int>(need => need == 2),
-                        It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()))
+                        It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()))
                     .ReturnsAsync(new List<ImportListItemInfo>
                     {
                         new ImportListItemInfo { Artist = "B" },
@@ -433,7 +433,7 @@ namespace Brainarr.Tests.Services.Core
                     CancellationToken.None);
 
                 Assert.Single(items);
-                topUp.Verify(t => t.TopUpAsync(It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()), Times.Never);
+                topUp.Verify(t => t.TopUpAsync(It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()), Times.Never);
             }
             finally { try { Directory.Delete(tmp, true); } catch { } }
         }
@@ -460,7 +460,7 @@ namespace Brainarr.Tests.Services.Core
                     .Returns(new List<Recommendation>());
 
                 topUp.Setup(t => t.TopUpAsync(
-                        It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()))
+                        It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()))
                     .ReturnsAsync(new List<ImportListItemInfo> { new ImportListItemInfo { Artist = "A", Album = "B" }, new ImportListItemInfo { Artist = "C", Album = "D" } });
 
                 var callOrder = new List<string>();
@@ -517,7 +517,7 @@ namespace Brainarr.Tests.Services.Core
                     });
                 // Return no top-up items to stay under target
                 topUp.Setup(t => t.TopUpAsync(
-                        It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()))
+                        It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()))
                     .ReturnsAsync(new List<ImportListItemInfo>());
 
                 var items = await pipeline.ProcessAsync(
@@ -705,7 +705,7 @@ namespace Brainarr.Tests.Services.Core
                     CancellationToken.None);
 
                 Assert.Equal(2, items.Count);
-                topUp.Verify(t => t.TopUpAsync(It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()), Times.Never);
+                topUp.Verify(t => t.TopUpAsync(It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()), Times.Never);
             }
             finally
             {
@@ -743,7 +743,7 @@ namespace Brainarr.Tests.Services.Core
                         It.IsAny<IDuplicationPrevention>(),
                         It.IsAny<LibraryProfile>(),
                         It.IsAny<int>(),
-                        It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()))
+                        It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()))
                     .ReturnsAsync(new List<ImportListItemInfo>
                     {
                         new ImportListItemInfo { Artist = "E", Album = "F" },
@@ -769,7 +769,7 @@ namespace Brainarr.Tests.Services.Core
                     It.IsAny<IDuplicationPrevention>(),
                     It.IsAny<LibraryProfile>(),
                     It.Is<int>(needed => needed == 3),
-                    It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()), Times.Once);
+                    It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()), Times.Once);
             }
             finally
             {
@@ -813,7 +813,7 @@ namespace Brainarr.Tests.Services.Core
                 artists.Verify(a => a.EnrichArtistsAsync(It.IsAny<List<Recommendation>>(), It.IsAny<CancellationToken>()), Times.Never);
                 gates.Verify(g => g.ApplySafetyGates(It.IsAny<List<Recommendation>>(), It.IsAny<BrainarrSettings>(), It.IsAny<ReviewQueueService>(), It.IsAny<RecommendationHistory>(), It.IsAny<Logger>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Performance.IPerformanceMetrics>(), It.IsAny<CancellationToken>()), Times.Never);
                 dedup.Verify(d => d.DeduplicateRecommendations(It.IsAny<List<ImportListItemInfo>>()), Times.Never);
-                topUp.Verify(t => t.TopUpAsync(It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()), Times.Never);
+                topUp.Verify(t => t.TopUpAsync(It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()), Times.Never);
             }
             finally { try { Directory.Delete(tmp, true); } catch { } }
         }
@@ -858,7 +858,7 @@ namespace Brainarr.Tests.Services.Core
 
                 topUp.Setup(t => t.TopUpAsync(
                         It.IsAny<BrainarrSettings>(), It.IsAny<IAIProvider>(), It.IsAny<ILibraryAnalyzer>(), It.IsAny<ILibraryAwarePromptBuilder>(),
-                        It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()))
+                        It.IsAny<IDuplicationPrevention>(), It.IsAny<LibraryProfile>(), It.IsAny<int>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(), It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()))
                     .ReturnsAsync(new List<ImportListItemInfo>());
 
                 var items = await pipeline.ProcessAsync(
@@ -1372,7 +1372,7 @@ namespace Brainarr.Tests.Services.Core
                     It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(),
                     It.IsAny<LibraryProfile>(), It.IsAny<int>(),
                     It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(),
-                    It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()), Times.Never);
+                    It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()), Times.Never);
             }
             finally { try { Directory.Delete(tmp, true); } catch { } }
         }
@@ -1544,7 +1544,7 @@ namespace Brainarr.Tests.Services.Core
                     It.IsAny<ILibraryAwarePromptBuilder>(), It.IsAny<IDuplicationPrevention>(),
                     It.IsAny<LibraryProfile>(), It.IsAny<int>(),
                     It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.ValidationResult>(),
-                    It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>()), Times.Never);
+                    It.IsAny<CancellationToken>(), It.IsAny<System.Collections.Generic.IReadOnlyList<NzbDrone.Core.Parser.Model.ImportListItemInfo>>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IArtistMbidResolver>(), It.IsAny<NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment.IMusicBrainzResolver>()), Times.Never);
             }
             finally { try { Directory.Delete(tmp, true); } catch { } }
         }

--- a/Brainarr.Tests/Services/Core/TopUpDeliveredExclusionEnrichmentTests.cs
+++ b/Brainarr.Tests/Services/Core/TopUpDeliveredExclusionEnrichmentTests.cs
@@ -137,6 +137,89 @@ namespace Brainarr.Tests.Services.Core
             resolver.Verify(r => r.EnrichArtistsAsync(It.IsAny<List<Recommendation>>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
         }
 
+        // ---------- Album-mode parity: top-up MBID-enriches + gates album recs (same gap as T2, for albums) ----------
+
+        [Fact]
+        [Trait("Category", "TopUp")]
+        public async Task TopUp_AlbumMode_WithRequireMbids_EnrichesTopUpRecs_SoResolvableAlbumSurvivesMbidFilter()
+        {
+            var (planner, provider, analyzer, prompt, dedup, _) = Build();
+
+            // Provider returns two NEW album recs, neither carrying MBIDs (as real GLM output never does).
+            List<Recommendation> Returned() => new List<Recommendation>
+            {
+                Rec("Boards of Canada", "Music Has the Right to Children"),
+                Rec("Obscure Krautrock Act", "Unknown Tape")
+            };
+            provider.Setup(p => p.GetRecommendationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Returned);
+            provider.Setup(p => p.GetRecommendationsAsync(It.IsAny<string>())).ReturnsAsync(Returned);
+
+            // The album resolver assigns BOTH artist+album MBIDs to the resolvable album, leaves the other bare.
+            var mbidResolver = new Mock<IMusicBrainzResolver>();
+            mbidResolver.Setup(r => r.EnrichWithMbidsAsync(It.IsAny<List<Recommendation>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<Recommendation> recs, CancellationToken ct) =>
+                    recs.Select(r => r.Artist == "Boards of Canada"
+                        ? r with { ArtistMusicBrainzId = "mbid-boc", AlbumMusicBrainzId = "rg-mhtrtc" }
+                        : r).ToList());
+
+            var settings = new BrainarrSettings
+            {
+                Provider = AIProvider.Ollama,
+                MaxRecommendations = 10,
+                RecommendationMode = RecommendationMode.SpecificAlbums,
+                RequireMbids = true
+            };
+
+            var result = await planner.TopUpAsync(
+                settings, provider.Object, analyzer.Object, prompt.Object, dedup.Object,
+                new LibraryProfile(), needed: 2, initialValidation: null, cancellationToken: CancellationToken.None,
+                alreadyAccepted: null, artistResolver: null, mbidResolver: mbidResolver.Object);
+
+            // Album-mode top-up must MBID-enrich (parity with artist mode) and gate the unresolvable album,
+            // so the user's RequireMbids contract holds for top-up items exactly as it does on the first pass.
+            result.Should().ContainSingle();
+            result[0].Artist.Should().Be("Boards of Canada");
+            result[0].AlbumMusicBrainzId.Should().Be("rg-mhtrtc");
+            result[0].ArtistMusicBrainzId.Should().Be("mbid-boc");
+            mbidResolver.Verify(r => r.EnrichWithMbidsAsync(It.IsAny<List<Recommendation>>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        [Trait("Category", "TopUp")]
+        public async Task TopUp_AlbumMode_WithoutRequireMbids_DoesNotDropUnenrichedRecs()
+        {
+            var (planner, provider, analyzer, prompt, dedup, _) = Build();
+
+            List<Recommendation> Returned() => new List<Recommendation>
+            {
+                Rec("Boards of Canada", "Music Has the Right to Children"),
+                Rec("Obscure Krautrock Act", "Unknown Tape")
+            };
+            provider.Setup(p => p.GetRecommendationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Returned);
+            provider.Setup(p => p.GetRecommendationsAsync(It.IsAny<string>())).ReturnsAsync(Returned);
+
+            // Resolver enriches neither (simulating MusicBrainz misses); without RequireMbids nothing is gated.
+            var mbidResolver = new Mock<IMusicBrainzResolver>();
+            mbidResolver.Setup(r => r.EnrichWithMbidsAsync(It.IsAny<List<Recommendation>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<Recommendation> recs, CancellationToken ct) => recs);
+
+            var settings = new BrainarrSettings
+            {
+                Provider = AIProvider.Ollama,
+                MaxRecommendations = 10,
+                RecommendationMode = RecommendationMode.SpecificAlbums,
+                RequireMbids = false
+            };
+
+            var result = await planner.TopUpAsync(
+                settings, provider.Object, analyzer.Object, prompt.Object, dedup.Object,
+                new LibraryProfile(), needed: 2, initialValidation: null, cancellationToken: CancellationToken.None,
+                alreadyAccepted: null, artistResolver: null, mbidResolver: mbidResolver.Object);
+
+            // RequireMbids off: both album recs flow through (no MBID gate), matching first-pass behavior.
+            result.Should().HaveCount(2);
+        }
+
         [Fact]
         [Trait("Category", "TopUp")]
         public async Task TopUp_ExcludesAlreadyDelivered_AndReturnsOnlyResolvedNewArtists()


### PR DESCRIPTION
## Problem

Album-mode iterative top-up added provider recommendations **raw**, bypassing the `RequireMbids` gate the first pass enforces.

`TopUpPlanner.TopUpAsync` only MBID-enriched and gated top-up recs for **artist mode** (the prior T2 fix, `TopUpDeliveredExclusionEnrichmentTests`), and was never passed an `IMusicBrainzResolver`. In **album mode** with `RequireMbids = true`, the enforcement block (`if (shouldRecommendArtists && settings.RequireMbids)`) was skipped entirely, so album top-up items were added with no MBID resolution and no gate — even though the first pass (`RecommendationPipeline` → `MusicBrainzResolver.EnrichWithMbidsAsync` + `SafetyGateService`) requires **both** artist and album MBIDs in album mode.

Net effect: the user's MBID-reliability contract silently did not apply to top-up items in album mode, contradicting first-pass behavior and falling back to fuzzy name matching for those albums.

## Fix

- Thread the **same** `IMusicBrainzResolver` used by the initial batch into `TopUpAsync` (new optional param; `ITopUpPlanner` + `RecommendationPipeline` call site wired to `_mbidResolver`).
- Add a symmetric album-mode branch: enrich top-up recs, then drop any still missing artist **or** album MBID, with the drops attributed in the existing `Top-Up Planner summary` (`enrichment-dropped` / `no-MBID removed`) — same honest accounting as the artist path.
- Scope: `!shouldRecommendArtists && settings.RequireMbids` only. No behavior change when `RequireMbids` is off or in artist mode.

## Tests (TDD)

- `TopUp_AlbumMode_WithRequireMbids_EnrichesTopUpRecs_SoResolvableAlbumSurvivesMbidFilter` — resolvable album survives, unresolvable dropped (verified RED before fix: 2 raw items returned including the MBID-less one; GREEN after).
- `TopUp_AlbumMode_WithoutRequireMbids_DoesNotDropUnenrichedRecs` — `RequireMbids` off ⇒ passthrough, matching first pass.
- Mechanical mock-arity updates in `RecommendationPipelineTests` for the new optional parameter.

Full suite: **3103 passed, 0 failed, 20 skipped**.

Found via the album-mode recommendation-quality loop on the live `lidarr-e2e` instance (`recommendationMode=specificAlbums`, niche styles `ambient/dub-techno/krautrock`, `RequireMbids=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)