### PR TITLE
feat(prompt): add off-style negative constraint to library-aligned style block

### DIFF
--- a/Brainarr.Plugin/Services/Prompting/LibraryPromptRenderer.cs
+++ b/Brainarr.Plugin/Services/Prompting/LibraryPromptRenderer.cs
@@ -109,6 +109,10 @@ public class LibraryPromptRenderer : IPromptRenderer
                 }
 
                 builder.AppendLine("Rule: Recommendations must live inside these styles and be grounded in the user's existing collection footprint.");
+                // Negative constraint: the library shown below is mixed-genre, and models drift off-style
+                // by pulling neighbours of unrelated library artists. Bind every recommendation to the
+                // selected styles and forbid out-of-style picks even when they appear in that library.
+                builder.AppendLine("Do NOT recommend artists or albums outside the selected styles (e.g. no jazz, classical, rock, metal, or other styles not listed above) even if they appear in the library shown below. The library is context for adjacency within these styles, not a license to leave them.");
             }
             builder.AppendLine();
         }

--- a/Brainarr.Tests/Services/Prompting/LibraryPromptRendererTests.cs
+++ b/Brainarr.Tests/Services/Prompting/LibraryPromptRendererTests.cs
@@ -601,6 +601,94 @@ namespace Brainarr.Tests.Services.Prompting
             Assert.DoesNotContain("STYLE FILTERS (library-aligned)", prompt, StringComparison.Ordinal);
         }
 
+        // The literal negative-constraint marker the renderer must emit in the library-aligned
+        // (non-genre-first) style path. Kept as a const so the RED/GREEN tests and any future
+        // grep stay anchored to the exact phrase.
+        private const string OffStyleNegativeConstraintMarker =
+            "Do NOT recommend artists or albums outside the selected styles";
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        [Trait("Category", "PromptRenderer")]
+        public void Render_LibraryAlignedStyles_IncludesOffStyleNegativeConstraint()
+        {
+            // Library-aligned path: selected slugs that DO have coverage (sum > 0) → NOT genre-first.
+            // This is the path iteration-7 flagged: positive anchors but no explicit instruction
+            // forbidding off-style picks pulled from the (mixed-genre) library shown below.
+            var sample = new LibrarySample();
+            sample.Artists.Add(new LibrarySampleArtist
+            {
+                ArtistId = 1,
+                Name = "ExistingEdmArtist",
+                MatchedStyles = new[] { "techno" },
+                Weight = 1.0,
+            });
+
+            var styleContext = new StylePlanContext(
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "edm", "techno", "trance" },
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "edm", "techno", "trance" },
+                new List<StyleEntry>
+                {
+                    new() { Name = "EDM", Slug = "edm" },
+                    new() { Name = "Techno", Slug = "techno" },
+                    new() { Name = "Trance", Slug = "trance" }
+                },
+                new List<StyleEntry>(),
+                new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["edm"] = 5,
+                    ["techno"] = 4,
+                    ["trance"] = 3
+                },
+                relaxed: false,
+                threshold: 0.75,
+                trimmed: new List<string>(),
+                inferred: new List<string>());
+
+            var plan = new PromptPlan(sample, new[] { "edm", "techno", "trance" })
+            {
+                Profile = new LibraryProfile
+                {
+                    TotalArtists = 12,
+                    TotalAlbums = 30,
+                    Metadata = new Dictionary<string, object>(),
+                    StyleContext = new LibraryStyleContext()
+                },
+                Settings = new BrainarrSettings
+                {
+                    DiscoveryMode = DiscoveryMode.Adjacent,
+                    SamplingStrategy = SamplingStrategy.Balanced,
+                    MaxRecommendations = 30
+                },
+                StyleContext = styleContext,
+                ShouldRecommendArtists = true,
+                Compression = new PromptCompressionState(maxArtists: 5, maxAlbumGroups: 5, maxAlbumsPerGroup: 3, minAlbumsPerGroup: 1)
+            };
+
+            var renderer = new LibraryPromptRenderer();
+            var prompt = renderer.Render(plan, ModelPromptTemplate.Default, CancellationToken.None);
+
+            // Sanity: this is the library-aligned path, not genre-first.
+            Assert.Contains("STYLE FILTERS (library-aligned)", prompt, StringComparison.Ordinal);
+            // The negative constraint binds the model to the seed styles and tells it not to be
+            // pulled off-style by the library shown below.
+            Assert.Contains(OffStyleNegativeConstraintMarker, prompt, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        [Trait("Category", "PromptRenderer")]
+        public void Render_NoStyles_OmitsOffStyleNegativeConstraint()
+        {
+            // No styleFilters set → behavior must be unchanged (no negative style constraint).
+            var plan = CreateMinimalPlan(recommendArtists: true);
+
+            var renderer = new LibraryPromptRenderer();
+            var prompt = renderer.Render(plan, ModelPromptTemplate.Default, CancellationToken.None);
+
+            Assert.DoesNotContain(OffStyleNegativeConstraintMarker, prompt, StringComparison.Ordinal);
+        }
+
         private static PromptPlan CreateMinimalPlan(bool recommendArtists = false)
         {
             var sample = new LibrarySample();


### PR DESCRIPTION
## What

When `styleFilters` are set **and the library covers them** (the library-aligned / non-genre-first path in `LibraryPromptRenderer`), the rendered prompt listed positive style anchors + coverage but gave the model **no explicit instruction to stay on-style**. Models (notably GLM) drift by pulling neighbours of unrelated artists out of the mixed-genre library section shown below, producing off-style recommendations that the #628 post-validation filter then has to drop (top-up churn).

This adds an explicit **negative constraint** in the library-aligned branch binding every recommendation to the selected styles and forbidding out-of-style picks even when they appear in the library context. It **complements** (does not replace) the #628 post-filter and reduces off-style slippage at the source.

## The constraint (rendered text)

`Brainarr.Plugin/Services/Prompting/LibraryPromptRenderer.cs` (library-aligned `else` branch, after the existing positive "Rule:" line):

> Do NOT recommend artists or albums outside the selected styles (e.g. no jazz, classical, rock, metal, or other styles not listed above) even if they appear in the library shown below. The library is context for adjacency within these styles, not a license to leave them.

## Scope guard

- Emitted **only** inside `styles.HasStyles && !styleSeeded`. No styles set → behavior unchanged.
- The genre-first / `styleSeeded` path already carries its own "every recommendation must belong to the seed styles" binding — untouched.
- Does **not** touch `BrainarrOrchestrator.cs`.

## Deterministic evidence (merge-gating)

- RED→GREEN: `Render_LibraryAlignedStyles_IncludesOffStyleNegativeConstraint` (styleFilters edm/techno/trance with non-zero coverage → asserts the constraint is present) and `Render_NoStyles_OmitsOffStyleNegativeConstraint` (no styles → asserts it is absent).
- Golden snapshot (`LibraryPromptRendererGoldenTests`) unaffected — its fixture uses no styles.
- Full suite: **3106 passed, 0 failed, 22 skipped** (skips are Docker-E2E / integration / release-E2E requiring live infra).

## Live

Deployed to the lidarr-e2e :8787 instance (gitSha 3a2dec03, host Lidarr 3.1.2.4913), plugin loads cleanly in `/api/v1/system/plugins` with 0 external `Lidarr.Plugin.*` refs and deployed-DLL-sha == manifest. The live forced-fetch attainment confirmation (GLM-noisy, directional) was **deferred** — see PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)