### PR TITLE
fix: guard untrusted expiry-epoch parsing in credential loaders (R2-08)

### DIFF
--- a/Brainarr.Plugin/Services/Support/CredentialRefreshService.cs
+++ b/Brainarr.Plugin/Services/Support/CredentialRefreshService.cs
@@ -104,7 +104,12 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                 if (!oauth.TryGetProperty("expiresAt", out var expiresAtElement))
                     return;
 
-                var expiresAt = DateTimeOffset.FromUnixTimeMilliseconds(expiresAtElement.GetInt64());
+                if (EpochExpiry.FromMilliseconds(expiresAtElement) is not { } expiresAt)
+                {
+                    _logger.Warn("Claude Code token has a malformed expiresAt; treating as expired/invalid.");
+                    OnRefreshFailed("ClaudeCode", "Token expiry is malformed. Run 'claude login' to re-authenticate.");
+                    return;
+                }
                 var timeUntilExpiry = expiresAt - DateTimeOffset.UtcNow;
 
                 if (timeUntilExpiry <= TimeSpan.Zero)
@@ -178,10 +183,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
 
                 if (tokens.TryGetProperty("expires_at", out var expiresAtElement))
                 {
-                    if (expiresAtElement.ValueKind == JsonValueKind.Number)
-                    {
-                        expiresAt = DateTimeOffset.FromUnixTimeSeconds(expiresAtElement.GetInt64());
-                    }
+                    expiresAt = EpochExpiry.FromSeconds(expiresAtElement);
                 }
 
                 if (expiresAt == null)

--- a/Brainarr.Plugin/Services/Support/EpochExpiry.cs
+++ b/Brainarr.Plugin/Services/Support/EpochExpiry.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Services
+{
+    /// <summary>
+    /// R2-08: parse an untrusted <c>expiresAt</c>/<c>expires_at</c> epoch from credential JSON without throwing
+    /// on a malformed or overflowing value. <see cref="DateTimeOffset.FromUnixTimeMilliseconds"/> /
+    /// <see cref="DateTimeOffset.FromUnixTimeSeconds"/> throw <see cref="ArgumentOutOfRangeException"/> past their
+    /// representable range (e.g. <see cref="long.MaxValue"/>), so a hostile token file would otherwise blow up the
+    /// credential-load path. These return <c>null</c> instead, so the caller treats the value as "no usable
+    /// expiry". Mirrors Common's <c>TimeParsing</c>; collapses onto it once the plugin re-pins to a Common that
+    /// ships it.
+    /// </summary>
+    internal static class EpochExpiry
+    {
+        private static readonly long MinMs = DateTimeOffset.MinValue.ToUnixTimeMilliseconds();
+        private static readonly long MaxMs = DateTimeOffset.MaxValue.ToUnixTimeMilliseconds();
+        private static readonly long MinS = DateTimeOffset.MinValue.ToUnixTimeSeconds();
+        private static readonly long MaxS = DateTimeOffset.MaxValue.ToUnixTimeSeconds();
+
+        /// <summary>Epoch milliseconds → UTC instant, or null when the element is not an in-range integer.</summary>
+        public static DateTimeOffset? FromMilliseconds(JsonElement element)
+            => element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var ms) && ms >= MinMs && ms <= MaxMs
+                ? DateTimeOffset.FromUnixTimeMilliseconds(ms)
+                : null;
+
+        /// <summary>Epoch seconds → UTC instant, or null when the element is not an in-range integer.</summary>
+        public static DateTimeOffset? FromSeconds(JsonElement element)
+            => element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var s) && s >= MinS && s <= MaxS
+                ? DateTimeOffset.FromUnixTimeSeconds(s)
+                : null;
+    }
+}

--- a/Brainarr.Plugin/Services/Support/SubscriptionCredentialLoader.cs
+++ b/Brainarr.Plugin/Services/Support/SubscriptionCredentialLoader.cs
@@ -146,11 +146,11 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                         DateTimeOffset? expiresAtDate = null;
                         if (oauth.TryGetProperty("expiresAt", out var expiresAtElement))
                         {
-                            expiresAtDate = DateTimeOffset.FromUnixTimeMilliseconds(expiresAtElement.GetInt64());
-                            if (expiresAtDate < DateTimeOffset.UtcNow)
+                            expiresAtDate = EpochExpiry.FromMilliseconds(expiresAtElement);
+                            if (expiresAtDate is null || expiresAtDate < DateTimeOffset.UtcNow)
                             {
                                 return CredentialResult.Failure(
-                                    $"Claude Code token expired at {expiresAtDate:u}. Run 'claude login' to refresh.");
+                                    "Claude Code token is expired or has a malformed expiry. Run 'claude login' to refresh.");
                             }
 
                             // Warn if expiring soon (within 24 hours)
@@ -250,10 +250,7 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
                         DateTimeOffset? expiresAt = null;
                         if (tokens.TryGetProperty("expires_at", out var expiresAtElement))
                         {
-                            if (expiresAtElement.ValueKind == JsonValueKind.Number)
-                            {
-                                expiresAt = DateTimeOffset.FromUnixTimeSeconds(expiresAtElement.GetInt64());
-                            }
+                            expiresAt = EpochExpiry.FromSeconds(expiresAtElement);
                         }
 
                         // Extract refresh token if available

--- a/Brainarr.Tests/Services/Support/EpochExpiryTests.cs
+++ b/Brainarr.Tests/Services/Support/EpochExpiryTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Text.Json;
+using FluentAssertions;
+using NzbDrone.Core.ImportLists.Brainarr.Services;
+using Xunit;
+
+namespace NzbDrone.Core.ImportLists.Brainarr.Tests.Services.Support
+{
+    /// <summary>
+    /// R2-08: credential JSON carries an untrusted expiresAt/expires_at epoch. A malformed/overflowing value
+    /// (e.g. long.MaxValue) must not throw out of the credential-load path — EpochExpiry returns null instead.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class EpochExpiryTests
+    {
+        private static JsonElement Element(string json)
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.Clone();
+        }
+
+        [Fact]
+        public void FromMilliseconds_Valid_ReturnsInstant()
+        {
+            EpochExpiry.FromMilliseconds(Element("1700000000000")).Should().Be(
+                DateTimeOffset.FromUnixTimeMilliseconds(1700000000000));
+        }
+
+        [Fact]
+        public void FromSeconds_Valid_ReturnsInstant()
+        {
+            EpochExpiry.FromSeconds(Element("1700000000")).Should().Be(
+                DateTimeOffset.FromUnixTimeSeconds(1700000000));
+        }
+
+        [Theory]
+        [InlineData("9223372036854775807")]  // long.MaxValue
+        [InlineData("-9223372036854775808")] // long.MinValue
+        public void FromMilliseconds_Overflow_ReturnsNull_DoesNotThrow(string json)
+        {
+            EpochExpiry.FromMilliseconds(Element(json)).Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("9223372036854775807")]
+        [InlineData("-9223372036854775808")]
+        public void FromSeconds_Overflow_ReturnsNull_DoesNotThrow(string json)
+        {
+            EpochExpiry.FromSeconds(Element(json)).Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("\"not a number\"")]
+        [InlineData("true")]
+        [InlineData("null")]
+        public void NonNumeric_ReturnsNull(string json)
+        {
+            EpochExpiry.FromMilliseconds(Element(json)).Should().BeNull();
+            EpochExpiry.FromSeconds(Element(json)).Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
## Round-2 review R2-08 (brainarr sweep)

`CredentialRefreshService` + `SubscriptionCredentialLoader` parsed `expiresAt`/`expires_at` straight from credential JSON via `DateTimeOffset.FromUnixTime*(element.GetInt64())`. A malformed/overflowing value (e.g. `long.MaxValue`) throws `ArgumentOutOfRangeException` (and `GetInt64` throws on a non-integer) — caught by the enclosing handler today, but that turns a bad token file into a swallowed exception rather than a clean "no usable expiry".

### Fix
Adds `EpochExpiry` (range-checked `FromMilliseconds`/`FromSeconds`, returns `null` on bad input) and routes all four sites through it. The immediate-use site (`SubscriptionCredentialLoader`) treats `null` as expired/malformed so the reject-on-bad-token semantics are preserved.

Mirrors Common's new `TimeParsing` helper (Lidarr.Plugin.Common **#624**) — collapses onto it once the plugin re-pins to a Common that ships it.

### Tests
53/53: `EpochExpiry` overflow→null / non-numeric→null + the existing credential-loader suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)