### PR TITLE
ci(plugin-package): serialize validation test build to fix MSB3030 race

### DIFF
--- a/.github/workflows/plugin-package.yml
+++ b/.github/workflows/plugin-package.yml
@@ -196,11 +196,19 @@ jobs:
       env:
         REQUIRE_PACKAGE_TESTS: "true"
         PLUGIN_PACKAGE_PATH: "${{ github.workspace }}/Brainarr-latest.net8.0.zip"
+        # Avoid transient file-lock flakiness from shared MSBuild/VBCSCompiler servers
+        # (matches "Test and Coverage"). Combined with -m:1 below, this serializes the
+        # test-project build so the Common+Abstractions submodule projects aren't built
+        # concurrently into both bin/ and bin-tests/ (which raced into MSB3030/CS2012:
+        # "Lidarr.Plugin.Abstractions.dll ... being used by another process").
+        DOTNET_CLI_DISABLE_BUILD_SERVERS: "1"
       run: |
         dotnet test Brainarr.Tests/Brainarr.Tests.csproj \
           --configuration Release \
           --filter "Category=Packaging" \
           --nologo \
+          -m:1 \
+          --disable-build-servers \
           -p:PluginPackagingDisable=true
 
     - name: Upload Package Artifact


### PR DESCRIPTION
## Problem
Follow-up to #624. With `LIDARR_PATH` now set, the CS0234 compile error is gone, but the **📦 Plugin Package** → **Validate packaging policy (unit tests)** step revealed the **next latent failure** (dispatched run [26835127613](https://github.com/RicherTunes/Brainarr/actions/runs/26835127613) on the post-#624 main):

```
warning MSB3026: Could not copy "obj/Release/net8.0/Lidarr.Plugin.Abstractions.dll" to
  "bin/Release/net8.0/..." because it is being used by another process. Beginning retry 1...
error MSB3030: Could not copy ".../bin/Release/net8.0/Lidarr.Plugin.Abstractions.dll" because it was not found.
```
(locally this manifests as `CS2012: Cannot open ...Abstractions.dll for writing ... being used by another process`.)

## Root cause
The validation step lets `dotnet test` drive its **own multi-process build**. `Brainarr.Tests` references both:
- `Brainarr.Plugin` with `OutputPath=bin-tests\` (un-merged), and
- the Common TestKit (`Lidarr.Plugin.Common` → `Lidarr.Plugin.Abstractions`, default `bin\`).

With parallel MSBuild + shared build servers, the **Abstractions project is built concurrently into two output paths** (`bin\` and `bin-tests\`), racing on the shared `obj/Release/net8.0/Lidarr.Plugin.Abstractions.dll` intermediate → the `bin\` copy is clobbered/not produced → MSB3030.

The green **Test and Coverage** job never hits this because it sets `DOTNET_CLI_DISABLE_BUILD_SERVERS=1` and builds with serialized `-m:1 --disable-build-servers`.

## Fix (workflow-only)
Apply the same serialization to the validation `dotnet test`:
- `env: DOTNET_CLI_DISABLE_BUILD_SERVERS: "1"`
- `-m:1 --disable-build-servers`

## Validation (local, CI-faithful)
Clean checkout, assemblies extracted to `ext/Lidarr-docker/_output/net8.0`, `ext/Lidarr/_output` absent (matches runner), package zip present:
- **Before** (no `-m:1`/`--disable-build-servers`): reproduced the `Abstractions.dll ... being used by another process` lock.
- **After**: clean build + **4/4 Category=Packaging tests pass**, two consecutive clean runs (deterministic).

`actionlint` passes.

> Plugin Package runs on push-to-main + `workflow_dispatch` only (not PRs), so this PR's checks won't include it. After merge I'll dispatch a Plugin Package run on the new `main` SHA to confirm the full job is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)