### PR TITLE
fix(enrichment): rate-limit ArtistMbidResolver MusicBrainz queries to 1 req/s (parity with album resolver)

### DIFF
--- a/Brainarr.Plugin/Services/Enrichment/ArtistMbidResolver.cs
+++ b/Brainarr.Plugin/Services/Enrichment/ArtistMbidResolver.cs
@@ -25,6 +25,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment
         private const string BaseUrl = "https://musicbrainz.org/ws/2";
         private readonly HttpClient _httpClient;
         private readonly Logger _logger;
+        private readonly NzbDrone.Core.ImportLists.Brainarr.Services.IRateLimiter _rateLimiter;
         private ISearchForNewArtist _artistSearch; // optional
         // Bounded so a long-running, singleton resolver can't accumulate one entry per distinct
         // artist name forever (the old Dictionary had a TTL checked on read but never evicted).
@@ -35,10 +36,22 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment
             new BoundedConcurrentDictionary<string, (string id, DateTime at)>(CacheCapacity, StringComparer.OrdinalIgnoreCase);
         private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(12);
 
-        public ArtistMbidResolver(Logger logger, HttpClient httpClient = null)
+        public ArtistMbidResolver(Logger logger, HttpClient httpClient = null, NzbDrone.Core.ImportLists.Brainarr.Services.IRateLimiter rateLimiter = null)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _httpClient = httpClient ?? NzbDrone.Core.ImportLists.Brainarr.Services.Http.SecureHttpClientFactory.Create("musicbrainz");
+            // Mirror MusicBrainzResolver: the artist fallback query hits the same MusicBrainz host
+            // (1 req/sec hard rule), so it must share the "musicbrainz" rate-limiter bucket.
+            // Constructed-by-default but injectable for tests.
+            if (rateLimiter != null)
+            {
+                _rateLimiter = rateLimiter;
+            }
+            else
+            {
+                _rateLimiter = new NzbDrone.Core.ImportLists.Brainarr.Services.RateLimiter(logger);
+                NzbDrone.Core.ImportLists.Brainarr.Services.RateLimiterConfiguration.ConfigureDefaults(_rateLimiter);
+            }
             _artistSearch = null;
             // Headers are configured in SecureHttpClientFactory
         }
@@ -90,8 +103,8 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment
                     result.Add(rec);
                 }
 
-                // Be nice to MusicBrainz
-                await Task.Delay(200, ct);
+                // Throttling handled centrally via RateLimiter("musicbrainz") — the token bucket
+                // is now the single source of MusicBrainz pacing (parity with MusicBrainzResolver).
             }
 
             _logger.Info($"Artist MBID resolution complete: resolved {resolvedCount}/{resolvableCount} artists (returned {result.Count})");
@@ -141,8 +154,11 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment
                 }
             }
 
-            // 3) Fallback: direct MusicBrainz query
-            using var resp = await _httpClient.GetAsync(url, ct);
+            // 3) Fallback: direct MusicBrainz query, routed through the shared "musicbrainz"
+            // rate-limiter bucket (1 req/sec) so it never trips MusicBrainz's hard cap (which
+            // returns 503 and was being treated as a permanent "no MBID"). Parity with
+            // MusicBrainzResolver.ResolveMbidAsync.
+            using var resp = await _rateLimiter.ExecuteAsync("musicbrainz", async (token) => await _httpClient.GetAsync(url, token), ct);
             if (!resp.IsSuccessStatusCode)
             {
                 _logger.Debug($"MusicBrainz artist query failed: {resp.StatusCode} for {rec.Artist}");

--- a/Brainarr.Tests/Services/Enrichment/ArtistMbidResolverBestEffortTests.cs
+++ b/Brainarr.Tests/Services/Enrichment/ArtistMbidResolverBestEffortTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -6,6 +7,7 @@ using System.Threading.Tasks;
 using Brainarr.Tests.Helpers;
 using FluentAssertions;
 using NzbDrone.Core.ImportLists.Brainarr.Models;
+using NzbDrone.Core.ImportLists.Brainarr.Services;
 using NzbDrone.Core.ImportLists.Brainarr.Services.Enrichment;
 using Xunit;
 
@@ -25,6 +27,45 @@ namespace Brainarr.Tests.Services.Enrichment
             }
         }
 
+        // Returns a 200 with a single confident artist match for every request.
+        private sealed class OkHandler : HttpMessageHandler
+        {
+            private readonly string _json;
+            public OkHandler(string json) { _json = json; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_json)
+                };
+                return Task.FromResult(response);
+            }
+        }
+
+        // Pass-through rate limiter that records every resource key it is asked to gate.
+        private sealed class SpyRateLimiter : IRateLimiter
+        {
+            public List<string> Resources { get; } = new List<string>();
+
+            public Task<T> ExecuteAsync<T>(string resource, Func<Task<T>> action)
+            {
+                Resources.Add(resource);
+                return action();
+            }
+
+            public Task<T> ExecuteAsync<T>(string resource, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken)
+            {
+                Resources.Add(resource);
+                return action(cancellationToken);
+            }
+
+            public void Configure(string resource, int maxRequests, TimeSpan period)
+            {
+                // no-op
+            }
+        }
+
         [Fact]
         public async Task EnrichArtistsAsync_PreservesOriginalRecommendation_WhenLookupFails()
         {
@@ -40,6 +81,31 @@ namespace Brainarr.Tests.Services.Enrichment
             result.Should().HaveCount(1);
             result[0].Artist.Should().Be("Radiohead");
             result[0].ArtistMusicBrainzId.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task EnrichArtistsAsync_RoutesMusicBrainzQuery_ThroughRateLimiter()
+        {
+            // Arrange: the fallback MusicBrainz GET (no AttachSearchService) must be gated by the
+            // shared "musicbrainz" rate-limiter bucket (1 req/s) — parity with MusicBrainzResolver.
+            var handler = new OkHandler("{\"artists\":[{\"id\":\"a-1\",\"name\":\"Bicep\",\"score\":100}]}");
+            var spy = new SpyRateLimiter();
+            var resolver = new ArtistMbidResolver(TestLogger.CreateNullLogger(), new HttpClient(handler), spy);
+            var recs = new List<Recommendation>
+            {
+                new Recommendation { Artist = "Bicep", Confidence = 0.9 },
+                new Recommendation { Artist = "Goldie", Confidence = 0.9 }
+            };
+
+            // Act
+            var result = await resolver.EnrichArtistsAsync(recs, CancellationToken.None);
+
+            // Assert: every per-artist fallback query went through the limiter under "musicbrainz",
+            // and the resolved MBID flowed back onto the recommendation.
+            spy.Resources.Should().OnlyContain(r => r == "musicbrainz");
+            spy.Resources.Should().HaveCount(2);
+            result.Should().HaveCount(2);
+            result[0].ArtistMusicBrainzId.Should().Be("a-1");
         }
     }
 }


### PR DESCRIPTION
## Finding

The artist-only enrichment path (`ArtistMbidResolver.ResolveArtistAsync`, `Brainarr.Plugin/Services/Enrichment/ArtistMbidResolver.cs`) issued its MusicBrainz `/artist/?query=` GET **directly** through `HttpClient` with **no rate limiter** — only a flat `await Task.Delay(200, ct)` (~5 req/s) at the end of the per-item loop. MusicBrainz enforces a hard **~1 req/sec** cap and returns **HTTP 503 ServiceUnavailable** when exceeded, which the resolver treats as a permanent "no MBID" (`!resp.IsSuccessStatusCode → return null`).

Live logs: **61/61 artist-path resolutions failed with 503** for famous, definitely-in-MusicBrainz artists.

The sibling album-pair resolver (`MusicBrainzResolver.ResolveMbidAsync`) routes its GET through the shared `RateLimiter` under the `"musicbrainz"` bucket (`Configure("musicbrainz", 1, TimeSpan.FromSeconds(1))` via `RateLimiterConfiguration.ConfigureDefaults`) and has **0** such failures. This was a straight **parity gap** between the two resolvers.

## Fix (one concern: rate-limiter parity)

- `ArtistMbidResolver` gains an optional 3rd ctor param `IRateLimiter rateLimiter = null`. When null it constructs `new RateLimiter(logger)` + `RateLimiterConfiguration.ConfigureDefaults(...)`, mirroring `MusicBrainzResolver`'s ctor exactly. Existing construction sites (`new ArtistMbidResolver(logger)` in `BrainarrOrchestratorFactory`, `(logger, httpClient)` in tests) compile unchanged.
- The fallback MB GET is wrapped through the limiter:
  ```csharp
  using var resp = await _rateLimiter.ExecuteAsync("musicbrainz", async (token) => await _httpClient.GetAsync(url, token), ct);
  ```
- The now-redundant `await Task.Delay(200, ct)` is removed — the token bucket is the single source of MusicBrainz pacing. Cancellation propagation and the best-effort "preserve original recommendation on failure" behavior are unchanged.

## Deterministic test

Added `EnrichArtistsAsync_RoutesMusicBrainzQuery_ThroughRateLimiter` (in `ArtistMbidResolverBestEffortTests.cs`) with a pass-through `SpyRateLimiter` that records each `resource` key. With no `AttachSearchService` (so the fallback MB path is used), resolving 2 artists against a 200/single-match handler asserts `spy.Resources` is exactly `["musicbrainz","musicbrainz"]` and the MBID flows back onto the recommendation (`result[0].ArtistMusicBrainzId == "a-1"`).

**Strict TDD:** observed **RED first** — `Expected spy.Resources to contain only items matching (r == "musicbrainz"), but the collection is empty.` (the GET was still direct) — then **GREEN** after wiring the wrap. The existing `EnrichArtistsAsync_PreservesOriginalRecommendation_WhenLookupFails` (503 → preserved rec, null MBID) still passes. Full suite: **3109 passed / 0 failed / 20 skipped**.

## Follow-up (out of scope)

`AttachArtistSearchService` (`Brainarr.Plugin/Services/Core/BrainarrOrchestrator.cs:686`) is defined but never called, so the robust Lidarr-side `ISearchForNewArtist` path is effectively dead in production — **all** artist resolution falls through to the (now rate-limited) direct MusicBrainz query. Wiring up the Lidarr-side path is a separate future concern and is intentionally not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)