### PR TITLE
fix(logging): correct misleading pipeline-position wording + style-slug list rendering

### DIFF
--- a/Brainarr.Plugin/Services/Core/DuplicateFilterService.cs
+++ b/Brainarr.Plugin/Services/Core/DuplicateFilterService.cs
@@ -279,11 +279,15 @@ namespace NzbDrone.Core.ImportLists.Brainarr.Services
 
             if (duplicatesFound > 0)
             {
-                _logger.Info($"Filtered out {duplicatesFound} recommendation(s) already present in the library prior to validation");
+                _logger.Info(FormatLibraryDuplicatesMessage(duplicatesFound));
             }
 
             return filtered;
         }
+
+        // internal for log-message accuracy unit tests (InternalsVisibleTo "Brainarr.Tests").
+        internal static string FormatLibraryDuplicatesMessage(int duplicatesFound)
+            => $"Filtered out {duplicatesFound} recommendation(s) already present in the library after validation (before enrichment)";
 
         private static string DecodeComparisonValue(string value)
         {

--- a/Brainarr.Plugin/Services/Prompting/Services/DefaultSamplingService.cs
+++ b/Brainarr.Plugin/Services/Prompting/Services/DefaultSamplingService.cs
@@ -19,6 +19,13 @@ public sealed class DefaultSamplingService : ISamplingService
     private readonly IContextPolicy _contextPolicy;
     private const int AbsoluteRelaxedCap = 1200;
 
+    // internal for log-message accuracy unit tests (InternalsVisibleTo "Brainarr.Tests").
+    // Pre-formatted (no structured-template hole) on purpose: passing the joined slug string as a
+    // single template capture renders inside ONE quote pair under the host's NLog 5.x
+    // (selected=["lofi-hip-hop, alternative-rock"]), which misreads as a single slug.
+    internal static string FormatStrictOnlyLogMessage(string scope, int strictCount, IEnumerable<string> selectedSlugs)
+        => $"{scope} style matches remain strict-only: count={strictCount}, selected=[{string.Join(", ", selectedSlugs)}]";
+
     public DefaultSamplingService(Logger logger, IStyleCatalogService styleCatalog, IContextPolicy contextPolicy)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -174,10 +181,7 @@ public sealed class DefaultSamplingService : ISamplingService
             }
             else if (!selection.ShouldUseRelaxedMatches)
             {
-                _logger.Debug(
-                    "Artist style matches remain strict-only: count={StrictCount}, selected=[{Selected}]",
-                    strictIds.Count,
-                    string.Join(", ", selection.SelectedSlugs));
+                _logger.Debug(FormatStrictOnlyLogMessage("Artist", strictIds.Count, selection.SelectedSlugs));
             }
         }
 
@@ -385,10 +389,7 @@ public sealed class DefaultSamplingService : ISamplingService
             }
             else if (!selection.ShouldUseRelaxedMatches)
             {
-                _logger.Debug(
-                    "Album style matches remain strict-only: count={StrictCount}, selected=[{Selected}]",
-                    strictIds.Count,
-                    string.Join(", ", selection.SelectedSlugs));
+                _logger.Debug(FormatStrictOnlyLogMessage("Album", strictIds.Count, selection.SelectedSlugs));
             }
         }
 

--- a/Brainarr.Tests/Logging/LogMessageAccuracyTests.cs
+++ b/Brainarr.Tests/Logging/LogMessageAccuracyTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using NzbDrone.Core.ImportLists.Brainarr.Services;
+using NzbDrone.Core.ImportLists.Brainarr.Services.Prompting.Services;
+using Xunit;
+
+namespace Brainarr.Tests.Logging
+{
+    /// <summary>
+    /// Pins the exact text of log emissions that were observed misleading in live runs:
+    /// 1. DuplicateFilterService claimed library-duplicate filtering ran "prior to validation",
+    ///    but RecommendationPipeline invokes it AFTER ValidateAsync completes (live log order:
+    ///    "Validation complete" 20:46:53 then this line 20:46:58), and before enrichment.
+    /// 2. The strict-only style-selection lines rendered all slugs inside ONE quote pair
+    ///    (selected=["lofi-hip-hop, alternative-rock"]) because the joined slug string was
+    ///    passed as a single structured-template capture, which the host's NLog 5.x quotes
+    ///    as one token — misreading as a single slug.
+    /// </summary>
+    public class LogMessageAccuracyTests
+    {
+        [Fact]
+        [Trait("Category", "Unit")]
+        public void LibraryDuplicatesMessage_states_post_validation_pipeline_position()
+        {
+            var message = DuplicateFilterService.FormatLibraryDuplicatesMessage(3);
+
+            message.Should().Be(
+                "Filtered out 3 recommendation(s) already present in the library after validation (before enrichment)");
+        }
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        public void ArtistStrictOnlyMessage_renders_each_slug_distinctly()
+        {
+            var message = DefaultSamplingService.FormatStrictOnlyLogMessage(
+                "Artist", 2, new[] { "lofi-hip-hop", "alternative-rock" });
+
+            message.Should().Be(
+                "Artist style matches remain strict-only: count=2, selected=[lofi-hip-hop, alternative-rock]");
+        }
+
+        [Fact]
+        [Trait("Category", "Unit")]
+        public void AlbumStrictOnlyMessage_renders_each_slug_distinctly()
+        {
+            var message = DefaultSamplingService.FormatStrictOnlyLogMessage(
+                "Album", 2, new[] { "lofi-hip-hop", "alternative-rock" });
+
+            message.Should().Be(
+                "Album style matches remain strict-only: count=2, selected=[lofi-hip-hop, alternative-rock]");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Iter-14 of the Brainarr hardening loop: two verified-misleading log emissions corrected. Text-only — zero behavior change.

### 1. DuplicateFilterService pipeline-position wording
`Brainarr.Plugin/Services/Core/DuplicateFilterService.cs` logged:

> Filtered out N recommendation(s) already present in the library **prior to validation**

but its only caller (`RecommendationPipeline.cs:87`) invokes `FilterExistingRecommendations` AFTER `ValidateAsync` completes — live log order proves it ("Validation complete" 20:46:53 → this line 20:46:58) — and before enrichment. Now reads:

> Filtered out N recommendation(s) already present in the library **after validation (before enrichment)**

### 2. Strict-only style-slug list rendered inside ONE quote pair
Observed live: `selected=["lofi-hip-hop, alternative-rock"]` — misreads as a single slug. Root cause: the `string.Join`'d slug list was passed as one structured-template capture, and the host's bundled **NLog 5.4.0** quotes string captures as a single token (reproduced against NLog 5.4.0; NLog 6 — used by the test project — does not quote, which is why a naive render-based test could not catch it). The artist + album strict-only messages are now pre-formatted via an internal helper so each slug renders distinctly under any host NLog version:

> `Artist style matches remain strict-only: count=2, selected=[lofi-hip-hop, alternative-rock]`

Information content unchanged.

## TDD

`Brainarr.Tests/Logging/LogMessageAccuracyTests.cs` pinned the corrected texts FIRST — 3/3 RED against the live-defective texts (refactor-extracted helpers faithfully reproducing the live rendering, including the NLog 5 quote pair) — then the one-line text fixes turned them GREEN.

## Validation

- Targeted tests: 3/3 green
- Full suite: 3078+ green; the only failures are pre-existing/local-environment (`BeValidUrl_WithMaliciousUrls_ReturnsExpected` `%3a` case fails identically on pristine origin/main in this environment; `Logs_Warning_When_Falling_Back_To_Default_Tokenizer` is an intermittent logger-capture flake) — both untouched by this change
- `./build.ps1 -Package`: build + package + closure validation green

🤖 Generated with [Claude Code](https://claude.com/claude-code)