### PR TITLE
docs(pipeline): document the inert post-validation style filter (hold for product call)

### DIFF
--- a/Brainarr.Plugin/Services/Core/BrainarrOrchestratorFactory.cs
+++ b/Brainarr.Plugin/Services/Core/BrainarrOrchestratorFactory.cs
@@ -165,6 +165,11 @@ internal static class BrainarrOrchestratorFactory
         // WS4.2: Use CommonBreakerRegistry which delegates to Common's AdvancedCircuitBreaker
         services.TryAddSingleton<IBreakerRegistry, CommonBreakerRegistry>();
 
+        // NOTE: the optional IStyleCatalogService is intentionally NOT injected here, which makes the
+        // pipeline's post-validation style filter inert in production. This is a known, deliberate
+        // state pending a product decision on match strictness — see the long comment at the
+        // "Style filtering" gate in RecommendationPipeline.ProcessAsync. Do not add the catalog
+        // argument without also addressing the strict-slug over-drop documented there.
         services.TryAddSingleton<IRecommendationPipeline>(sp =>
             new RecommendationPipeline(
                 sp.GetRequiredService<Logger>(),

--- a/Brainarr.Plugin/Services/Core/RecommendationPipeline.cs
+++ b/Brainarr.Plugin/Services/Core/RecommendationPipeline.cs
@@ -95,7 +95,31 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Core
                 }
             }
 
-            // Style filtering (if style catalog is available and filters are configured)
+            // Style filtering (if style catalog is available and filters are configured).
+            //
+            // KNOWN-INERT IN PRODUCTION (intentional; do not "fix" by blindly wiring it on):
+            //   The composition root (BrainarrOrchestratorFactory) constructs this pipeline WITHOUT
+            //   the optional _styleCatalog (it defaults to null), so this whole block is skipped in
+            //   the live DI graph. Even when a catalog IS injected, IsStyleSeededDiscovery below
+            //   short-circuits because the pipeline's LibraryProfile comes from
+            //   LibraryContextBuilder.BuildProfile, which never populates StyleContext → coverage is
+            //   null → "genre-first" is always true → the hard drop never runs. The block is therefore
+            //   exercised only by unit tests that inject both a catalog and a coverage-bearing profile.
+            //
+            //   This is NOT safe to enable as-is. With the strict (relax=false) default, the selected
+            //   slug set is the catalog-resolved styles ONLY (e.g. "edm techno trance" → {techno,
+            //   trance}; "edm" has no slug and is dropped by Normalize). A live filter would correctly
+            //   drop off-style jazz/classical/rock slippage (which GLM does emit intermittently — see
+            //   below) but would ALSO wrongly drop legitimately on-style house / progressive-house /
+            //   big-room / drum-and-bass artists whose genre slug isn't literally techno/trance.
+            //
+            //   Live measurement (GLM-5.1, artists mode, styles "edm techno trance", genre-first
+            //   prompt): off-style adherence is non-deterministic across runs with the SAME prompt —
+            //   one run ~1/28 off-style, another ~12/27 (jazz/classical/indie-rock). So the prompt
+            //   alone does not reliably keep the model on-style, i.e. this post-filter addresses a real
+            //   gap — but turning it on requires a product decision on match strictness (treat "edm" as
+            //   an umbrella over house/techno/trance/etc.) plus flowing StyleContext into the pipeline
+            //   profile. Tracked for the lead; keep the logic + tests until that call is made.
             if (_styleCatalog != null && settings.StyleFilters?.Any() == true)
             {
                 var preStyleFilter = validated.Count;


### PR DESCRIPTION
## Summary

Documents (comment-only, no behavior change) that Brainarr's **post-validation style filter** in `RecommendationPipeline.ProcessAsync` — the strict + relaxed `StyleCatalogService.IsMatch` drop, plus the `IsStyleSeededDiscovery` gate — is **dead code in production**, and captures the live measurement + the product decision needed before it can be safely enabled.

## The gap (characterized on the live lidarr-e2e instance)

Two independent reasons the filter never runs in the live DI graph:

1. **Null catalog (outermost gate):** `BrainarrOrchestratorFactory` constructs the pipeline via the 11-arg ctor; the optional `IStyleCatalogService styleCatalog` defaults to `null`, so `if (_styleCatalog != null && ...)` is always false. The catalog *is* registered in DI and injected into every other consumer (LibraryAnalyzer, prompt builder, selection service) — just not the pipeline. This looks like a wiring omission from `feat(styles)` (31e86b7), whose optional-param "backwards compat" ctor was never matched by a DI update.
2. **Null StyleContext (inner gate):** even with a catalog injected, the pipeline's `LibraryProfile` comes from `LibraryContextBuilder.BuildProfile`, which never populates `StyleContext`. So `IsStyleSeededDiscovery` hits its `coverage == null` branch → always `true` → the hard drop is skipped.

Verified live: across all `/config/logs`, both the `"Style filter removed N"` and the genre-first `"skipping post-validation style filter"` log lines have **zero hits ever**.

The existing unit tests (`RecommendationPipelineTests` style region, `StyleSeededDiscoveryTests`) exercise the filter only by injecting **both** a catalog **and** a coverage-bearing profile — a configuration production never builds (classic test-masks-dead-wiring).

## Why this is a hold, not a blind fix

Live measurement — GLM-5.1, artists mode, `styleFilters="edm techno trance"`, genre-first prompt (library lacks those styles → seed-styles mode confirmed in the rendered prompt):

| Run | Delivered | Hard off-style | Examples |
|-----|-----------|----------------|----------|
| A   | 28        | ~1 (≈4%)       | Daughter (indie folk) |
| B   | 27        | ~12 (≈44%)     | Coltrane, Monk, Glenn Gould, Philip Glass, Radiohead, The Cure, The Strokes, Stars of the Lid |

Same prompt, both told "every recommendation MUST belong to the seed styles." The adherence is **non-deterministic** — so the post-filter *does* address a real intermittent quality gap.

**But** enabling it as-is would harm results: with strict matching (`relaxStyleMatching=false` default) the selected slug set is the catalog-resolved styles only — `"edm techno trance"` → `{techno, trance}` (**"edm" has no catalog slug** and is dropped by `Normalize`). It would correctly drop the jazz/classical/rock slippage, but **also wrongly drop legitimately on-style house / progressive-house / big-room / drum-and-bass** artists (Daft Punk, Eric Prydz, Frankie Knuckles, Hardwell, Goldie…) whose genre slug isn't literally techno/trance.

## Decision

**Document + hold for the lead.** Turning the filter on requires a product call (treat "edm" as an umbrella style over house/techno/trance/etc.; decide strict vs relaxed default) **plus** flowing `StyleContext` into the pipeline profile. The logic + tests are kept intact for that future work. This PR only adds explanatory comments at the gate and the DI omission so the dead code isn't re-flagged and the rationale is captured in-tree.

Comment-only; relies on CI for build/test validation.