### PR TITLE
fix(metrics): raise slow-provider-response WARN threshold 10s→90s (was firing on 100% of reasoning-model calls)

### DIFF
--- a/Brainarr.Plugin/Performance/PerformanceMetrics.cs
+++ b/Brainarr.Plugin/Performance/PerformanceMetrics.cs
@@ -86,9 +86,28 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Performance
             _startTime = DateTime.UtcNow;
         }
 
+        // Threshold above which a provider response is logged as a slow-response WARN.
+        // The previous 10s threshold predated reasoning-class models (GLM/o1-style), which
+        // routinely take 15-70s by design, so it fired on ~100% of calls and buried genuinely
+        // actionable warnings in noise. 90s flags responses genuinely approaching the default
+        // ~120s provider timeout while treating normal reasoning-model latency as expected.
+        // Note: the per-call duration is still recorded as a metric (see RecordResponse below)
+        // regardless of whether this WARN fires, so no data is lost by raising the threshold.
+        internal const double SlowResponseWarnThresholdSeconds = 90;
+
+        /// <summary>
+        /// Pure, deterministic predicate: returns true when a provider response is slow enough
+        /// to warrant a WARN (i.e. strictly greater than <see cref="SlowResponseWarnThresholdSeconds"/>).
+        /// </summary>
+        internal static bool IsSlowResponse(TimeSpan duration) => duration.TotalSeconds > SlowResponseWarnThresholdSeconds;
+
         /// <summary>
         /// Records the response time for an AI provider request with automatic performance warnings.
-        /// Logs warnings for responses taking longer than 10 seconds.
+        /// Logs a WARN only for responses slower than <see cref="SlowResponseWarnThresholdSeconds"/> (90s).
+        /// The threshold was raised from the original 10s because reasoning-class models (GLM/o1-style)
+        /// normally take 15-70s, which made the old WARN fire on ~100% of calls; 90s instead flags
+        /// responses genuinely approaching the default ~120s provider timeout. The duration is always
+        /// recorded as a metric regardless of whether the WARN fires.
         /// </summary>
         /// <param name="provider">Name of the AI provider</param>
         /// <param name="duration">Actual response time measured</param>
@@ -97,7 +116,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Performance
             var metrics = _providerMetrics.GetOrAdd(provider, _ => new ProviderMetrics());
             metrics.RecordResponse(duration);
 
-            if (duration.TotalSeconds > 10)
+            if (IsSlowResponse(duration))
             {
                 _logger.Warn($"Provider {provider} took {duration.TotalSeconds:F1}s to respond");
             }

--- a/Brainarr.Tests/Performance/PerformanceMetricsTests.cs
+++ b/Brainarr.Tests/Performance/PerformanceMetricsTests.cs
@@ -1,0 +1,37 @@
+using System;
+using FluentAssertions;
+using NzbDrone.Core.ImportLists.Brainarr.Performance;
+using Xunit;
+
+namespace Brainarr.Tests.Performance
+{
+    /// <summary>
+    /// Pure-function tests for <see cref="PerformanceMetrics"/> slow-response detection.
+    /// Uses the deterministic <see cref="PerformanceMetrics.IsSlowResponse"/> predicate rather than
+    /// an NLog-capture test (the repo has known NLogTestLogger flakiness).
+    /// </summary>
+    public class PerformanceMetricsTests
+    {
+        [Fact]
+        public void IsSlowResponse_ThresholdBoundary()
+        {
+            // Normal reasoning-model latency (GLM/o1-style) routinely lands at ~16-70s.
+            // The live logs proved a 70s response fired the WARN on ~100% of calls under the
+            // old 10s threshold; with the recalibrated threshold this MUST NOT warn.
+            PerformanceMetrics.IsSlowResponse(TimeSpan.FromSeconds(70)).Should().BeFalse(
+                "normal reasoning-model latency (~70s) must not trip the slow-response WARN");
+
+            // A genuinely near-timeout response (default provider timeout ~120s) DOES warn.
+            PerformanceMetrics.IsSlowResponse(TimeSpan.FromSeconds(95)).Should().BeTrue(
+                "a response approaching the ~120s provider timeout is genuinely slow and must warn");
+
+            // Boundary check just below / at / just above the 90s threshold.
+            PerformanceMetrics.IsSlowResponse(TimeSpan.FromSeconds(89.9)).Should().BeFalse(
+                "just below the threshold must not warn");
+            PerformanceMetrics.IsSlowResponse(TimeSpan.FromSeconds(90)).Should().BeFalse(
+                "exactly at the threshold must not warn (strictly greater-than)");
+            PerformanceMetrics.IsSlowResponse(TimeSpan.FromSeconds(90.1)).Should().BeTrue(
+                "just above the threshold must warn");
+        }
+    }
+}


### PR DESCRIPTION
## Finding

`PerformanceMetrics.RecordProviderResponseTime` (`Brainarr.Plugin/Performance/PerformanceMetrics.cs`) logged a slow-response **WARN** for any response `> 10s`:

```csharp
if (duration.TotalSeconds > 10)
    _logger.Warn($"Provider {provider} took {duration.TotalSeconds:F1}s to respond");
```

The hardcoded `10`s threshold predates reasoning-class models. The live provider (Z.AI Coding / GLM_5_1, a reasoning model) takes **16.5s–68.9s on essentially every call**, so this WARN fired on **~100% of recommendation requests** — it was the single most frequent Brainarr WARN in the logs (**70 occurrences**) and buried genuinely actionable warnings in noise. The per-call duration is **also recorded as a metric** on the line above (`metrics.RecordResponse(duration)`), so the data is retained regardless of whether the WARN fires.

## Fix

Recalibrate the threshold to a named, documented constant — one concern only, kept pure-testable:

- `internal const double SlowResponseWarnThresholdSeconds = 90;` (with a comment explaining the 10s→90s rationale + that duration is still recorded as a metric)
- Pure, deterministic predicate: `internal static bool IsSlowResponse(TimeSpan duration) => duration.TotalSeconds > SlowResponseWarnThresholdSeconds;`
- Guard switched to `if (IsSlowResponse(duration))`; WARN message text unchanged
- Method XML doc updated (was "longer than 10 seconds")

`90s` flags responses genuinely approaching the default ~120s provider timeout while treating normal reasoning-model latency (15–70s) as expected. **No provider-awareness, WarnOnce, or timeout plumbing** was added (out of scope).

## Test (strict TDD)

New `Brainarr.Tests/Performance/PerformanceMetricsTests.cs` — a pure boundary test (`IsSlowResponse_ThresholdBoundary`), **not** an NLog-capture test (avoids known NLogTestLogger flakiness):

- `IsSlowResponse(70s)` ⇒ **false** (normal reasoning-model latency must NOT warn — the regression the live logs proved)
- `IsSlowResponse(95s)` ⇒ **true** (genuinely near the ~120s timeout DOES warn)
- boundary: `89.9s`→false, `90s`→false (strictly greater-than), `90.1s`→true

**RED→GREEN proven:** with the old 10s threshold the test failed on the 70s case — `Expected PerformanceMetrics.IsSlowResponse(TimeSpan.FromSeconds(70)) to be false ... but found True` (Failed: 1). After raising the constant to 90 → GREEN. Full suite: **3109 passed, 0 failed, 21 skipped**. `build.ps1 -Package` compiles clean (0 errors, package closure validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)