### PR TITLE
fix(security): zero the UTF-8 buffer in HashApiKey (R2-10)

### DIFF
--- a/Brainarr.Plugin/BrainarrSettings.Providers.cs
+++ b/Brainarr.Plugin/BrainarrSettings.Providers.cs
@@ -85,7 +85,17 @@ namespace NzbDrone.Core.ImportLists.Brainarr
                 return null;
             }
 
-            return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(plaintext)));
+            // R2-10: the UTF-8 encoding holds the API-key plaintext — zero it after hashing so it doesn't
+            // linger on the managed heap (consistent with the rest of the F-03 secret-handling path).
+            var bytes = Encoding.UTF8.GetBytes(plaintext);
+            try
+            {
+                return Convert.ToHexString(SHA256.HashData(bytes));
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(bytes);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Round-2 review R2-10

`HashApiKey` (the F-03 idempotency-cache fingerprint) encoded the API-key plaintext to a UTF-8 `byte[]` that was never zeroed, leaving key material on the managed heap after the SHA-256 was computed.

Fix: zero the encoding buffer in `finally`, consistent with the rest of the F-03 secret-handling path (`CryptographicOperations.ZeroMemory`). The buffer is internal hygiene not observable through the public API; the existing BRN-001 characterization suite guards the fingerprint's observable behaviour.

Brainarr.Tests API-key/provider suite 704/704 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)