### PR TITLE
fix(security): run SecureUrlValidator in top-level settings validator (R2-04)

### DIFF
--- a/Brainarr.Plugin/Configuration/BrainarrSettingsValidator.cs
+++ b/Brainarr.Plugin/Configuration/BrainarrSettingsValidator.cs
@@ -36,14 +36,21 @@ namespace NzbDrone.Core.ImportLists.Brainarr
             When(s => s.Provider == AIProvider.Ollama, () =>
             {
                 RuleFor(s => s.OllamaUrl)
-                    .Must(url => string.IsNullOrWhiteSpace(url) || Configuration.UrlValidator.IsValidLocalProviderUrl(url))
+                    // R2-04/F-06: permissive local-provider shape AND the SSRF guard (blocks cloud-metadata
+                    // endpoints, dangerous schemes, path traversal) — any host still allowed.
+                    .Must(url => string.IsNullOrWhiteSpace(url)
+                        || (Configuration.UrlValidator.IsValidLocalProviderUrl(url)
+                            && NzbDrone.Core.ImportLists.Brainarr.Services.Security.SecureUrlValidator.IsSafeProviderUrl(url)))
                     .WithMessage("Please enter a valid URL for Ollama (scheme + host + port). Example: http://localhost:11434 (or http://192.168.1.10:11434 for a remote server).");
             });
 
             When(s => s.Provider == AIProvider.LMStudio, () =>
             {
                 RuleFor(s => s.LMStudioUrl)
-                    .Must(url => string.IsNullOrWhiteSpace(url) || Configuration.UrlValidator.IsValidLocalProviderUrl(url))
+                    // R2-04/F-06: permissive local-provider shape AND the SSRF guard.
+                    .Must(url => string.IsNullOrWhiteSpace(url)
+                        || (Configuration.UrlValidator.IsValidLocalProviderUrl(url)
+                            && NzbDrone.Core.ImportLists.Brainarr.Services.Security.SecureUrlValidator.IsSafeProviderUrl(url)))
                     .WithMessage("Please enter a valid URL for LM Studio (scheme + host + port). Example: http://localhost:1234 (LM Studio's default OpenAI-compatible endpoint).");
             });
 

--- a/Brainarr.Tests/Configuration/BrainarrSettingsValidatorSsrfTests.cs
+++ b/Brainarr.Tests/Configuration/BrainarrSettingsValidatorSsrfTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using NzbDrone.Core.ImportLists.Brainarr;
+using NzbDrone.Core.ImportLists.Brainarr.Configuration;
+using Xunit;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Tests.Configuration
+{
+    /// <summary>
+    /// R2-04: the top-level BrainarrSettingsValidator (the user-facing Ollama/LM Studio URL fields) must run
+    /// the SecureUrlValidator SSRF guard, not only the permissive UrlValidator.IsValidLocalProviderUrl (which
+    /// accepts any parseable IP — including cloud-metadata endpoints). Closes the F-06 gap the Round-2 review
+    /// found: the "wired into all active validators" claim missed this validator.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class BrainarrSettingsValidatorSsrfTests
+    {
+        [Theory]
+        [InlineData(AIProvider.Ollama)]
+        [InlineData(AIProvider.LMStudio)]
+        public void MetadataEndpointUrl_IsRejected(AIProvider provider)
+        {
+            var settings = new BrainarrSettings { Provider = provider };
+            if (provider == AIProvider.Ollama) settings.OllamaUrl = "http://169.254.169.254/latest/meta-data/";
+            else settings.LMStudioUrl = "http://169.254.169.254/latest/meta-data/";
+
+            var result = new BrainarrSettingsValidator().Validate(settings);
+
+            result.IsValid.Should().BeFalse("a cloud-metadata endpoint must never pass provider-URL validation");
+        }
+
+        [Theory]
+        [InlineData(AIProvider.Ollama, "http://localhost:11434")]
+        [InlineData(AIProvider.LMStudio, "http://localhost:1234")]
+        [InlineData(AIProvider.Ollama, "http://192.168.1.10:11434")]
+        public void LegitimateLocalUrl_StillValid(AIProvider provider, string url)
+        {
+            var settings = new BrainarrSettings { Provider = provider };
+            if (provider == AIProvider.Ollama) settings.OllamaUrl = url;
+            else settings.LMStudioUrl = url;
+
+            var result = new BrainarrSettingsValidator().Validate(settings);
+
+            // The URL rule itself must not fail for a legit local provider URL (other rules may still apply).
+            result.Errors.Should().NotContain(e => e.PropertyName == nameof(BrainarrSettings.OllamaUrl) || e.PropertyName == nameof(BrainarrSettings.LMStudioUrl));
+        }
+    }
+}


### PR DESCRIPTION
Round-2 finding R2-04: BrainarrSettingsValidator (Ollama/LM Studio URL fields) bypassed SecureUrlValidator — a cloud-metadata URL (169.254.169.254) passed the user-facing settings validation. ANDed IsSafeProviderUrl in (blocks metadata/scheme/traversal, any host allowed). RED→GREEN, validator suites 42/42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)